### PR TITLE
Revamped 'dihedral_bockbone()' function

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -207,6 +207,12 @@
             "get_residue_count",
             "residue_iter"
         ],
+        "Chain level utility" : [
+            "get_chain_starts",
+            "get_chains",
+            "get_chain_count",
+            "chain_iter"
+        ],
         "Structure comparison" : [
             "average",
             "rmsd",

--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -95,6 +95,7 @@ from .integrity import *
 from .mechanics import *
 from .rdf import *
 from .residues import *
+from .chains import *
 from .sasa import *
 from .sse import *
 from .superimpose import *

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -1,0 +1,114 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+"""
+This module provides utility for handling data on chain level, rather than
+atom level.
+"""
+
+__author__ = "Patrick Kunzmann"
+__all__ = ["get_chain_starts", "get_chains", "get_chain_count", "chain_iter"]
+
+import numpy as np
+
+
+def get_chain_starts(array):
+    """
+    Get the indices in an atom array, which indicates the beginning of
+    a new chain.
+    
+    A new chain starts, when the chain ID changes.
+
+    This method is internally used by all other chain-related
+    functions.
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack) to get the chain starts from.
+        
+    Returns
+    -------
+    starts : ndarray, dtype=int
+        The start indices of new chains in `array`.
+    
+    See also
+    --------
+    get_residue_starts
+    """
+    chain_ids = array.chain_id
+    return np.where((chain_ids[:-1] != chain_ids[1:]))[0] + 1
+
+
+def get_chains(array):
+    """
+    Get the chain IDs of an atom array (stack).
+    
+    The chains are listed in the same order they occur in the array
+    (stack).
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack), where the chains are determined.
+        
+    Returns
+    -------
+    ids : ndarray, dtype=int
+        List of chain IDs.
+        
+    See also
+    --------
+    get_residues
+    """
+    return array.chain_id[get_chain_starts(array)]
+
+
+def get_chain_count(array):
+    """
+    Get the amount of chains in an atom array (stack).
+    
+    The count is determined from the `chain_id` annotation.
+    Each time the chain ID changes, the count is incremented.
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack), where the chains are counted.
+        
+    Returns
+    -------
+    count : int
+        Amount of chains.
+    
+    See also
+    --------
+    get_residue_count
+    """
+    return len(get_chain_starts(array))
+
+
+def chain_iter(array):
+    """
+    Iterate over all chains in an atom array (stack).
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack) to iterate over.
+        
+    Returns
+    -------
+    count : generator of AtomArray or AtomArrayStack
+        A generator of subarrays or substacks (dependent on the input
+        type) containing each chain of the input `array`.
+    
+    See also
+    --------
+    residue_iter
+    """
+    # The exclusive stop is appended to the chain starts
+    starts = np.append(get_chain_starts(array), [array.array_length()])
+    for i in range(len(starts)-1):
+        yield array[..., starts[i] : starts[i+1]]

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -38,7 +38,9 @@ def get_chain_starts(array):
     get_residue_starts
     """
     chain_ids = array.chain_id
-    return np.where((chain_ids[:-1] != chain_ids[1:]))[0] + 1
+    chain_changes = np.where((chain_ids[:-1] != chain_ids[1:]))[0] + 1
+    chain_starts = np.append([0], chain_changes)
+    return chain_starts
 
 
 def get_chains(array):
@@ -55,7 +57,7 @@ def get_chains(array):
         
     Returns
     -------
-    ids : ndarray, dtype=int
+    ids : ndarray, dtype=str
         List of chain IDs.
         
     See also

--- a/src/biotite/structure/geometry.py
+++ b/src/biotite/structure/geometry.py
@@ -515,8 +515,8 @@ def dihedral_backbone(atom_array):
     Examples
     --------
     
-    >>> phi, psi, omega = dihedral_backbone(atom_array, "A")
-    >>> print(np.stack([phi * 360/(2*np.pi), psi * 360/(2*np.pi)]).T)
+    >>> phi, psi, omega = dihedral_backbone(atom_array)
+    >>> print(np.stack([np.rad2deg(phi), np.rad2deg(psi)]).T)
     [[     nan  -56.145]
      [ -43.980  -51.309]
      [ -66.466  -30.898]

--- a/src/biotite/structure/geometry.py
+++ b/src/biotite/structure/geometry.py
@@ -16,6 +16,7 @@ import numpy as np
 from .atoms import Atom, AtomArray, AtomArrayStack, coord
 from .util import vector_dot, norm_vector
 from .filter import filter_backbone
+from .residues import get_residue_starts
 from .box import (coord_to_fraction, fraction_to_coord,
                   move_inside_box, is_orthogonal)
 from .error import BadStructureError
@@ -477,7 +478,7 @@ def index_dihedral(*args, **kwargs):
     return _call_non_index_function(dihedral, 4, *args, **kwargs)
 
 
-def dihedral_backbone(atom_array, chain_id):
+def dihedral_backbone(atom_array, chain_id=None):
     """
     Measure the characteristic backbone dihedral angles of a structure.
     
@@ -486,9 +487,15 @@ def dihedral_backbone(atom_array, chain_id):
     atom_array: AtomArray or AtomArrayStack
         The protein structure. A complete backbone, without gaps,
         is required here.
-    chain_id: string
+        The order of the backbone atoms for each residue must be
+        (N, CA, C).
+    chain_id: string, optional
         The ID of the polypeptide chain. The dihedral angles are
-        calculated for ``atom_array[atom_array.chain_id == chain_id]``
+        calculated for ``atom_array[atom_array.chain_id == chain_id]``.
+        By default, this filtering is not performed.
+        When not setting this parameter, make sure the atom array
+        contains only one chain, otherwise the dihedral angles will
+        contain wrong values.
     
     Returns
     -------
@@ -536,16 +543,21 @@ def dihedral_backbone(atom_array, chain_id):
      [ -77.264  124.223]
      [ -78.100      nan]]
     """
-    # Filter all backbone atoms
-    bb_coord = atom_array[...,
-                            filter_backbone(atom_array) &
-                            (atom_array.chain_id == chain_id)].coord
-    if bb_coord.shape[-1] % 3 != 0:
-        raise BadStructureError(
-            "AtomArray has insufficient amount of backbone atoms "
-            "(possibly missing terminus)"
-        )
+    bb_filter = filter_backbone(atom_array)
+    if chain_id is not None:
+        bb_filter &= (atom_array.chain_id == chain_id)
+    backbone = atom_array[..., bb_filter]
     
+    if backbone.array_length() % 3 != 0 \
+        or (backbone.atom_name[0::3] != "N" ).any() \
+        or (backbone.atom_name[1::3] != "CA").any() \
+        or (backbone.atom_name[2::3] != "C" ).any():
+            raise BadStructureError(
+                "The backbone is invalid, must be repeats of (N, CA, C), "
+                "maybe a backbone atom is missing"
+            )
+    
+    bb_coord = backbone.coord
     # Coordinates for dihedral angle calculation
     # Dim 0: Model index (only for atom array stacks)
     # Dim 1: Angle index

--- a/src/biotite/structure/geometry.py
+++ b/src/biotite/structure/geometry.py
@@ -16,7 +16,7 @@ import numpy as np
 from .atoms import Atom, AtomArray, AtomArrayStack, coord
 from .util import vector_dot, norm_vector
 from .filter import filter_backbone
-from .residues import get_residue_starts
+from .chains import chain_iter
 from .box import (coord_to_fraction, fraction_to_coord,
                   move_inside_box, is_orthogonal)
 from .error import BadStructureError
@@ -478,7 +478,7 @@ def index_dihedral(*args, **kwargs):
     return _call_non_index_function(dihedral, 4, *args, **kwargs)
 
 
-def dihedral_backbone(atom_array, chain_id=None):
+def dihedral_backbone(atom_array):
     """
     Measure the characteristic backbone dihedral angles of a structure.
     
