### PR TITLE
PDB writer checks for residue ID overflow

### DIFF
--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -293,25 +293,32 @@ class PDBFile(TextFile):
                       for charge in array.get_annotation("charge")]
         else:
             charge = [""] * array.array_length()
+        
+        # Atom IDs are supported up to 99999
+        # Residue IDs are supported up to 9999
+        pdb_atom_id = ((atom_id - 1) % 99999) + 1
+        pdb_res_id = ((array.res_id - 1) % 9999) + 1
 
+        # Do checks on atom array (stack)
         if array.array_length() >= 100000:
-            warn("More then 100,000 atoms per model.")
+            warn("More then 100,000 atoms per model")
+        if (array.res_id >= 10000).any():
+            warn("Residue IDs exceed 9999")
+        if np.isnan(array.coord).any():
+            raise ValueError("Coordinates contain 'NaN' values")
         
         if isinstance(array, AtomArray):
             self.lines = [None] * array.array_length()
             for i in range(array.array_length()):
-                pdb_id = atom_id[i]
-                if pdb_id >= 100000:
-                    pdb_id = pdb_id % 100000 + 1
                 self.lines[i] = ("{:6}".format(hetero[i]) + 
-                                  "{:>5d}".format(pdb_id) +
+                                  "{:>5d}".format(pdb_atom_id[i]) +
                                   " " +
                                   "{:4}".format(array.atom_name[i]) +
                                   " " +
                                   "{:3}".format(array.res_name[i]) +
                                   " " +
                                   "{:1}".format(array.chain_id[i]) +
-                                  "{:>4d}".format(array.res_id[i]) +
+                                  "{:>4d}".format(pdb_res_id[i]) +
                                   (" " * 4) +
                                   "{:>8.3f}".format(array.coord[i,0]) +
                                   "{:>8.3f}".format(array.coord[i,1]) +
@@ -332,18 +339,15 @@ class PDBFile(TextFile):
             # which are afterwards applied for each model
             templines = [None] * array.array_length()
             for i in range(array.array_length()):
-                pdb_id = atom_id[i]
-                if pdb_id >= 100000:
-                    pdb_id % 100000 + 1
                 templines[i] = ("{:6}".format(hetero[i]) + 
-                                 "{:>5d}".format(pdb_id) +
+                                 "{:>5d}".format(pdb_atom_id[i]) +
                                  " " +
                                  "{:4}".format(array.atom_name[i]) +
                                  " " +
                                  "{:3}".format(array.res_name[i]) +
                                  " " +
                                  "{:1}".format(array.chain_id[i]) +
-                                 "{:>4d}".format(array.res_id[i]) +
+                                 "{:>4d}".format(pdb_res_id[i]) +
                                  (" " * 28) +
                                  "{:>6.2f}".format(occupancy[i]) +
                                  "{:>6.3f}".format(b_factor[i]) +

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -143,12 +143,14 @@ def test_box_parsing():
            == approx(a.box.flatten().tolist(), abs=1e-2)
 
 
-def test_atoms_overflow():
+def test_id_overflow():
     # Create an atom array >= 100k atoms
     length = 100000
     a = struc.AtomArray(length)
+    a.coord = np.zeros(a.coord.shape)
     a.chain_id = np.full(length, "A")
-    a.res_id = np.full(length, 1)
+    # Create residue IDs over 10000
+    a.res_id = np.arange(1, length+1)
     a.res_name = np.full(length, "GLY")
     a.hetero = np.full(length, False)
     a.atom_name = np.full(length, "CA")


### PR DESCRIPTION
Furthermore, an issue in the PDB writer when having at least 200,000 atoms was fixed.