### PR TITLE
Renaming and improvement of AdjacencyMap

### DIFF
--- a/doc/examples/scripts/sequence/ws_genome_search.py
+++ b/doc/examples/scripts/sequence/ws_genome_search.py
@@ -74,7 +74,7 @@ print("Score:", rev_alignments[0].score)
 ########################################################################
 # Clearly the the alignment with the reverse genome seems to be the
 # right one.
-# For visualization puposes we have to apply a renumbering function
+# For visualization purposes we have to apply a renumbering function
 # for the genomic sequence,
 # since the original indices refer to the reverse complement sequence,
 # but we want the numbers to refer to the original one.

--- a/doc/examples/scripts/structure/adjacency_matrix.py
+++ b/doc/examples/scripts/structure/adjacency_matrix.py
@@ -25,13 +25,13 @@ array = strucio.load_structure(file_name)
 ca = array[array.atom_name == "CA"]
 # 7 Angstrom adjacency threshold
 threshold = 7
-# Create adjacency map of the CA atom array
+# Create cell list of the CA atom array
 # for efficient measurement of adjacency
-adjacency_map = struc.AdjacencyMap(ca, box_size=threshold)
+cell_list = struc.CellList(ca, cell_size=threshold)
 adjacency_matrix = np.zeros(( ca.array_length(), ca.array_length()),
                             dtype=np.uint8)
 for i in range(ca.array_length()):
-    indices = adjacency_map.get_atoms(ca.coord[i], radius=threshold)
+    indices = cell_list.get_atoms(ca.coord[i], radius=threshold)
     adjacency_matrix[i, indices] = 1
 
 figure = plt.figure()

--- a/doc/tutorial/sequence.rst
+++ b/doc/tutorial/sequence.rst
@@ -271,7 +271,7 @@ database, we can load the contents in the following way:
    import biotite.sequence as seq
    import biotite.sequence.io.fasta as fasta
    file = FastaFile()
-   file.read("tests/sequence/data/ec_bl21.fasta")
+   file.read("path/to/ec_bl21.fasta")
    for header, string in file:
        print(header)
        print(len(string))

--- a/doc/tutorial/structure.rst
+++ b/doc/tutorial/structure.rst
@@ -507,7 +507,7 @@ information of the third residue, a tyrosine:
 .. code-block:: python
    
    mmtf_file = mmtf.MMTFFile()
-   mmtf_file.read("tests/structure/data/1l2y.mmtf")
+   mmtf_file.read("path/to/1l2y.mmtf")
    stack = mmtf.get_structure(mmtf_file, include_bonds=True)
    tyrosine = stack[:, (stack.res_id == 3)]
    print("Bonds (indices):")

--- a/doc/tutorial/structure.rst
+++ b/doc/tutorial/structure.rst
@@ -378,7 +378,7 @@ Output:
     'N' 'CA' 'C' 'N' 'CA' 'C' 'N' 'CA' 'C']
 
 If you would like to know which atoms are in proximity to specific coordinates,
-have a look at the `AdjacencyMap` class.
+have a look at the `CellList` class.
 
 .. warning:: Creating a subarray or substack by indexing, does not necessarily
    copy the coordinates and annotation arrays. If possible, only *array views*

--- a/doc/tutorial/structure.rst
+++ b/doc/tutorial/structure.rst
@@ -513,6 +513,7 @@ information of the third residue, a tyrosine:
    print("Bonds (indices):")
    print(tyrosine.bonds)
    print("Bonds (atoms names):")
+   print(tyrosine.atom_name[tyrosine.bonds.as_array()[:, :2]])
 
 Output:
 

--- a/src/biotite/__init__.py
+++ b/src/biotite/__init__.py
@@ -2,7 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/sequence/__init__.py
+++ b/src/biotite/sequence/__init__.py
@@ -15,7 +15,7 @@ an `AlphabetError` is raised.
 
 Internally, a `Sequence` is saved as a `NumPy` `ndarray` of integer
 values, where each integer represents a symbol in the `Alphabet`.
-For example, 'A', 'C', 'G' and 'T' would be encoded into 1, 2, 3 and 4.
+For example, 'A', 'C', 'G' and 'T' would be encoded into 0, 1, 2 and 3.
 These integer values are called *symbol code*, the encoding of an entire
 sequence of symbols is called *sequence code*.
 

