### PR TITLE
Fixing module __name__ attribute

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,7 +67,7 @@ pygments_style = "sphinx"
 todo_include_todos = False
 
 # Prevents numpydoc from creating an autosummary which does not work
-# due to Biotite's import system
+# properly due to Biotite's import system
 numpydoc_show_class_members = False
 
 autodoc_member_order = "bysource"

--- a/src/biotite/__init__.py
+++ b/src/biotite/__init__.py
@@ -10,6 +10,7 @@ modules.
 """
 
 __version__ = "0.17.0"
+__name__ = "biotite"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/application/__init__.py
+++ b/src/biotite/application/__init__.py
@@ -29,6 +29,7 @@ used to run other code, similar to the *Python* :class:`Thread` or
 class:`Process` classes.
 """
 
+__name__ = "biotite.application"
 __author__ = "Patrick Kunzmann"
 
 from .application import *

--- a/src/biotite/application/application.py
+++ b/src/biotite/application/application.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Application", "AppStateError", "TimeoutError", "AppState",
            "requires_state"]

--- a/src/biotite/application/blast/__init__.py
+++ b/src/biotite/application/blast/__init__.py
@@ -7,6 +7,7 @@ A subpackage for heuristic local alignments against a large database
 using BLAST.
 """
 
+__name__ = "biotite.application.blast"
 __author__ = "Patrick Kunzmann"
 
 from .webapp import *

--- a/src/biotite/application/blast/alignment.py
+++ b/src/biotite/application/blast/alignment.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application.blast"
 __author__ = "Patrick Kunzmann"
 __all__ = ["BlastAlignment"]
 

--- a/src/biotite/application/blast/webapp.py
+++ b/src/biotite/application/blast/webapp.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application.blast"
 __author__ = "Patrick Kunzmann"
 __all__ = ["BlastWebApp"]
 

--- a/src/biotite/application/clustalo/__init__.py
+++ b/src/biotite/application/clustalo/__init__.py
@@ -6,6 +6,7 @@
 A subpackage for multiple sequence alignments using Clustal-Omega.
 """
 
+__name__ = "biotite.application.clustalo"
 __author__ = "Patrick Kunzmann"
 
 from .app import *

--- a/src/biotite/application/clustalo/app.py
+++ b/src/biotite/application/clustalo/app.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application.clustalo"
 __author__ = "Patrick Kunzmann"
 __all__ = ["ClustalOmegaApp"]
 

--- a/src/biotite/application/dssp/__init__.py
+++ b/src/biotite/application/dssp/__init__.py
@@ -6,6 +6,7 @@
 A subpackage for protein secondary structure annotation using DSSP.
 """
 
+__name__ = "biotite.application.dssp"
 __author__ = "Patrick Kunzmann"
 
 from .app import *

--- a/src/biotite/application/dssp/app.py
+++ b/src/biotite/application/dssp/app.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application.dssp"
 __author__ = "Patrick Kunzmann"
 __all__ = ["DsspApp"]
 

--- a/src/biotite/application/localapp.py
+++ b/src/biotite/application/localapp.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application"
 __author__ = "Patrick Kunzmann"
 __all__ = ["LocalApp"]
 

--- a/src/biotite/application/mafft/__init__.py
+++ b/src/biotite/application/mafft/__init__.py
@@ -6,6 +6,7 @@
 A subpackage for multiple sequence alignments using MAFFT.
 """
 
+__name__ = "biotite.application.mafft"
 __author__ = "Patrick Kunzmann"
 
 from .app import *

--- a/src/biotite/application/mafft/app.py
+++ b/src/biotite/application/mafft/app.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application.mafft"
 __author__ = "Patrick Kunzmann"
 __all__ = ["MafftApp"]
 

--- a/src/biotite/application/msaapp.py
+++ b/src/biotite/application/msaapp.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application"
 __author__ = "Patrick Kunzmann"
 __all__ = ["MSAApp"]
 