@@ -487,15 +487,10 @@ def dihedral_backbone(atom_array, chain_id=None):
     atom_array: AtomArray or AtomArrayStack
         The protein structure. A complete backbone, without gaps,
         is required here.
+        Chain transitions are allowed, the angles at the transition are
+        `NaN`.
         The order of the backbone atoms for each residue must be
         (N, CA, C).
-    chain_id: string, optional
-        The ID of the polypeptide chain. The dihedral angles are
-        calculated for ``atom_array[atom_array.chain_id == chain_id]``.
-        By default, this filtering is not performed.
-        When not setting this parameter, make sure the atom array
-        contains only one chain, otherwise the dihedral angles will
-        contain wrong values.
     
     Returns
     -------
@@ -544,8 +539,6 @@ def dihedral_backbone(atom_array, chain_id=None):
      [ -78.100      nan]]
     """
     bb_filter = filter_backbone(atom_array)
-    if chain_id is not None:
-        bb_filter &= (atom_array.chain_id == chain_id)
     backbone = atom_array[..., bb_filter]
     
     if backbone.array_length() % 3 != 0 \
@@ -556,16 +549,28 @@ def dihedral_backbone(atom_array, chain_id=None):
                 "The backbone is invalid, must be repeats of (N, CA, C), "
                 "maybe a backbone atom is missing"
             )
-    
-    bb_coord = backbone.coord
+    phis = []
+    psis = []
+    omegas = []
+    for chain_bb in chain_iter(backbone):
+        phi, psi, omega = _dihedral_backbone(chain_bb)
+        phis.append(phi)
+        psis.append(psi)
+        omegas.append(omega)
+    return np.concatenate(phis), np.concatenate(psis), np.concatenate(omegas)
+
+
+
+def _dihedral_backbone(chain_bb):
+    bb_coord = chain_bb.coord
     # Coordinates for dihedral angle calculation
     # Dim 0: Model index (only for atom array stacks)
     # Dim 1: Angle index
     # Dim 2: X, Y, Z coordinates
     # Dim 3: Atoms involved in dihedral angle
-    if isinstance(atom_array, AtomArray):
+    if isinstance(chain_bb, AtomArray):
         angle_coord_shape = (len(bb_coord)//3, 3, 4)
-    elif isinstance(atom_array, AtomArrayStack):
+    elif isinstance(chain_bb, AtomArrayStack):
         angle_coord_shape = (bb_coord.shape[0], bb_coord.shape[1]//3, 3, 4)
     phi_coord   = np.full(angle_coord_shape, np.nan)
     psi_coord   = np.full(angle_coord_shape, np.nan)

--- a/src/biotite/structure/residues.py
+++ b/src/biotite/structure/residues.py
@@ -35,7 +35,7 @@ def get_residue_starts(array):
         
     Returns
     -------
-    starts : ndarray
+    starts : ndarray, dtype=int
         The start indices of residues in `array`.
     """
     chain_ids = array.chain_id