--- a/src/biotite/sequence/graphics/alignment.py
+++ b/src/biotite/sequence/graphics/alignment.py
@@ -350,7 +350,7 @@ class AlignmentSimilarityVisualizer(AlignmentVisualizer):
     For determination of the color, this `AlignmentVisualizer` uses a
     measure called *average normalized similarity*.
 
-    The *normalized similarity* of one symbol *i* to antother symbol *j*
+    The *normalized similarity* of one symbol *i* to another symbol *j*
     is defined as
 
     .. math:: S_{norm}(i,j) = \\frac{S(i,j) - \\min\\limits_j(S(i,j))} {\\max\\limits_j(S(i,j)) - \\min\\limits_j(S(i,j))}

--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -3,7 +3,7 @@
 # information.
 
 """
-A subpackage for handling protein structures. 
+A subpackage for handling molecular structures. 
 
 In this context an atom is described by two kinds of attributes: the
 coordinates and the annotations. The annotations include information

--- a/src/biotite/structure/adjacency.pyx
+++ b/src/biotite/structure/adjacency.pyx
@@ -109,8 +109,12 @@ cdef class AdjacencyMap:
             self._boxes[i,j,k] = <ptr> box_ptr
             
     def __dealloc__(self):
-        if self._boxes is not None:
-            deallocate_ptrs(self._boxes)
+        try:
+            if self._boxes is not None:
+                deallocate_ptrs(self._boxes)
+        except AttributeError:
+            # Happens if self._boxes is not initialized
+            pass
     
     def get_atoms(self, np.ndarray coord, float32 radius):
         """

--- a/src/biotite/structure/adjacency.pyx
+++ b/src/biotite/structure/adjacency.pyx
@@ -58,7 +58,7 @@ cdef class AdjacencyMap:
     cdef float32[:] _max_coord
     cdef int _max_box_length
     
-    def __init__(self, atom_array not None, float box_size):
+    def __cinit__(self, atom_array not None, float box_size):
         cdef float32 x, y, z
         cdef int i, j, k
         cdef int atom_array_i

--- a/src/biotite/structure/adjacency.pyx
+++ b/src/biotite/structure/adjacency.pyx
@@ -8,7 +8,7 @@ a location.
 """
 
 __author__ = "Patrick Kunzmann"
-__all__ = ["AdjacencyMap"]
+__all__ = ["CellList"]
 
 cimport cython
 cimport numpy as np
@@ -21,98 +21,98 @@ ctypedef np.uint64_t ptr
 ctypedef np.float32_t float32
 
 
-cdef class AdjacencyMap:
+cdef class CellList:
     """
     This class enables the efficient search of atoms in vicinity of a
     defined location.
     
-    This class stores the indices of an atom array in virtual "boxes",
+    This class stores the indices of an atom array in virtual "cells",
     each corresponding to a specific coordinate interval. If the atoms
     in vicinity of a specific location are searched, only the atoms in
-    the relevant boxes are checked. Effectively this decreases the
-    operation time from *O(n)* to *O(1)*, after the `AdjacencyMap` has been
-    created. Therefore an `AdjacencyMap` saves calculation time in those
+    the relevant cells are checked. Effectively this decreases the
+    operation time from *O(n)* to *O(1)*, after the `CellList` has been
+    created. Therefore an `CellList` saves calculation time in those
     cases, where vicinity is checked for multiple locations.
     
     Parameters
     ----------
     atom_array : AtomArray
-        The `AtomArray` to create the `AdjacencyMap` for.
-    box_size: float
-        The coordinate interval each box has for x, y and z axis.
-        The amount of boxes depends on the range of coordinatesin the
-        `atom_array` and the `box_size`.
+        The `AtomArray` to create the `CellList` for.
+    cell_size: float
+        The coordinate interval each cell has for x, y and z axis.
+        The amount of cells depends on the range of coordinates in the
+        `atom_array` and the `cell_size`.
             
     Examples
     --------
     