--- a/src/biotite/application/muscle/__init__.py
+++ b/src/biotite/application/muscle/__init__.py
@@ -6,6 +6,7 @@
 A subpackage for multiple sequence alignments using MUSCLE.
 """
 
+__name__ = "biotite.application.muscle"
 __author__ = "Patrick Kunzmann"
 
 from .app import *

--- a/src/biotite/application/muscle/app.py
+++ b/src/biotite/application/muscle/app.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application.muscle"
 __author__ = "Patrick Kunzmann"
 __all__ = ["MuscleApp"]
 

--- a/src/biotite/application/webapp.py
+++ b/src/biotite/application/webapp.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.application"
 __author__ = "Patrick Kunzmann"
 __all__ = ["WebApp", "RuleViolationError"]
 

--- a/src/biotite/copyable.py
+++ b/src/biotite/copyable.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Copyable"]
 

--- a/src/biotite/database/__init__.py
+++ b/src/biotite/database/__init__.py
@@ -23,6 +23,7 @@ temporary directory by using :func:`biotite.temp_dir()` or
 :func:`biotite.temp_file()` as path name.
 """
 
+__name__ = "biotite.database"
 __author__ = "Patrick Kunzmann"
 
 from .error import *

--- a/src/biotite/database/entrez/__init__.py
+++ b/src/biotite/database/entrez/__init__.py
@@ -6,6 +6,7 @@
 A subpackage for downloading files from the NCBI Entrez database.
 """
 
+__name__ = "biotite.database.entrez"
 __author__ = "Patrick Kunzmann"
 
 from .download import *

--- a/src/biotite/database/entrez/check.py
+++ b/src/biotite/database/entrez/check.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.database.entrez"
 __author__ = "Patrick Kunzmann, Maximilian Dombrowsky"
 __all__ = ["check_for_errors"]
 

--- a/src/biotite/database/entrez/download.py
+++ b/src/biotite/database/entrez/download.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.database.entrez"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_database_name", "fetch", "fetch_single_file"]
 

--- a/src/biotite/database/entrez/query.py
+++ b/src/biotite/database/entrez/query.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.database.entrez"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Query", "SimpleQuery", "CompositeQuery", "search"]
 

--- a/src/biotite/database/error.py
+++ b/src/biotite/database/error.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.database"
 __author__ = "Patrick Kunzmann"
 __all__ = ["RequestError"]
 

--- a/src/biotite/database/rcsb/__init__.py
+++ b/src/biotite/database/rcsb/__init__.py
@@ -6,6 +6,7 @@
 A subpackage for downloading files from the RCSB PDB.
 """
 
+__name__ = "biotite.database.rcsb"
 __author__ = "Patrick Kunzmann"
 
 from .download import *

--- a/src/biotite/database/rcsb/download.py
+++ b/src/biotite/database/rcsb/download.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.database.rcsb"
 __author__ = "Patrick Kunzmann"
 __all__ = ["fetch"]
 

