### PR TITLE
Superimposition uses boolean mask

### DIFF
--- a/doc/examples/scripts/structure/ku_superimposition.py
+++ b/doc/examples/scripts/structure/ku_superimposition.py
@@ -38,7 +38,9 @@ ku = ku[~struc.filter_solvent(ku)]
 ku_dna_common = ku_dna[struc.filter_intersection(ku_dna, ku)]
 ku_common = ku[struc.filter_intersection(ku, ku_dna)]
 # Superimpose
-ku_superimposed, transformation = struc.superimpose(ku_dna_common, ku_common)
+ku_superimposed, transformation = struc.superimpose(
+    ku_dna_common, ku_common, (ku_common.atom_name == "CA")
+)
 # We do not want the cropped structures
 # -> apply superimposition on structures before intersection filtering
 ku_superimposed = struc.superimpose_apply(ku, transformation)

--- a/tests/structure/test_superimpose.py
+++ b/tests/structure/test_superimpose.py
@@ -21,7 +21,9 @@ def test_superimposition_array(path):
     mobile = fixed.copy()
     mobile = struc.rotate(mobile, (1,2,3))
     mobile = struc.translate(mobile, (1,2,3))
-    fitted, transformation = struc.superimpose(fixed, mobile, False)
+    fitted, transformation = struc.superimpose(
+        fixed, mobile, (mobile.atom_name == "CA")
+    )
     assert struc.rmsd(fixed, fitted) == pytest.approx(0)
     fitted = struc.superimpose_apply(mobile, transformation)
     assert struc.rmsd(fixed, fitted) == pytest.approx(0)
@@ -34,7 +36,11 @@ def test_superimposition_stack(ca_only):
     stack = pdbx.get_structure(pdbx_file)
     fixed = stack[0]
     mobile = stack[1:]
-    fitted, transformation = struc.superimpose(fixed, mobile, ca_only)
+    if ca_only:
+        mask = (mobile.atom_name == "CA")
+    else:
+        mask = None
+    fitted, transformation = struc.superimpose(fixed, mobile, mask)
     if ca_only:
         # The superimpositions are better for most cases than the
         # superimpositions in the structure file


### PR DESCRIPTION
Structure superimposition uses now boolean masks for selecting considered atoms. This increases the flexibility of the function.