-    >>> adj_map = AdjacencyMap(atom_array, box_size=5)
-    >>> near_atoms = atom_array[adj_map.get_atoms([1,2,3], radius=7)]
+    >>> cell_list = CellList(atom_array, cell_size=5)
+    >>> near_atoms = atom_array[cell_list.get_atoms([1,2,3], radius=7)]
     """
     
     cdef float32[:,:] _coord
-    cdef ptr[:,:,:] _boxes
-    cdef int[:,:,:] _box_length
-    cdef float _boxsize
+    cdef ptr[:,:,:] _cells
+    cdef int[:,:,:] _cell_length
+    cdef float _cellsize
     cdef float32[:] _min_coord
     cdef float32[:] _max_coord
-    cdef int _max_box_length
+    cdef int _max_cell_length
     
-    def __cinit__(self, atom_array not None, float box_size):
+    def __cinit__(self, atom_array not None, float cell_size):
         cdef float32 x, y, z
         cdef int i, j, k
         cdef int atom_array_i
-        cdef int* box_ptr = NULL
+        cdef int* cell_ptr = NULL
         cdef int length
         
-        if self._has_initialized_boxes():
+        if self._has_initialized_cells():
             raise Exception("Duplicate call of constructor")
-        self._boxes = None
-        if box_size <= 0:
-            raise ValueError("Box size must be greater than 0")
+        self._cells = None
+        if cell_size <= 0:
+            raise ValueError("Cell size must be greater than 0")
         if atom_array.coord is None:
             raise ValueError("Atom array must not be empty")
         if np.isnan(atom_array.coord).any():
             raise ValueError("Atom array contains NaN values")
         coord = atom_array.coord.astype(np.float32)
         self._coord = coord
-        self._boxsize = box_size
-        # calculate how many boxes are required for each dimension
+        self._cellsize = cell_size
+        # calculate how many cells are required for each dimension
         min_coord = np.min(coord, axis=0).astype(np.float32)
         max_coord = np.max(coord, axis=0).astype(np.float32)
         self._min_coord = min_coord
         self._max_coord = max_coord
-        box_count = (((max_coord - min_coord) / box_size) +1).astype(int)
+        cell_count = (((max_coord - min_coord) / cell_size) +1).astype(int)
         # ndarray of pointers to C-arrays
         # containing indices to atom array
-        self._boxes = np.zeros(box_count, dtype=np.uint64)
+        self._cells = np.zeros(cell_count, dtype=np.uint64)
         # Stores the length of the C-arrays
-        self._box_length = np.zeros(box_count, dtype=np.int32)
-        # Fill boxes
+        self._cell_length = np.zeros(cell_count, dtype=np.int32)
+        # Fill cells
         for atom_array_i in range(self._coord.shape[0]):
             x = self._coord[atom_array_i, 0]
             y = self._coord[atom_array_i, 1]
             z = self._coord[atom_array_i, 2]
-            # Get box indices for coordinates
-            self._get_box_index(x, y, z, &i, &j, &k)
-            # Increment box length and reallocate
-            length = self._box_length[i,j,k] + 1
-            box_ptr = <int*>self._boxes[i,j,k]
-            box_ptr = <int*>realloc(box_ptr, length * sizeof(int))
-            if not box_ptr:
+            # Get cell indices for coordinates
+            self._get_cell_index(x, y, z, &i, &j, &k)
+            # Increment cell length and reallocate
+            length = self._cell_length[i,j,k] + 1
+            cell_ptr = <int*>self._cells[i,j,k]
+            cell_ptr = <int*>realloc(cell_ptr, length * sizeof(int))
+            if not cell_ptr:
                 raise MemoryError()
-            # Potentially increase max box length
-            if length > self._max_box_length:
-                self._max_box_length = length
-            # Store atom array index in respective box
-            box_ptr[length-1] = atom_array_i
-            # Store new box pointer and length
-            self._box_length[i,j,k] = length
-            self._boxes[i,j,k] = <ptr> box_ptr
+            # Potentially increase max cell length
+            if length > self._max_cell_length:
+                self._max_cell_length = length
+            # Store atom array index in respective cell
+            cell_ptr[length-1] = atom_array_i
+            # Store new cell pointer and length
+            self._cell_length[i,j,k] = length
+            self._cells[i,j,k] = <ptr> cell_ptr
             
     def __dealloc__(self):
-        if self._has_initialized_boxes():
-            deallocate_ptrs(self._boxes)
+        if self._has_initialized_cells():
+            deallocate_ptrs(self._cells)
     
     def get_atoms(self, np.ndarray coord, float32 radius):
         """
@@ -135,20 +135,20 @@ cdef class AdjacencyMap:
             
         See Also
         --------