--- a/src/biotite/database/rcsb/query.py
+++ b/src/biotite/database/rcsb/query.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.database.rcsb"
 __author__ = "Patrick Kunzmann, Maximilian Dombrowsky"
 __all__ = ["Query", "CompositeQuery", "RangeQuery", "SimpleQuery",
            "ResolutionQuery", "BFactorQuery", "MolecularWeightQuery",

--- a/src/biotite/file.py
+++ b/src/biotite/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite"
 __author__ = "Patrick Kunzmann"
 __all__ = ["File", "TextFile", "InvalidFileError"]
 

--- a/src/biotite/sequence/__init__.py
+++ b/src/biotite/sequence/__init__.py
@@ -61,6 +61,7 @@ An :class:`AnnotatedSequence` combines an :class:`Annotation` and a
 :class:`Sequence`.
 """
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 
 from .alphabet import *

--- a/src/biotite/sequence/align/__init__.py
+++ b/src/biotite/sequence/align/__init__.py
@@ -26,6 +26,7 @@ The aligning functions are usually C-accelerated, reducing the
 computation time substantially.
 """
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 
 from .alignment import *

--- a/src/biotite/sequence/align/alignment.py
+++ b/src/biotite/sequence/align/alignment.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 
 import numpy as np

--- a/src/biotite/sequence/align/matrix.py
+++ b/src/biotite/sequence/align/matrix.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 
 from ..sequence import Sequence

--- a/src/biotite/sequence/align/multiple.pyx
+++ b/src/biotite/sequence/align/multiple.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 __all__ = ["align_multiple"]
 

--- a/src/biotite/sequence/align/pairwise.pyx
+++ b/src/biotite/sequence/align/pairwise.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 __all__ = ["align_ungapped", "align_optimal"]
 

--- a/src/biotite/sequence/alphabet.py
+++ b/src/biotite/sequence/alphabet.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Alphabet", "LetterAlphabet", "AlphabetMapper", "AlphabetError"]
 

--- a/src/biotite/sequence/annotation.py
+++ b/src/biotite/sequence/annotation.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Location", "Feature", "Annotation", "AnnotatedSequence"]
 

--- a/src/biotite/sequence/codec.pyx
+++ b/src/biotite/sequence/codec.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 __all__ = ["encode_chars", "decode_to_chars"]
 

--- a/src/biotite/sequence/codon.py
+++ b/src/biotite/sequence/codon.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 __all__ = ["CodonTable"]
 

--- a/src/biotite/sequence/graphics/__init__.py
+++ b/src/biotite/sequence/graphics/__init__.py
@@ -22,6 +22,7 @@ Similarily, the appearance of sequence features in the function
 objects.
 """
 
+__name__ = "biotite.sequence.graphics"
 __author__ = "Patrick Kunzmann"
 
 from .alignment import *

--- a/src/biotite/sequence/graphics/alignment.py
+++ b/src/biotite/sequence/graphics/alignment.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.graphics"
 __author__ = "Patrick Kunzmann"
 __all__ = ["SymbolPlotter", "LetterPlotter", "LetterSimilarityPlotter",
            "LetterTypePlotter", "plot_alignment",

--- a/src/biotite/sequence/graphics/colorschemes.py
+++ b/src/biotite/sequence/graphics/colorschemes.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.graphics"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_color_scheme", "list_color_scheme_names", "load_color_scheme"]
 

--- a/src/biotite/sequence/graphics/dendrogram.py
+++ b/src/biotite/sequence/graphics/dendrogram.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.graphics"
 __author__ = "Patrick Kunzmann"
 __all__ = ["plot_dendrogram"]
 

--- a/src/biotite/sequence/graphics/features.py
+++ b/src/biotite/sequence/graphics/features.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.graphics"
 __author__ = "Patrick Kunzmann"
 __all__ = ["plot_feature_map", "FeaturePlotter", "MiscFeaturePlotter",
            "CodingPlotter", "PromoterPlotter", "TerminatorPlotter",

--- a/src/biotite/sequence/graphics/logo.py
+++ b/src/biotite/sequence/graphics/logo.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.graphics"
 __author__ = "Patrick Kunzmann"
 __all__ = ["plot_sequence_logo"]
 

--- a/src/biotite/sequence/io/__init__.py
+++ b/src/biotite/sequence/io/__init__.py
@@ -6,4 +6,5 @@
 A subpackage for reading and writing sequence related data.
 """
 
+__name__ = "biotite.sequence.io"
 __author__ = "Patrick Kunzmann"

--- a/src/biotite/sequence/io/fasta/__init__.py
+++ b/src/biotite/sequence/io/fasta/__init__.py
@@ -15,6 +15,7 @@ Furthermore, the package contains convenience functions for
 getting/setting directly :class:`Sequence` objects, rather than strings.
 """
 
+__name__ = "biotite.sequence.io.fasta"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/sequence/io/fasta/convert.py
+++ b/src/biotite/sequence/io/fasta/convert.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.io.fasta"
 __author__ = "Patrick Kunzmann"
 
 from ...sequence import Sequence

--- a/src/biotite/sequence/io/fasta/file.py
+++ b/src/biotite/sequence/io/fasta/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.io.fasta"
 __author__ = "Patrick Kunzmann"
 
 from ....file import TextFile

--- a/src/biotite/sequence/io/fastq/__init__.py
+++ b/src/biotite/sequence/io/fastq/__init__.py
@@ -12,6 +12,7 @@ strings being the keys and the sequences and quality scores being the
 values.
 """
 
+__name__ = "biotite.sequence.io.fastq"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/sequence/io/fastq/file.py
+++ b/src/biotite/sequence/io/fastq/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.io.fastq"
 __author__ = "Patrick Kunzmann"
 
 from numbers import Integral

--- a/src/biotite/sequence/io/genbank/__init__.py
+++ b/src/biotite/sequence/io/genbank/__init__.py
@@ -8,6 +8,7 @@ This subpackage is used for reading/writing information
 and *GenPept* format.
 """
 
+__name__ = "biotite.sequence.io.genbank"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/sequence/io/genbank/annotation.py
+++ b/src/biotite/sequence/io/genbank/annotation.py
@@ -6,6 +6,7 @@
 Functions for converting an annotation from/to a GenBank file.
 """
 
+__name__ = "biotite.sequence.io.genbank"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_annotation", "set_annotation"]
 

--- a/src/biotite/sequence/io/genbank/file.py
+++ b/src/biotite/sequence/io/genbank/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.io.genbank"
 __author__ = "Patrick Kunzmann"
 __all__ = ["GenBankFile", "MultiFile"]
 

--- a/src/biotite/sequence/io/genbank/metadata.py
+++ b/src/biotite/sequence/io/genbank/metadata.py
@@ -6,6 +6,7 @@
 Functions for obtaining metadata fields of a GenBank file.
 """
 
+__name__ = "biotite.sequence.io.genbank"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_locus", "get_definition", "get_accession", "get_version",
            "get_gi", "get_db_link", "get_source",

--- a/src/biotite/sequence/io/genbank/sequence.py
+++ b/src/biotite/sequence/io/genbank/sequence.py
@@ -6,6 +6,7 @@
 Functions for converting a sequence from/to a GenBank file.
 """
 
+__name__ = "biotite.sequence.io.genbank"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_sequence", "get_annotated_sequence",
            "set_sequence", "set_annotated_sequence"]

