### PR TITLE
Temporary files with generated unique name

### DIFF
--- a/src/biotite/application/clustalo/app.py
+++ b/src/biotite/application/clustalo/app.py
@@ -11,7 +11,6 @@ from ...sequence.sequence import Sequence
 from ...sequence.seqtypes import NucleotideSequence, ProteinSequence
 from ...sequence.io.fasta.file import FastaFile
 from ...sequence.align.alignment import Alignment
-from ...temp import temp_file
 
 
 class ClustalOmegaApp(MSAApp):

--- a/src/biotite/application/dssp/app.py
+++ b/src/biotite/application/dssp/app.py
@@ -41,17 +41,11 @@ class DsspApp(LocalApp):
         If true, the console output goes into DEVNULL. (Default: True)
     """
     
-    # Prevents overwriting of input and output files
-    # of different DsspApp instancs
-    _counter = 0
-    
     def __init__(self, atom_array, bin_path="dssp", mute=True):
         super().__init__(bin_path, mute)
         self._array = atom_array
-        DsspApp._counter += 1
-        self._id = DsspApp._counter
-        self._in_file_name  = temp_file("dssp_in_{:d}.pdb".format(self._id))
-        self._out_file_name = temp_file("dssp_out_{:d}.dssp".format(self._id))
+        self._in_file_name  = temp_file("pdb")
+        self._out_file_name = temp_file("pdb")
 
     def run(self):
         in_file = PDBFile()

--- a/src/biotite/application/mafft/app.py
+++ b/src/biotite/application/mafft/app.py
@@ -11,7 +11,6 @@ from ...sequence.sequence import Sequence
 from ...sequence.seqtypes import NucleotideSequence, ProteinSequence
 from ...sequence.io.fasta.file import FastaFile
 from ...sequence.align.alignment import Alignment
-from ...temp import temp_file
 
 
 class MafftApp(MSAApp):

--- a/src/biotite/application/msaapp.py
+++ b/src/biotite/application/msaapp.py
@@ -35,10 +35,6 @@ class MSAApp(LocalApp, metaclass=abc.ABCMeta):
         If true, the console output goes into DEVNULL. (Default: True)
     """
     
-    # Prevents overwriting of input and output files
-    # of different MSAApp instancs
-    _counter = 0
-    
     def __init__(self, sequences, bin_path=None, mute=True):
         # Check if all sequences share the same alphabet
         alphabet = sequences[0].get_alphabet()
@@ -49,10 +45,8 @@ class MSAApp(LocalApp, metaclass=abc.ABCMeta):
             bin_path = self.get_default_bin_path()
         super().__init__(bin_path, mute)
         self._sequences = sequences
-        MSAApp._counter += 1
-        self._id = MSAApp._counter
-        self._in_file_name  = temp_file("msa_in_{:d}.fa".format(self._id))
-        self._out_file_name = temp_file("msa_out_{:d}.fa".format(self._id))
+        self._in_file_name  = temp_file("fa")
+        self._out_file_name = temp_file("fa")
 
     def run(self):
         in_file = FastaFile()

--- a/src/biotite/application/muscle/app.py
+++ b/src/biotite/application/muscle/app.py
@@ -11,7 +11,6 @@ from ...sequence.sequence import Sequence
 from ...sequence.seqtypes import NucleotideSequence, ProteinSequence
 from ...sequence.io.fasta.file import FastaFile
 from ...sequence.align.alignment import Alignment
-from ...temp import temp_file
 
 
 class MuscleApp(MSAApp):

--- a/src/biotite/temp.py
+++ b/src/biotite/temp.py
@@ -32,22 +32,25 @@ def _delete_temp():
 
 def temp_file(suffix=""):
     """
-    Get a file path to a temporary file with the given file name.
+    Get a file path to a temporary file.
     
     All temporary files will be deleted after script execution.
     
     Parameters
     ----------
-    file_name : str
-        The base name of the file.
+    suffix : str
+        Suffix of the file.
+        By default no suffix will be appended.
     
     Returns
     -------
     temp_file_name : str
-        `file_name` appended to the path of the temporary directory.
+        a file name in the temporary directory.
     """
     global _temp_dir
     _create_temp_dir()
