### PR TITLE
TypeError is raises when 'AtomArrayStack' is given to 'CellList' instead of 'AtomArray'

### DIFF
--- a/src/biotite/structure/celllist.pyx
+++ b/src/biotite/structure/celllist.pyx
@@ -16,6 +16,7 @@ from libc.stdlib cimport realloc, malloc, free
 
 import numpy as np
 from .atoms import coord as to_coord
+from .atoms import AtomArrayStack
 from .box import repeat_box_coord, move_inside_box
 
 ctypedef np.uint64_t ptr
@@ -99,9 +100,11 @@ cdef class CellList:
         cdef int* cell_ptr = NULL
         cdef int length
 
+        if isinstance(atom_array, AtomArrayStack):
+            raise TypeError("Expected 'AtomArray' but got 'AtomArrayStack'")
+        coord = to_coord(atom_array)
         # the length of the array before appending periodic copies
         # if 'periodic' is true
-        coord = to_coord(atom_array)
         self._orig_length = coord.shape[0]
         self._box = None
         if coord.ndim != 2:


### PR DESCRIPTION
This PR introduces this type check, since the accidental exchange of an `AtomArray` with an `AtomArrayStack` can be quite common.