--- a/src/biotite/sequence/io/gff/__init__.py
+++ b/src/biotite/sequence/io/gff/__init__.py
@@ -19,6 +19,7 @@ interface to this format, and high-level functions for extracting
    information.
 """
 
+__name__ = "biotite.sequence.io.gff"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/sequence/io/gff/convert.py
+++ b/src/biotite/sequence/io/gff/convert.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.io.gff"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_annotation", "set_annotation"]
 

--- a/src/biotite/sequence/io/gff/file.py
+++ b/src/biotite/sequence/io/gff/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.io.gff"
 __author__ = "Patrick Kunzmann"
 __all__ = ["GFFFile"]
 

--- a/src/biotite/sequence/phylo/__init__.py
+++ b/src/biotite/sequence/phylo/__init__.py
@@ -28,6 +28,7 @@ popular *UPGMA* (:func:`upgma()`) and *Neighbor-Joining*
 (:func:`neighbor_joining()`) algorithms.
 """
 
+__name__ = "biotite.sequence.phylo"
 __author__ = "Patrick Kunzmann"
 
 from .tree import *

--- a/src/biotite/sequence/phylo/nj.pyx
+++ b/src/biotite/sequence/phylo/nj.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.phylo"
 __author__ = "Patrick Kunzmann"
 __all__ = ["neighbor_joining"]
 

