### PR TITLE
Fix for Msgpack 1.0

### DIFF
--- a/src/biotite/structure/graphics/atoms.py
+++ b/src/biotite/structure/graphics/atoms.py
@@ -49,24 +49,32 @@ def plot_atoms(axes, atoms, colors, line_width=1.0, background_color=None):
         raise ValueError("The given axes mut be an 'Axes3D'")
     if atoms.bonds is None:
         raise ValueError("The atom array must have an associated bond list")
-
+    
+    # Calculating connections between atoms
     line_coord = []
     line_colors = []
     for index1, index2 in atoms.bonds.as_array()[:,:2]:
+        # Every connection consist of two lines:
+        # One from the first atom to the center
+        # and from from the second atom to the center
         line_start = atoms.coord[index1]
         line_end = atoms.coord[index2]
         line_center = (line_start + line_end) / 2
         
+        # Add line from first atom
         line_coord.append((
-        line_start, line_center
+            line_start, line_center
         ))
         line_colors.append(colors[index1])
         
+        # Add line from second atom
         line_coord.append((
-        line_end, line_center
+            line_end, line_center
         ))
         line_colors.append(colors[index2])
 
+    # Plot computed line coordinates and colors
+    # Use 'Line3DCollection' for higher efficiency
     lines = Line3DCollection(
         line_coord, color=line_colors, linewidths=line_width
     )

--- a/src/biotite/structure/info/atoms.py
+++ b/src/biotite/structure/info/atoms.py
@@ -28,7 +28,7 @@ def _init_dataset():
         # Database is already initialized
         return
 
-    # Residuue data is taken from
+    # Residue data is taken from
     # ftp://ftp.wwpdb.org/pub/pdb/data/monomers/components.cif
     # (2019/01/27)
     _info_dir = dirname(realpath(__file__))

--- a/src/biotite/structure/info/bonds.py
+++ b/src/biotite/structure/info/bonds.py
@@ -32,7 +32,7 @@ def _init_dataset():
     _info_dir = dirname(realpath(__file__))
     with open(join(_info_dir, "intra_bonds.msgpack"), "rb") as file:
         _intra_bonds_raw = msgpack.unpack(
-            file, use_list=False, raw=False
+            file, use_list=False, raw=False, strict_map_key=False
         )
         _intra_bonds = {}
         for group, group_bonds_raw in _intra_bonds_raw.items():


### PR DESCRIPTION
Msgpack 1.0 introduced a breaking change: The default value for `strict_map_key` was set from `False` to `True`. This PR fixes the implications.