### PR TITLE
allow string/file-like as template for load_structure

### DIFF
--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -27,7 +27,7 @@ def load_structure(file_path, template=None):
     ----------
     file_path : str
         The path to structure file.
-    template : AtomArray or AtomArrayStack, optional
+    template : AtomArray or AtomArrayStack or file-like object or str, optional
         Only required when reading a trajectory file.
     
     Returns
@@ -44,6 +44,10 @@ def load_structure(file_path, template=None):
         If a trajectory file is loaded without specifying the
         `template` parameter.
     """
+    # eventually load template from file
+    if template != None and not (isinstance(template, AtomArray) or isinstance(template, AtomArrayStack)):
+        template = load_structure(template)
+
     # We only need the suffix here
     filename, suffix = os.path.splitext(file_path)
     if suffix == ".pdb":

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -11,6 +11,7 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["load_structure", "save_structure"]
 
 import os.path
+import io
 from ..atoms import AtomArray, AtomArrayStack
 
 
@@ -44,8 +45,8 @@ def load_structure(file_path, template=None):
         If a trajectory file is loaded without specifying the
         `template` parameter.
     """
-    # eventually load template from file
-    if template != None and not (isinstance(template, AtomArray) or isinstance(template, AtomArrayStack)):
+    # Optionally load template from file
+    if isinstance(template, io.IOBase):
         template = load_structure(template)
 
     # We only need the suffix here

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -46,7 +46,7 @@ def load_structure(file_path, template=None):
         `template` parameter.
     """
     # Optionally load template from file
-    if isinstance(template, io.IOBase):
+    if isinstance(template, (io.IOBase, str)):
         template = load_structure(template)
 
     # We only need the suffix here

--- a/src/biotite/structure/io/general.pyi
+++ b/src/biotite/structure/io/general.pyi
@@ -2,13 +2,13 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
-from typing import Optional, Union
+from typing import Optional, Union, TextIO, BinaryIO
 from .atoms import AtomArrayStack, AtomArray
 
 
 def load_structure(
     file_path: str,
     template: Optional[Union[AtomArrayStack, AtomArray]] = None
-) -> Union[AtomArray, AtomArrayStack]: ...
+) -> Union[AtomArray, AtomArrayStack, TextIO, BinaryIO, str]: ...
 
 def save_structure(file_path: str, array: AtomArrayStack) -> None: ...

--- a/tests/structure/test_generalio.py
+++ b/tests/structure/test_generalio.py
@@ -27,9 +27,9 @@ def test_loading(path):
 def test_loading_template_with_trj():
     template = join(data_dir, "1l2y.pdb")
     trajectory = join(data_dir, "1l2y.xtc")
-    a = strucio.load_structure(trajectory, template)
-    assert isinstance(a, struc.AtomArrayStack)
-    assert len(a) > 1
+    stack = strucio.load_structure(trajectory, template)
+    assert isinstance(stack, struc.AtomArrayStack)
+    assert len(stack) > 1
 
 
 @pytest.mark.parametrize("suffix", ["pdb","cif","gro","pdbx","mmtf"])

--- a/tests/structure/test_generalio.py
+++ b/tests/structure/test_generalio.py
@@ -23,6 +23,14 @@ def test_loading(path):
         array = strucio.load_structure(path)
 
 
+def test_loading_template_with_trj():
+    template = join(data_dir, "1l2y.pdb")
+    trajectory = join(data_dir, "1l2y.xtc")
+    a = strucio.load_structure(trajectory, template)
+    assert isinstance(a, struc.AtomArrayStack)
+    assert len(a) > 1
+
+
 @pytest.mark.parametrize("suffix", ["pdb","cif","gro","pdbx","mmtf"])
 def test_saving(suffix):
     array = strucio.load_structure(join(data_dir, "1l2y.mmtf"))

--- a/tests/structure/test_generalio.py
+++ b/tests/structure/test_generalio.py
@@ -23,6 +23,7 @@ def test_loading(path):
         array = strucio.load_structure(path)
 
 
+@pytest.mark.xfail(raises=ImportError)
 def test_loading_template_with_trj():
     template = join(data_dir, "1l2y.pdb")
     trajectory = join(data_dir, "1l2y.xtc")


### PR DESCRIPTION
Right now, loading a trajectory is a two-step because the template has to be loaded in memory before calling ```load_structure```. This can be reduced to a oneliner by allowing to submit strings as templates:


```python
from biotite.structure.io import load_structure

# "abc.pdb" is automatically loaded as template 
stack = load_structure("abc.xtc", template="abc.pdb")
```