--- a/src/biotite/sequence/phylo/tree.pyx
+++ b/src/biotite/sequence/phylo/tree.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.phylo"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Tree", "TreeNode", "as_binary", "TreeError"]
 

--- a/src/biotite/sequence/phylo/upgma.pyx
+++ b/src/biotite/sequence/phylo/upgma.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.phylo"
 __author__ = "Patrick Kunzmann"
 __all__ = ["upgma"]
 

--- a/src/biotite/sequence/search.py
+++ b/src/biotite/sequence/search.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 __all__ = ["find_subsequence", "find_symbol", "find_symbol_first",
            "find_symbol_last"]

--- a/src/biotite/sequence/seqtypes.py
+++ b/src/biotite/sequence/seqtypes.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 __all__ = ["GeneralSequence", "NucleotideSequence", "ProteinSequence"]
 

--- a/src/biotite/sequence/sequence.py
+++ b/src/biotite/sequence/sequence.py
@@ -6,6 +6,7 @@
 The module contains the :class:`Sequence` superclass and :class:`GeneralSequence`.
 """
 
+__name__ = "biotite.sequence"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Sequence"]
 

--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -94,6 +94,7 @@ manipulation and visualization.
 The universal length unit in this package is Å. 
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 
 from .atoms import *

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -7,6 +7,7 @@ This module contains the main types of the ``structure`` subpackage:
 :class:`Atom`, :class:`AtomArray` and :class:`AtomArrayStack`. 
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Atom", "AtomArray", "AtomArrayStack", "array", "stack", "coord"]
 

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -7,6 +7,7 @@ This module allows efficient search of atoms in a defined radius around
 a location.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["BondList", "BondType"]
 

--- a/src/biotite/structure/box.py
+++ b/src/biotite/structure/box.py
@@ -7,6 +7,7 @@ Functions related to working with the simulation box or unit cell
 of a structure 
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["vectors_from_unitcell", "unitcell_from_vectors", "box_volume",
            "repeat_box", "repeat_box_coord", "move_inside_box",

--- a/src/biotite/structure/celllist.pyx
+++ b/src/biotite/structure/celllist.pyx
@@ -7,6 +7,7 @@ This module allows efficient search of atoms in a defined radius around
 a location.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["CellList"]
 

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -7,6 +7,7 @@ This module provides utility for handling data on chain level, rather than
 atom level.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_chain_starts", "get_chains", "get_chain_count", "chain_iter"]
 

--- a/src/biotite/structure/compare.py
+++ b/src/biotite/structure/compare.py
@@ -7,6 +7,7 @@ This module provides functions for calculation of characteristic values when
 comparing multiple structures with each other.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["rmsd", "rmsf", "average"]
 

--- a/src/biotite/structure/error.py
+++ b/src/biotite/structure/error.py
@@ -6,6 +6,7 @@
 This module contains all possible errors of the `structure` subpackage.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["BadStructureError"]
 

--- a/src/biotite/structure/filter.py
+++ b/src/biotite/structure/filter.py
@@ -7,6 +7,7 @@ This module provides utility functions for creating filters on atom
 arrays and atom array stacks.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["filter_solvent", "filter_monoatomic_ions", "filter_amino_acids",
            "filter_backbone", "filter_intersection",

--- a/src/biotite/structure/geometry.py
+++ b/src/biotite/structure/geometry.py
@@ -7,6 +7,7 @@ This module provides functions for geometric measurements between atoms
 in a structure, mainly lenghts and angles.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["displacement", "index_displacement", "distance", "index_distance",
            "angle", "index_angle", "dihedral", "index_dihedral",

--- a/src/biotite/structure/hbond.py
+++ b/src/biotite/structure/hbond.py
@@ -6,6 +6,7 @@
 This module provides functions for hydrogen bonding calculation.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Daniel Bauer, Patrick Kunzmann"
 __all__ = ["hbond", "hbond_frequency"]
 

--- a/src/biotite/structure/info/__init__.py
+++ b/src/biotite/structure/info/__init__.py
@@ -14,6 +14,7 @@ via tools from the
 repository.
 """
 
