### PR TITLE
pdbs 'atom_id' field overflows when there are more than 100000 atoms

### DIFF
--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -293,12 +293,18 @@ class PDBFile(TextFile):
                       for charge in array.get_annotation("charge")]
         else:
             charge = [""] * array.array_length()
+
+        if array.array_length() >= 100000:
+            warn("More then 100,000 atoms per model.")
         
         if isinstance(array, AtomArray):
             self.lines = [None] * array.array_length()
             for i in range(array.array_length()):
+                pdb_id = atom_id[i]
+                if pdb_id >= 100000:
+                    pdb_id = pdb_id % 100000 + 1
                 self.lines[i] = ("{:6}".format(hetero[i]) + 
-                                  "{:>5d}".format(atom_id[i]) +
+                                  "{:>5d}".format(pdb_id) +
                                   " " +
                                   "{:4}".format(array.atom_name[i]) +
                                   " " +
@@ -326,8 +332,11 @@ class PDBFile(TextFile):
             # which are afterwards applied for each model
             templines = [None] * array.array_length()
             for i in range(array.array_length()):
+                pdb_id = atom_id[i]
+                if pdb_id >= 100000:
+                    pdb_id % 100000 + 1
                 templines[i] = ("{:6}".format(hetero[i]) + 
-                                 "{:>5d}".format(atom_id[i]) +
+                                 "{:>5d}".format(pdb_id) +
                                  " " +
                                  "{:4}".format(array.atom_name[i]) +
                                  " " +

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -150,8 +150,6 @@ def test_atoms_overflow(recwarn):
     a = array(atoms)
     a.res_id = np.array([1] * 100000)
     a.atom_name = np.array(['CA'] * 100000)
-    for i in range(150000):
-        atom = Atom([1,2,3])
     
     # write stack to pdb file and make sure a warning is thrown
     with pytest.warns(UserWarning):

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -144,25 +144,25 @@ def test_box_parsing():
            == approx(a.box.flatten().tolist(), abs=1e-2)
 
 
-def test_atoms_overflow(recwarn):
-    # create a stack > 100k atoms
+def test_atoms_overflow():
+    # Create a stack > 100k atoms
     atoms = [Atom([1,2,3]) for i in range(100000)]
     a = array(atoms)
     a.res_id = np.array([1] * 100000)
     a.atom_name = np.array(['CA'] * 100000)
     
-    # write stack to pdb file and make sure a warning is thrown
+    # Write stack to pdb file and make sure a warning is thrown
     with pytest.warns(UserWarning):
         tmp_file_name = biotite.temp_file(".pdb")
         tmp_pdb_file = pdb.PDBFile()
         tmp_pdb_file.set_structure(a)
         tmp_pdb_file.write(tmp_file_name)
 
-    # assert file can be read properly
+    # Assert file can be read properly
     a2 = io.load_structure(tmp_file_name)
     assert(a2.array_length() == a.array_length())
     
-    # manually check if the written atom id is correct
+    # Manually check if the written atom id is correct
     with open(tmp_file_name) as output:
         last_line = output.readlines()[-1]
         atom_id = int(last_line.split()[1])

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -3,16 +3,15 @@
 # information.
 
 import itertools
-import numpy as np
 import glob
 from os.path import join, splitext
 import pytest
 from pytest import approx
+import numpy as np
 import biotite
 import biotite.structure as struc
 import biotite.structure.io.pdb as pdb
 import biotite.structure.io.pdbx as pdbx
-from biotite.structure.atoms import AtomArray, array, Atom
 import biotite.structure.io as io
 from .util import data_dir
 
@@ -122,7 +121,7 @@ def test_box_shape(path, single_model):
     pdb_file.read(path)
     a = pdb_file.get_structure(model=model)
 
-    if isinstance(a, AtomArray):
+    if isinstance(a, struc.AtomArray):
         expected_box_dim = (3, 3)
     else:
         expected_box_dim = (len(a), 3, 3)
@@ -145,11 +144,15 @@ def test_box_parsing():
 
 
 def test_atoms_overflow():
-    # Create a stack > 100k atoms
-    atoms = [Atom([1,2,3]) for i in range(100000)]
-    a = array(atoms)
-    a.res_id = np.array([1] * 100000)
-    a.atom_name = np.array(['CA'] * 100000)
+    # Create an atom array >= 100k atoms
+    length = 100000
+    a = struc.AtomArray(length)
+    a.chain_id = np.full(length, "A")
+    a.res_id = np.full(length, 1)
+    a.res_name = np.full(length, "GLY")
+    a.hetero = np.full(length, False)
+    a.atom_name = np.full(length, "CA")
+    a.element = np.full(length, "C")
     
     # Write stack to pdb file and make sure a warning is thrown
     with pytest.warns(UserWarning):


### PR DESCRIPTION
AtomArrays with more then 100k atoms cause an overflow of the atom_id field when written to a pdb file. This results in the the pdb_id field of pdb files to be larger then expected and results in broken files (cannot be parsed by biotite or other common programs). This patch fixes this behaviour by starting with atom_id = 1 once 99,999 is reached. A user warning is thrown if such a file is written.