### PR TITLE
handle dummy boxes in .gro correctly

### DIFF
--- a/src/biotite/structure/io/gro/file.py
+++ b/src/biotite/structure/io/gro/file.py
@@ -196,10 +196,11 @@ class GROFile(TextFile):
                 box = set_box_dimen(box_param)
                 # Create a box in the stack if not already existing
                 # and the box is not a dummy
-                if array.box is None and box is not None:
-                    array.box = np.zeros((array.stack_depth(), 3, 3))
-                array.box[m] = box
-
+                if box is not None:
+                    if array.box is None: 
+                        array.box = np.zeros((array.stack_depth(), 3, 3))
+                    array.box[m] = box
+                    
         return array
 
             

--- a/tests/structure/test_gro.py
+++ b/tests/structure/test_gro.py
@@ -119,4 +119,25 @@ def test_gro_id_overflow():
     assert s.array_length() == num_atoms
 
 
+def test_gro_no_box():
+    """
+    .gro file format requires valid box parameters at the end of each
+    model. However, if we read such a file in, the resulting object should not
+    have an assigned box.
+    """
 
+    # Create an AtomArray
+    atom = Atom([1,2,3], atom_name="CA", element="C", res_name="X", res_id=1)
+    atoms = array([atom])
+
+    # Write .gro file
+    tmp_file_name = biotite.temp_file(".gro")
+    io.save_structure(tmp_file_name, atoms)
+    
+    # Read in file
+    gro_file = gro.GROFile()
+    gro_file.read(tmp_file_name)
+    s = gro_file.get_structure()
+
+    # Assert no box with 0 dimension
+    assert s.box is None


### PR DESCRIPTION
There is a small issue with the .gro input reader resulting in an exception if an empty box (x=y=z=0.000) is read in. This fixes this problem and also implements an appropriate unit test.