### PR TITLE
Alignment objects are not iterable

### DIFF
--- a/src/biotite/sequence/align/alignment.py
+++ b/src/biotite/sequence/align/alignment.py
@@ -145,6 +145,9 @@ class Alignment(object):
         else:
             raise IndexError("Invalid alignment index")
     
+    def __iter__(self):
+        raise TypeError("'Alignment' object is not iterable")
+    
     @staticmethod
     def trace_from_strings(seq_str_list):
         """


### PR DESCRIPTION
Prior to this PR, the iteration over alignment objects yielded no elements. This PR forbids such an iteration.