### PR TITLE
GRO files are terminated with a newline 

### DIFF
--- a/src/biotite/structure/io/gro/file.py
+++ b/src/biotite/structure/io/gro/file.py
@@ -302,4 +302,6 @@ class GROFile(TextFile):
                 self.lines.append(get_box_dimen(array[i]))
         else:
             raise TypeError("An atom array or stack must be provided")
+        # Add terminal newline, since PyMOL requires it
+        self.lines.append("")
 


### PR DESCRIPTION
Without a newline GRO files cannot be opened in PyMOL