### PR TITLE
Allow passing additional keyword arguments to io.load_structure method

### DIFF
--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -15,7 +15,7 @@ import io
 from ..atoms import AtomArray, AtomArrayStack
 
 
-def load_structure(file_path, template=None):
+def load_structure(file_path, template=None, **kwargs):
     """
     Load an atom array or stack from a structure file without the need
     to manually instantiate a :class:`File` object.
@@ -55,7 +55,7 @@ def load_structure(file_path, template=None):
         from .pdb import PDBFile
         file = PDBFile()
         file.read(file_path)
-        array = file.get_structure()
+        array = file.get_structure(**kwargs)
         if isinstance(array, AtomArrayStack) and array.stack_depth() == 1:
             # Stack containing only one model -> return as atom array
             return array[0]
@@ -65,7 +65,7 @@ def load_structure(file_path, template=None):
         from .pdbx import PDBxFile, get_structure
         file = PDBxFile()
         file.read(file_path)
-        array = get_structure(file)
+        array = get_structure(file, **kwargs)
         if isinstance(array, AtomArrayStack) and array.stack_depth() == 1:
             # Stack containing only one model -> return as atom array
             return array[0]
@@ -75,7 +75,7 @@ def load_structure(file_path, template=None):
         from .gro import GROFile
         file = GROFile()
         file.read(file_path)
-        array = file.get_structure()
+        array = file.get_structure(**kwargs)
         if isinstance(array, AtomArrayStack) and array.stack_depth() == 1:
             # Stack containing only one model -> return as atom array
             return array[0]
@@ -85,7 +85,7 @@ def load_structure(file_path, template=None):
         from .mmtf import MMTFFile, get_structure
         file = MMTFFile()
         file.read(file_path)
-        array = get_structure(file)
+        array = get_structure(file, **kwargs)
         if isinstance(array, AtomArrayStack) and array.stack_depth() == 1:
             # Stack containing only one model -> return as atom array
             return array[0]
@@ -120,7 +120,7 @@ def load_structure(file_path, template=None):
         if suffix == ".netcdf":
             traj_file_cls = NetCDFFile
         file = traj_file_cls()
-        file.read(file_path)
+        file.read(file_path, **kwargs)
         return file.get_structure(template)
     else:
         raise ValueError(f"Unknown file format '{suffix}'")

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -98,7 +98,7 @@ def load_structure(file_path, template=None, **kwargs):
         from .npz import NpzFile
         file = NpzFile()
         file.read(file_path)
-        array = file.get_structure()
+        array = file.get_structure(**kwargs)
         if isinstance(array, AtomArrayStack) and array.stack_depth() == 1:
             # Stack containing only one model -> return as atom array
             return array[0]

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -30,6 +30,9 @@ def load_structure(file_path, template=None, **kwargs):
         The path to structure file.
     template : AtomArray or AtomArrayStack or file-like object or str, optional
         Only required when reading a trajectory file.
+    kwargs
+        Additional parameters will be passed to either the `get_structure` or
+        `read` of the file object. This does not affect templates.
     
     Returns
     -------

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -129,7 +129,7 @@ def load_structure(file_path, template=None, **kwargs):
         raise ValueError(f"Unknown file format '{suffix}'")
 
 
-def save_structure(file_path, array):
+def save_structure(file_path, array, **kwargs):
     """
     Save an atom array or stack to a structure file without the need
     to manually instantiate a :class:`File` object.
@@ -143,7 +143,10 @@ def save_structure(file_path, array):
         The path to structure file.
     array : AtomArray or AtomArrayStack
         The structure to be saved.
-    
+    kwargs
+        Additional parameters will be passed to the respective `set_structure`
+        method.
+
     Raises
     ------
     ValueError
@@ -154,27 +157,27 @@ def save_structure(file_path, array):
     if suffix == ".pdb":
         from .pdb import PDBFile
         file = PDBFile()
-        file.set_structure(array)
+        file.set_structure(array, **kwargs)
         file.write(file_path)
     elif suffix == ".cif" or suffix == ".pdbx":
         from .pdbx import PDBxFile, set_structure
         file = PDBxFile()