--- a/tests/structure/test_chains.py
+++ b/tests/structure/test_chains.py
@@ -1,0 +1,34 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+import biotite.structure as struc
+import biotite.structure.io as strucio
+import numpy as np
+from os.path import join
+from .util import data_dir
+import pytest
+
+
+@pytest.fixture
+def array():
+    return strucio.load_structure(join(data_dir, "1igy.mmtf"))
+
+def test_get_chain_starts(array):
+    _, ref_starts = np.unique(array.chain_id, return_index=True)
+    test_starts = struc.get_chain_starts(array)
+    # All first occurences of a chain id are automatically chain starts
+    assert set(ref_starts).issubset(set(test_starts))
+
+def test_get_chains(array):
+    assert struc.get_chains(array).tolist() == ["A", "B", "C", "D", "B", "D"]
+
+def test_get_chain_count(array):
+    assert struc.get_chain_count(array) == 6
+
+def test_chain_iter(array):
+    n = 0
+    for chain in struc.get_chains(array):
+        n += 1
+        assert isinstance(array, struc.AtomArray)
+    assert n == 6

--- a/tests/structure/test_geometry.py
+++ b/tests/structure/test_geometry.py
@@ -43,13 +43,13 @@ def test_dihedral_backbone():
     stack = strucio.load_structure(join(data_dir, "1l2y.mmtf"))
     array = stack[0]
     # Test array
-    phi, psi, omega = struc.dihedral_backbone(array, "A")
+    phi, psi, omega = struc.dihedral_backbone(array)
     assert omega.shape == (20,)
     # Remove nan values
     omega = np.abs(omega)[:-1]
     assert omega.tolist() == pytest.approx([np.pi] * len(omega), rel=0.05)
     # Test stack
-    phi, psi, omega = struc.dihedral_backbone(stack, "A")
+    phi, psi, omega = struc.dihedral_backbone(stack)
     assert omega.shape == (38,20)
     # Remove nan values
     omega = np.abs(omega)[:, :-1]


### PR DESCRIPTION
This PR changes the `dihedral_backbone()` function:

- Added chain-level functionality, similar to the existing residue-level functionality
- The `chain_id`, parameter is removed, the function iterates over all chains
- Improved validity check for input atom arrays