-        get_atoms_in_box
+        get_atoms_in_cell
         """
         cdef np.ndarray indices = \
-            self.get_atoms_in_box(coord, int(radius/self._boxsize)+1)
+            self.get_atoms_in_cell(coord, int(radius/self._cellsize)+1)
         cdef np.ndarray sel_coord = np.asarray(self._coord)[indices]
         dist = distance(sel_coord, coord)
         return indices[dist <= radius]
     
-    def get_atoms_in_box(self, np.ndarray coord,
-                         int box_r=1,
+    def get_atoms_in_cell(self, np.ndarray coord,
+                         int cell_r=1,
                          bint efficient_mode=False,
                          np.ndarray array_indices=None):
         """
-        Search for atoms in vicinity of the given box.
+        Search for atoms in vicinity of the given cell.
         
         This is more efficient than `get_atoms()`.
         
@@ -157,17 +157,17 @@ cdef class AdjacencyMap:
         coord : ndarray, dtype=float
             The central coordinates, around which the atoms are
             searched.
-        box_r: float, optional
-            The radius around `coord` (in amount of boxes), in which
+        cell_r: float, optional
+            The radius around `coord` (in amount of cells), in which
             the atoms are searched. This does not correspond to the
             Euclidian distance used in `get_atoms()`. In this case, all
-            atoms in the box corresponding to `coord` and in adjacent
-            boxes are returned.
-            By default atoms are searched in the box of `coord`
-            and adjacent boxes.
+            atoms in the cell corresponding to `coord` and in adjacent
+            cells are returned.
+            By default atoms are searched in the cell of `coord`
+            and adjacent cells.
         efficient_mode : bool, optional
             If enabled, the method will be much more efficient for
-            multiple calls of this method with the same `box_r`.
+            multiple calls of this method with the same `cell_r`.
             Rather than creating a new `ndarray` buffer for the
             indices, the indices will be put into the provided
             `array_indices` buffer.
@@ -179,7 +179,7 @@ cdef class AdjacencyMap:
             calls, since no new `ndarray` needs to be created.
             Note, that the array needs sufficient size (larger than
             the actual amount of resulting indices), that is dependent
-            on `box_r`.
+            on `cell_r`.
             When you call the method the first time in
             `efficient_mode`, leave this parameter out, a reusable
             array of sufficient size will be created for you.