+    if suffix != "" and not suffix.startswith("."):
+        suffix = "." + suffix
     return tempfile.mktemp(suffix=suffix, dir=_temp_dir)
      
 

--- a/src/biotite/temp.py
+++ b/src/biotite/temp.py
@@ -8,6 +8,7 @@ __all__ = ["temp_file", "temp_dir"]
 import shutil
 import atexit
 import os
+import tempfile
 
 
 _temp_dir = ""
@@ -29,7 +30,7 @@ def _delete_temp():
         shutil.rmtree(_temp_dir)
 
 
-def temp_file(file_name):
+def temp_file(suffix=""):
     """
     Get a file path to a temporary file with the given file name.
     
@@ -47,7 +48,7 @@ def temp_file(file_name):
     """
     global _temp_dir
     _create_temp_dir()
-    return os.path.join(_temp_dir, file_name)
+    return tempfile.mktemp(suffix=suffix, dir=_temp_dir)
      
 
 def temp_dir():

--- a/tests/database/test_entrez.py
+++ b/tests/database/test_entrez.py
@@ -19,6 +19,16 @@ def test_fetch():
     prot_seq = fasta.get_sequence(fasta_file)
 
 @pytest.mark.xfail(raises=ConnectionError)
+def test_fetch_single_file():
+    file = entrez.fetch_single_file(
+        ["1L2Y_A", "3O5R_A"], biotite.temp_file("fa"), "protein", "fasta"
+    )
+    fasta_file = fasta.FastaFile()
+    fasta_file.read(file)
+    prot_seqs = fasta.get_sequences(fasta_file)
+    assert len(prot_seqs) == 2
+
+@pytest.mark.xfail(raises=ConnectionError)
 def test_fetch_invalid():
     with pytest.raises(ValueError):
         file = entrez.fetch("xxxx", biotite.temp_dir(), "fa", "protein",

--- a/tests/structure/test_gro.py
+++ b/tests/structure/test_gro.py
@@ -12,7 +12,6 @@ from os.path import join, basename
 from .util import data_dir
 import pytest
 from pytest import approx
-import tempfile
 
 
 @pytest.mark.parametrize("path, is_stack", itertools.product(
@@ -70,14 +69,14 @@ def test_pdb_to_gro(file_index, is_stack):
     a1 = pdb_file.get_structure(model=model)
 
     # Save stack as gro
-    tmp = tempfile.NamedTemporaryFile(suffix=".gro").name
+    tmp_file_name = biotite.temp_file("gro")
     gro_file = gro.GROFile()
     gro_file.set_structure(a1)
-    gro_file.write(tmp)
+    gro_file.write(tmp_file_name)
 
     # Reload stack from gro
     gro_file = gro.GROFile()
-    gro_file.read(tmp)
+    gro_file.read(tmp_file_name)
     a2 = gro_file.get_structure(model=model)
 
     assert a1.array_length() == a2.array_length()

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -81,14 +81,14 @@ def test_guess_elements():
     removed_stack.element[:] = ''
 
     # save stack without elements to tmp file
-    tmp_file = biotite.temp_file("guess_elements.pdb")
+    tmp_file_name = biotite.temp_file(".pdb")
     tmp_pdb_file = pdb.PDBFile()
     tmp_pdb_file.set_structure(removed_stack)
-    tmp_pdb_file.write(tmp_file)
+    tmp_pdb_file.write(tmp_file_name)
 
     # read new stack from file with guessed elements
     guessed_pdb_file = pdb.PDBFile()
-    guessed_pdb_file.read(tmp_file)
+    guessed_pdb_file.read(tmp_file_name)
     guessed_stack = guessed_pdb_file.get_structure()
 
     assert guessed_stack.element.tolist() == stack.element.tolist()


### PR DESCRIPTION
The `temp` module uses `tempfile.mktemp()` to generate file names for temporary files in `.biotitetemp`.