+__name__ = "biotite.structure.info"
 __author__ = "Patrick Kunzmann"
 
 from .masses import *

--- a/src/biotite/structure/info/bonds.py
+++ b/src/biotite/structure/info/bonds.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.info"
 __author__ = "Patrick Kunzmann"
 __all__ = ["bond_dataset", "bond_order", "bonds_in_residue"]
 

--- a/src/biotite/structure/info/masses.py
+++ b/src/biotite/structure/info/masses.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.info"
 __author__ = "Patrick Kunzmann"
 __all__ = ["mass"]
 

--- a/src/biotite/structure/info/misc.py
+++ b/src/biotite/structure/info/misc.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.info"
 __author__ = "Patrick Kunzmann"
 __all__ = ["full_name", "link_type"]
 

--- a/src/biotite/structure/info/radii.py
+++ b/src/biotite/structure/info/radii.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.info"
 __author__ = "Patrick Kunzmann"
 __all__ = ["vdw_radius_protor", "vdw_radius_single"]
 

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -7,6 +7,7 @@ This module allows checking of atom arrays and atom array stacks for
 errors in the structure.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["check_id_continuity", "check_bond_continuity",
            "check_duplicate_atoms"]

--- a/src/biotite/structure/io/__init__.py
+++ b/src/biotite/structure/io/__init__.py
@@ -21,6 +21,7 @@ Besides the mentioned structure formats, Gromacs trajectory files can be
 loaded, if `mdtraj` is installed.
 """
 
+__name__ = "biotite.structure.io"
 __author__ = "Patrick Kunzmann"
 
 from .trajfile import *

--- a/src/biotite/structure/io/dcd/__init__.py
+++ b/src/biotite/structure/io/dcd/__init__.py
@@ -7,6 +7,7 @@ This subpackage is used for reading and writing trajectories in the
 CDC format used by software like *CHARMM*, *OpenMM* and *NAMD*.
 """
 
+__name__ = "biotite.structure.io.dcd"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/dcd/file.py
+++ b/src/biotite/structure/io/dcd/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.dcd"
 __author__ = "Patrick Kunzmann"
 __all__ = ["DCDFile"]
 

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -7,6 +7,7 @@ This module contains a convenience function for loading structures from
 general structure files.
 """
 
+__name__ = "biotite.structure.io"
 __author__ = "Patrick Kunzmann"
 __all__ = ["load_structure", "save_structure"]
 

--- a/src/biotite/structure/io/gro/__init__.py
+++ b/src/biotite/structure/io/gro/__init__.py
@@ -8,6 +8,7 @@ This subpackage is used for reading and writing an :class:`AtomArray` or
 software package.
 """
 
+__name__ = "biotite.structure.io.gro"
 __author__ = "Daniel Bauer"
 
 from .file import *

--- a/src/biotite/structure/io/gro/file.py
+++ b/src/biotite/structure/io/gro/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.gro"
 __author__ = "Daniel Bauer, Patrick Kunzmann"
 __all__ = ["GROFile"]
 