-        set_structure(file, array, data_block="STRUCTURE")
+        set_structure(file, array, data_block="STRUCTURE", **kwargs)
         file.write(file_path)
     elif suffix == ".gro":
         from .gro import GROFile
         file = GROFile()
-        file.set_structure(array)
+        file.set_structure(array, **kwargs)
         file.write(file_path)
     elif suffix == ".mmtf":
         from .mmtf import MMTFFile, set_structure
         file = MMTFFile()
-        set_structure(file, array)
+        set_structure(file, array, **kwargs)
         file.write(file_path)
     elif suffix == ".npz":
         from .npz import NpzFile
         file = NpzFile()
-        file.set_structure(array)
+        file.set_structure(array, **kwargs)
         file.write(file_path)
     elif suffix in [".trr", ".xtc", ".tng", ".dcd", ".netcdf"]:
         from .trr import TRRFile
@@ -193,7 +196,7 @@ def save_structure(file_path, array):
         if suffix == ".netcdf":
             traj_file_cls = NetCDFFile
         file = traj_file_cls()
-        file.set_structure(array)
+        file.set_structure(array, **kwargs)
         file.write(file_path)
     else:
         raise ValueError(f"Unknown file format '{suffix}'")

--- a/tests/structure/test_generalio.py
+++ b/tests/structure/test_generalio.py
@@ -31,6 +31,7 @@ def test_loading_template_with_trj():
     assert isinstance(stack, struc.AtomArrayStack)
     assert len(stack) > 1
 
+
 @pytest.mark.xfail(raises=ImportError)
 def test_loading_with_extra_args():
     template = join(data_dir, "1l2y.pdb")
@@ -44,6 +45,10 @@ def test_loading_with_extra_args():
     stack = strucio.load_structure(trajectory, template=struc[0], start=5, stop=6)
     assert len(stack) == 1
 
+    # loading should fail with wrong arguments
+    with pytest.raises(TypeError):
+        strucio.load_structure(template, start=2)
+    
 
 @pytest.mark.xfail(raises=ImportError)
 @pytest.mark.parametrize(
@@ -56,3 +61,17 @@ def test_saving(suffix):
     strucio.save_structure(
         biotite.temp_file("1l2y." + suffix), array
     )
+
+
+@pytest.mark.xfail(raises=ImportError)
+@pytest.mark.parametrize(
+    "suffix",
+    ["pdb", "cif", "gro", "pdbx", "mmtf",
+     "trr", "xtc", "tng", "dcd", "netcdf"]
+)
+def test_saving_with_extra_args(suffix):
+    array = strucio.load_structure(join(data_dir, "1l2y.mmtf"))
+    with pytest.raises(TypeError):
+        strucio.save_structure(
+            biotite.temp_file("1l2y." + suffix), array, answer=42
+        )

--- a/tests/structure/test_generalio.py
+++ b/tests/structure/test_generalio.py
@@ -31,6 +31,19 @@ def test_loading_template_with_trj():
     assert isinstance(stack, struc.AtomArrayStack)
     assert len(stack) > 1
 
+@pytest.mark.xfail(raises=ImportError)
+def test_loading_with_extra_args():
+    template = join(data_dir, "1l2y.pdb")
+    trajectory = join(data_dir, "1l2y.xtc")
+
+    # test if arguments are passed to text files as get_structure arg
+    struc = strucio.load_structure(template, extra_fields="b_factor")
+    assert "b_factor" in dir(struc)
+
+    # test if arguments are passed to read for trajectories
+    stack = strucio.load_structure(trajectory, template=struc[0], start=5, stop=6)
+    assert len(stack) == 1
+
 
 @pytest.mark.xfail(raises=ImportError)
 @pytest.mark.parametrize(


### PR DESCRIPTION
Keyword arguments submitted as **kwargs will be passed to the files `get_structure` method for non-trajectories (pdb, gro..) and to `read` for trajectories (xtc, tng, ....). It seems like no file format has additional arguments for both so far.

The only weak spot is template loading from a string, which won't get additional arguments. This would require creating (and maintaining) a list of allowed arguments for `read` and `get_structure` for every possible trajectory/template combination. Users can pass AtomArrays instead if it is required to pass additional arguments to a template. 