### PR TITLE
Structures read from mmCIF files use 'auth_seq_id' instead of 'label_seq_id' for residue ID

### DIFF
--- a/src/biotite/structure/io/mmtf/convertarray.pyx
+++ b/src/biotite/structure/io/mmtf/convertarray.pyx
@@ -238,10 +238,6 @@ def set_structure(file, array):
     file["groupsPerChain"] = res_per_chain.tolist()
     file["numGroups"] = len(res_ids)
     file.set_array("groupIdList", res_ids, codec=8)
-     # Sequence index starts at 0, res IDs at 1
-     # -> decrement (the hetero residues (-1) exclusive)
-    res_ids[res_ids != -1] -= 1
-    file.set_array("sequenceIndexList", res_ids, codec=8)
     file.set_array("groupTypeList", res_types, codec=4)
     file["groupList"] = residues
     file["numAtoms"] = model_count * array_length

--- a/src/biotite/structure/io/mmtf/convertfile.pyx
+++ b/src/biotite/structure/io/mmtf/convertfile.pyx
@@ -87,10 +87,7 @@ def get_structure(file, model=None, insertion_code=[], altloc=[],
     cdef int32[:] chains_per_model = np.array(file["chainsPerModel"], np.int32)
     cdef int32[:] res_per_chain = np.array(file["groupsPerChain"], np.int32)
     cdef int32[:] res_type_i = file["groupTypeList"]
-    cdef np.ndarray index_list = file["sequenceIndexList"]
-    # Sequence index starts at 0, res IDs at 1
-    # -> increment (the hetero residues (-1) exclusive)
-    index_list[index_list != -1] += 1
+    cdef np.ndarray index_list = file["groupIdList"]
     cdef int32[:] res_ids = index_list
     cdef np.ndarray x_coord = file["xCoordList"]
     cdef np.ndarray y_coord = file["yCoordList"]

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -141,7 +141,7 @@ def get_structure(pdbx_file, model=None, data_block=None,
 def _fill_annotations(array, model_dict, extra_fields):
     array.set_annotation("chain_id", model_dict["auth_asym_id"].astype("U3"))
     array.set_annotation("res_id", np.array([-1 if e in [".","?"] else int(e)
-                                      for e in model_dict["label_seq_id"]]))
+                                      for e in model_dict["auth_seq_id"]]))
     array.set_annotation("res_name", model_dict["label_comp_id"].astype("U3"))
     array.set_annotation("hetero", (model_dict["group_PDB"] == "HETATM"))
     array.set_annotation("atom_name", model_dict["label_atom_id"].astype("U6"))
@@ -238,7 +238,7 @@ def set_structure(pdbx_file, array, data_block=None):
     atom_site_dict["label_asym_id"] = np.copy(array.chain_id)
     atom_site_dict["label_entity_id"] = _determine_entity_id(array.chain_id)
     atom_site_dict["label_seq_id"] = np.array(["." if e == -1 else str(e)
-                                            for e in array.res_id])
+                                               for e in array.res_id])
     atom_site_dict["auth_seq_id"] = atom_site_dict["label_seq_id"]
     atom_site_dict["auth_comp_id"] = atom_site_dict["label_comp_id"]
     atom_site_dict["auth_asym_id"] = atom_site_dict["label_asym_id"]

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -239,7 +239,10 @@ def set_structure(pdbx_file, array, data_block=None):
     atom_site_dict["label_entity_id"] = _determine_entity_id(array.chain_id)
     atom_site_dict["label_seq_id"] = np.array(["." if e == -1 else str(e)
                                             for e in array.res_id])
-    atom_site_dict["auth_asym_id"] = np.copy(array.chain_id)
+    atom_site_dict["auth_seq_id"] = atom_site_dict["label_seq_id"]
+    atom_site_dict["auth_comp_id"] = atom_site_dict["label_comp_id"]
+    atom_site_dict["auth_asym_id"] = atom_site_dict["label_asym_id"]
+    atom_site_dict["auth_atom_id"] = atom_site_dict["label_atom_id"]
     #Optional categories
     if "atom_id" in annot_categories:
         # Take values from 'atom_id' category

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -260,13 +260,20 @@ class PDBxFile(TextFile):
         """
         if block is None:
             block = self.get_block_names()[0]
-            
+        
         sample_category_value = list(category_dict.values())[0]
         if (isinstance(sample_category_value, (np.ndarray, list))):
             is_looped = True
         else:
             is_looped = False
-            
+        
+        # Value arrays (looped categories) can be modified (e.g. quoted)
+        # Hence make a copy to avoid unwaned side effects
+        # due to modification of input values
+        if is_looped:
+            category_dict = {key : val.copy() for key, val
+                             in category_dict.items()}
+
         # Enclose values with quotes if required
         for key, value in category_dict.items():
             if is_looped:
@@ -311,7 +318,7 @@ class PDBxFile(TextFile):
                          + " " * (req_len-len(key)) + value
                          for key, value in category_dict.items()]
             
-        # A command line is set after every category
+        # A comment line is set after every category
         newlines += ["#"]
         
         if (block,category) in self._categories:

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -43,9 +43,7 @@ def test_pdbx_consistency(file_index, is_stack):
     pdbx_file = pdbx.PDBxFile()
     pdbx_file.read(cif_paths[file_index])
     a2 = pdbx.get_structure(pdbx_file, model=model)
-    # Expected fail in res_id
-    for category in ["chain_id", "res_name", "hetero",
-                     "atom_name", "element"]:
+    for category in a1.get_annotation_categories():
         assert a1.get_annotation(category).tolist() == \
                a2.get_annotation(category).tolist()
     assert a1.coord.tolist() == a2.coord.tolist()

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -44,11 +44,15 @@ def test_conversion(path, is_stack):
         array1 = pdbx.get_structure(pdbx_file, model=1)
     pdbx_file = pdbx.PDBxFile()
     pdbx.set_structure(pdbx_file, array1, data_block="test")
+    print(str(pdbx_file)[:10000])
     if is_stack:
         array2 = pdbx.get_structure(pdbx_file)
     else:
         array2 = pdbx.get_structure(pdbx_file, model=1)
-    assert array1 == array2
+    for category in array1.get_annotation_categories():
+        assert array1.get_annotation(category).tolist() == \
+               array2.get_annotation(category).tolist()
+    assert array1.coord.tolist() == array2.coord.tolist()
 
 def test_extra_fields():
     path = join(data_dir, "1l2y.cif")


### PR DESCRIPTION
This PR changes the mmCIF field that is read for the `AromArray` `res_id` field from `label_seq_id` to `auth_seq_id`. This brings two improvements:

   - More consistency with PDB files
   - For MMTF files, the `groupIdList` files can be used
   - Additional distinction between multiple equal `HETERO` molecules