--- a/src/biotite/structure/io/mmtf/__init__.py
+++ b/src/biotite/structure/io/mmtf/__init__.py
@@ -9,6 +9,7 @@ features a smaller file size and a highly increased I/O operation
 performance, than the text based file formats.
 """
 
+__name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/mmtf/convertarray.pyx
+++ b/src/biotite/structure/io/mmtf/convertarray.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 __all__ = ["set_structure"]
 

--- a/src/biotite/structure/io/mmtf/convertfile.pyx
+++ b/src/biotite/structure/io/mmtf/convertfile.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_structure"]
 

--- a/src/biotite/structure/io/mmtf/decode.pyx
+++ b/src/biotite/structure/io/mmtf/decode.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 __all__ = ["decode_array"]
 

--- a/src/biotite/structure/io/mmtf/encode.pyx
+++ b/src/biotite/structure/io/mmtf/encode.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 __all__ = ["encode_array"]
 

--- a/src/biotite/structure/io/mmtf/file.py
+++ b/src/biotite/structure/io/mmtf/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 __all__ = ["MMTFFile"]
 

--- a/src/biotite/structure/io/netcdf/__init__.py
+++ b/src/biotite/structure/io/netcdf/__init__.py
@@ -7,6 +7,7 @@ This subpackage is used for reading and writing trajectories in the
 *AMBER* NetCDF format.
 """
 
+__name__ = "biotite.structure.io.netcdf"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/netcdf/file.py
+++ b/src/biotite/structure/io/netcdf/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.netcdf"
 __author__ = "Patrick Kunzmann"
 __all__ = ["NetCDFFile"]
 

--- a/src/biotite/structure/io/npz/__init__.py
+++ b/src/biotite/structure/io/npz/__init__.py
@@ -11,6 +11,7 @@ Biotite internal usage due to fast I/O operations and preservation
 of all atom annotation arrays.
 """
 
+__name__ = "biotite.structure.io.npz"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/npz/file.py
+++ b/src/biotite/structure/io/npz/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.npz"
 __author__ = "Patrick Kunzmann"
 __all__ = ["NpzFile"]
 

--- a/src/biotite/structure/io/pdb/__init__.py
+++ b/src/biotite/structure/io/pdb/__init__.py
@@ -13,6 +13,7 @@ other software).
 In all other cases, usage of the ``pdbx`` subpackage is encouraged.
 """
 
+__name__ = "biotite.structure.io.pdb"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -7,6 +7,7 @@ Some convenience functions for consistency with other ``structure.io``
 subpackages.
 """
 
+__name__ = "biotite.structure.io.pdb"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_structure", "set_structure"]
 

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.pdb"
 __author__ = "Patrick Kunzmann, Daniel Bauer"
 __all__ = ["PDBFile"]
 

--- a/src/biotite/structure/io/pdb/hybrid36.pyx
+++ b/src/biotite/structure/io/pdb/hybrid36.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.pdb"
 __author__ = "Patrick Kunzmann"
 __all__ = ["encode_hybrid36", "decode_hybrid36", "max_hybrid36_number"]
 

--- a/src/biotite/structure/io/pdbx/__init__.py
+++ b/src/biotite/structure/io/pdbx/__init__.py
@@ -10,6 +10,7 @@ Additional utility functions allow conversion of these dictionaries to
 :class:`AtomArray` and :class:`AtomArrayStack` objects and vice versa.
 """
 
+__name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
 
 from .convert import *

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_sequence", "get_structure", "set_structure"]
 

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
 __all__ = ["PDBxFile"]
 

--- a/src/biotite/structure/io/tng/__init__.py
+++ b/src/biotite/structure/io/tng/__init__.py
@@ -7,6 +7,7 @@ This subpackage is used for reading and writing trajectories in the
 compressed *Gromacs* TNG format.
 """
 
+__name__ = "biotite.structure.io.tng"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/tng/file.py
+++ b/src/biotite/structure/io/tng/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.tng"
 __author__ = "Patrick Kunzmann"
 __all__ = ["TNGFile"]
 

--- a/src/biotite/structure/io/trajfile.py
+++ b/src/biotite/structure/io/trajfile.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io"
 __author__ = "Patrick Kunzmann"
 __all__ = ["TrajectoryFile"]
 

--- a/src/biotite/structure/io/trr/__init__.py
+++ b/src/biotite/structure/io/trr/__init__.py
@@ -7,6 +7,7 @@ This subpackage is used for reading and writing trajectories in the
 uncompressed *Gromacs* TRR format.
 """
 
