### PR TITLE
dihedrals: correct output shape for multiple chains

### DIFF
--- a/src/biotite/structure/geometry.py
+++ b/src/biotite/structure/geometry.py
@@ -557,7 +557,8 @@ def dihedral_backbone(atom_array):
         phis.append(phi)
         psis.append(psi)
         omegas.append(omega)
-    return np.concatenate(phis), np.concatenate(psis), np.concatenate(omegas)
+    return np.concatenate(phis, axis=1), np.concatenate(psis, axis=1), \
+        np.concatenate(omegas, axis=1)
 
 
 

--- a/src/biotite/structure/geometry.py
+++ b/src/biotite/structure/geometry.py
@@ -557,8 +557,8 @@ def dihedral_backbone(atom_array):
         phis.append(phi)
         psis.append(psi)
         omegas.append(omega)
-    return np.concatenate(phis, axis=1), np.concatenate(psis, axis=1), \
-        np.concatenate(omegas, axis=1)
+    return np.concatenate(phis, axis=-1), np.concatenate(psis, axis=-1), \
+        np.concatenate(omegas, axis=-1)
 
 
 


### PR DESCRIPTION
The result for multiple chains is concatenated along the wrong axis. For X frames, Y residues and Z chains, the result should be of the shape (X, Y*Z), but the current outbut is (X*Z, Y). This resolves this issue.