@@ -204,7 +204,7 @@ cdef class AdjacencyMap:
         """
         # Pessimistic assumption on index array length requirement
         cdef int length
-        cdef int index_array_length = (2*box_r + 1)**3 * self._max_box_length
+        cdef int index_array_length = (2*cell_r + 1)**3 * self._max_cell_length
         if not efficient_mode or array_indices is None:
             array_indices = np.zeros(index_array_length, dtype=np.int32)
         else:
@@ -214,54 +214,54 @@ cdef class AdjacencyMap:
                     raise ValueError("Optionally provided index array"
                                      "is insufficient")
         # Fill index array
-        length = self._get_atoms_in_box(coord.astype(np.float32, copy=False),
-                                        array_indices, box_r)
+        length = self._get_atoms_in_cell(coord.astype(np.float32, copy=False),
+                                        array_indices, cell_r)
         if not efficient_mode:
             return array_indices[:length]
         else:
             return array_indices, length
     
     
-    def _get_atoms_in_box(self,
+    def _get_atoms_in_cell(self,
                           float32[:] coord not None,
                           int[:] indices not None,
-                          int box_r=1):
+                          int cell_r=1):
         cdef int length
         cdef int* ptr
         cdef float32 x, y,z
         cdef int i=0, j=0, k=0
         cdef int adj_i, adj_j, adj_k
-        cdef int array_i, box_i
+        cdef int array_i, cell_i
         x = coord[0]
         y = coord[1]
         z = coord[2]
-        self._get_box_index(x, y, z, &i, &j, &k)
+        self._get_cell_index(x, y, z, &i, &j, &k)
         array_i = 0
-        # Look into boxes of the indices and adjacent boxes
+        # Look into cells of the indices and adjacent cells
         # in all 3 dimensions
-        for adj_i in range(i-box_r, i+box_r+1):
-            if (adj_i >= 0 and adj_i < self._boxes.shape[0]):
-                for adj_j in range(j-box_r, j+box_r+1):
-                    if (adj_j >= 0 and adj_j < self._boxes.shape[1]):
-                        for adj_k in range(k-box_r, k+box_r+1):
-                            if (adj_k >= 0 and adj_k < self._boxes.shape[2]):
+        for adj_i in range(i-cell_r, i+cell_r+1):
+            if (adj_i >= 0 and adj_i < self._cells.shape[0]):
+                for adj_j in range(j-cell_r, j+cell_r+1):
+                    if (adj_j >= 0 and adj_j < self._cells.shape[1]):
+                        for adj_k in range(k-cell_r, k+cell_r+1):
+                            if (adj_k >= 0 and adj_k < self._cells.shape[2]):
                                 # Fill with index array
-                                # with indices in box
-                                ptr = <int*>self._boxes[adj_i, adj_j, adj_k]
-                                length = self._box_length[adj_i, adj_j, adj_k]
-                                for box_i in range(length):
-                                    indices[array_i] = ptr[box_i]
+                                # with indices in cell
+                                ptr = <int*>self._cells[adj_i, adj_j, adj_k]
+                                length = self._cell_length[adj_i, adj_j, adj_k]
+                                for cell_i in range(length):
+                                    indices[array_i] = ptr[cell_i]
                                     array_i += 1
         # return the actual length of the index array
         return array_i
     
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef inline void _get_box_index(self, float32 x, float32 y, float32 z,
+    cdef inline void _get_cell_index(self, float32 x, float32 y, float32 z,
                              int* i, int* j, int* k):
-        i[0] = <int>((x - self._min_coord[0]) / self._boxsize)
-        j[0] = <int>((y - self._min_coord[1]) / self._boxsize)
-        k[0] = <int>((z - self._min_coord[2]) / self._boxsize)
+        i[0] = <int>((x - self._min_coord[0]) / self._cellsize)
+        j[0] = <int>((y - self._min_coord[1]) / self._cellsize)
+        k[0] = <int>((z - self._min_coord[2]) / self._cellsize)
     
     
     cdef inline bint _check_coord(self, float32 x, float32 y, float32 z):
@@ -273,12 +273,12 @@ cdef class AdjacencyMap:
             return False
         return True
     
-    cdef inline bint _has_initialized_boxes(self):
+    cdef inline bint _has_initialized_cells(self):
         # Memoryviews are not initialized on class creation
-        # This method checks if a the _boxes memoryview was initialized
+        # This method checks if a the _cells memoryview was initialized
         # and is not None
         try:
-            if self._boxes is not None:
+            if self._cells is not None:
                 return True
             else:
                 return False
@@ -288,10 +288,10 @@ cdef class AdjacencyMap:
 
 cdef inline deallocate_ptrs(ptr[:,:,:] ptrs):
     cdef int i, j, k
-    cdef int* box_ptr
-    # Free box pointers
+    cdef int* cell_ptr
+    # Free cell pointers
     for i in range(ptrs.shape[0]):
         for j in range(ptrs.shape[1]):
             for k in range(ptrs.shape[2]):
-                box_ptr = <int*>ptrs[i,j,k]
-                free(box_ptr)
+                cell_ptr = <int*>ptrs[i,j,k]
+                free(cell_ptr)

--- a/tests/structure/test_adjacency.py
+++ b/tests/structure/test_adjacency.py
@@ -10,7 +10,7 @@ import pytest
 def test_adjacency_map():
     array = struc.AtomArray(length=5)
     array.coord = np.array([[0,0,i] for i in range(5)])
-    map = struc.AdjacencyMap(array, box_size=1)
-    assert map.get_atoms(np.array([0,0,0.1]), 1).tolist() == [0,1]
-    assert map.get_atoms(np.array([0,0,1.1]), 1).tolist() == [1,2]
-    assert map.get_atoms(np.array([0,0,1.1]), 2).tolist() == [0,1,2,3]
+    cell_list = struc.CellList(array, cell_size=1)
+    assert cell_list.get_atoms(np.array([0,0,0.1]), 1).tolist() == [0,1]
+    assert cell_list.get_atoms(np.array([0,0,1.1]), 1).tolist() == [1,2]
+    assert cell_list.get_atoms(np.array([0,0,1.1]), 2).tolist() == [0,1,2,3]


### PR DESCRIPTION
- `AdjacencyMap` is now called `CellList`
- Use of `__cinit__()` instead of `__init__()`
- Fixed `AttributeError` in` __dealloc__()` when constructor call fails  