+__name__ = "biotite.structure.io.trr"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/trr/file.py
+++ b/src/biotite/structure/io/trr/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.trr"
 __author__ = "Patrick Kunzmann"
 __all__ = ["TRRFile"]
 

--- a/src/biotite/structure/io/xtc/__init__.py
+++ b/src/biotite/structure/io/xtc/__init__.py
@@ -7,6 +7,7 @@ This subpackage is used for reading and writing trajectories in the
 compressed *Gromacs* XTC format.
 """
 
+__name__ = "biotite.structure.io.xtc"
 __author__ = "Patrick Kunzmann"
 
 from .file import *

--- a/src/biotite/structure/io/xtc/file.py
+++ b/src/biotite/structure/io/xtc/file.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.structure.io.xtc"
 __author__ = "Patrick Kunzmann"
 __all__ = ["XTCFile"]
 

--- a/src/biotite/structure/mechanics.py
+++ b/src/biotite/structure/mechanics.py
@@ -7,6 +7,7 @@ This module provides functions for calculation of mechanical or
 mass-related properties of a molecular structure.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["mass_center", "gyration_radius"]
 

--- a/src/biotite/structure/rdf.py
+++ b/src/biotite/structure/rdf.py
@@ -6,6 +6,7 @@
 This module provides functions to calculate the radial distribution function.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Daniel Bauer, Patrick Kunzmann"
 __all__ = ["rdf"]
 

--- a/src/biotite/structure/residues.py
+++ b/src/biotite/structure/residues.py
@@ -7,6 +7,7 @@ This module provides utility for handling data on residue level, rather than
 atom level.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_residue_starts", "apply_residue_wise", "spread_residue_wise",
            "get_residues", "get_residue_count", "residue_iter"]

--- a/src/biotite/structure/sasa.pyx
+++ b/src/biotite/structure/sasa.pyx
@@ -7,6 +7,7 @@ Use this module to calculate the Solvent Accessible Surface Area (SASA) of
 a protein or single atoms.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["sasa"]
 

--- a/src/biotite/structure/sse.py
+++ b/src/biotite/structure/sse.py
@@ -7,6 +7,7 @@ This module allows estimation of secondary structure elements in protein
 structures.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["annotate_sse"]
 

--- a/src/biotite/structure/superimpose.py
+++ b/src/biotite/structure/superimpose.py
@@ -6,6 +6,7 @@
 This module provides functions for structure superimposition.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["superimpose", "superimpose_apply"]
 

--- a/src/biotite/structure/transform.py
+++ b/src/biotite/structure/transform.py
@@ -7,6 +7,7 @@ This module provides different transformations#
 that can be applied on structures.
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["translate", "rotate", "rotate_centered"]
 

--- a/src/biotite/structure/util.py
+++ b/src/biotite/structure/util.py
@@ -6,6 +6,7 @@
 Utility functions for in internal use in `Bio.Structure` package
 """
 
+__name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["vector_dot", "norm_vector", "distance"]
 

--- a/src/biotite/temp.py
+++ b/src/biotite/temp.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite"
 __author__ = "Patrick Kunzmann"
 __all__ = ["temp_file", "temp_dir"]
 

--- a/src/biotite/visualize.py
+++ b/src/biotite/visualize.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite"
 __author__ = "Patrick Kunzmann"
 __all__ = ["colors", "set_font_size_in_coord"]
 


### PR DESCRIPTION
In *Biotite* functions and classes are imported via the subpackage name, the individual modules are effectively shadowed. However, classes still contain the original module name, e.g. `biotite.sequence.seqtypes.NucleotideSequence` instead of `biotite.sequence.NucleotideSequence`.

For more consistency and correct linking of the superclass in the API documentation, this PR sets each module's `__name__` attribute to the name of the respective subpackage the module is part of.