### PR TITLE
Fix geometry.distance documentation

### DIFF
--- a/src/biotite/structure/geometry.py
+++ b/src/biotite/structure/geometry.py
@@ -189,6 +189,12 @@ def distance(atoms1, atoms2, box=None):
         Alternatively an ndarray containing the coordinates can be
         provided.
         Usual *NumPy* broadcasting rules apply.
+    box : ndarray, shape=(3,3) or shape=(m,3,3), optional
+        If this parameter is set, periodic boundary conditions are
+        taken into account (minimum-image convention), based on
+        the box vectors given with this parameter.
+        The shape *(m,3,3)* is only allowed, when the input coordinates
+        comprise multiple models.
     
     Returns
     -------
@@ -196,12 +202,6 @@ def distance(atoms1, atoms2, box=None):
         The atom distances.
         The shape is equal to the shape of the input `atoms` with the
         highest dimensionality minus the last axis.
-    box : ndarray, shape=(3,3) or shape=(m,3,3), optional
-        If this parameter is set, periodic boundary conditions are
-        taken into account (minimum-image convention), based on
-        the box vectors given with this parameter.
-        The shape *(m,3,3)* is only allowed, when the input coordinates
-        comprise multiple models.
     
     See also
     --------


### PR DESCRIPTION
The doc for the "box" parameter in geometry.distance happend to end in the Returns section instead of Parameters leading to wrong autocomplete suggestions.