### PR TITLE
Read only score matrix in substitution matrices

### DIFF
--- a/src/biotite/sequence/align/matrix.py
+++ b/src/biotite/sequence/align/matrix.py
@@ -130,13 +130,16 @@ class SubstitutionMatrix(object):
                     f"Matrix has shape {score_matrix.shape}, "
                     f"but {alph_shape} is required"
                 )
-            self._matrix = np.copy(score_matrix.astype(np.int32))
+            self._matrix = score_matrix.astype(np.int32)
         elif isinstance(score_matrix, str):
             matrix_dict = SubstitutionMatrix.dict_from_db(score_matrix)
-            self._fill_with_matrix_dict(matrix_dict)      
+            self._fill_with_matrix_dict(matrix_dict)
         else:
             raise TypeError("Matrix must be either a dictionary, "
                             "an 2-D ndarray or a string")
+        # This class is immutable and has a getter function for the
+        # score matrix -> make the score matrix read-only
+        self._matrix.setflags(write=False)
     
     def _fill_with_matrix_dict(self, matrix_dict):
         self._matrix = np.zeros(( len(self._alph1), len(self._alph2) ),
@@ -173,14 +176,11 @@ class SubstitutionMatrix(object):
         """
         Get the 2-D `ndarray` containing the score values.
         
-        In the strict sense, this breaks the immutability of the
-        `SubstitutionMatrix` object. Therefore, using the returned
-        `ndarray` read-only is strongly recommended.
-        
         Returns
         -------
-        matrix : ndarray
+        matrix : ndarray, shape=(m,n), dtype=np.int32
             The symbol code indexed score matrix.
+            The array is read-only.
         """
         return self._matrix
     

--- a/src/biotite/sequence/align/multiple.pyx
+++ b/src/biotite/sequence/align/multiple.pyx
@@ -327,7 +327,7 @@ def _get_distance_matrix(CodeType[:] _T, sequences, matrix,
     else:
         raise TypeError("Gap penalty must be either integer or tuple")
 
-    cdef int32[:,:] score_matrix = matrix.score_matrix()
+    cdef const int32[:,:] score_matrix = matrix.score_matrix()
     cdef int32[:,:] scores_v = scores
     cdef np.ndarray distances = np.zeros(
         (scores.shape[0], scores.shape[1]), dtype=np.float32

--- a/src/biotite/sequence/align/pairwise.pyx
+++ b/src/biotite/sequence/align/pairwise.pyx
@@ -89,7 +89,7 @@ def align_ungapped(seq1, seq2, matrix, score_only=False):
 @cython.wraparound(False)
 def _add_scores(CodeType1[:] code1 not None,
                 CodeType2[:] code2 not None,
-                int32[:,:] matrix not None):
+                const int32[:,:] matrix not None):
     cdef int32 score = 0
     cdef int i
     for i in range(code1.shape[0]):
@@ -381,7 +381,7 @@ def align_optimal(seq1, seq2, matrix, gap_penalty=-10,
 @cython.wraparound(False)
 def _fill_align_table(CodeType1[:] code1 not None,
                       CodeType2[:] code2 not None,
-                      int32[:,:] matrix not None,
+                      const int32[:,:] matrix not None,
                       uint8[:,:] trace_table not None,
                       int32[:,:] score_table not None,
                       int gap_penalty,
@@ -477,7 +477,7 @@ def _fill_align_table(CodeType1[:] code1 not None,
 @cython.wraparound(False)
 def _fill_align_table_affine(CodeType1[:] code1 not None,
                              CodeType2[:] code2 not None,
-                             int32[:,:] matrix not None,
+                             const int32[:,:] matrix not None,
                              uint8[:,:] trace_table not None,
                              int32[:,:] m_table not None,
                              int32[:,:] g1_table not None,


### PR DESCRIPTION
As `SubstitutionMatrix` objects are immutable, this PR sets the internal score matrix read-only. The alignment function implemented in Cython are updated to accept also a read-only buffer for the score matrix.