### PR TITLE
Fixing CellList when using 'periodic' in combination with 'selection'

### DIFF
--- a/src/biotite/structure/celllist.pyx
+++ b/src/biotite/structure/celllist.pyx
@@ -432,7 +432,6 @@ cdef class CellList:
         all_indices = self._get_atoms_in_cells(
             coord, cell_radii, is_multi_radius
         )
-        print(np.asarray(all_indices))
         # These have to be narrowed down in the next step
         # using the Euclidian distance
         


### PR DESCRIPTION
When using a `CellList` with `periodic=True` and a `selection` out of bounds memory access is possible.
Furthermore, `create_adjacency_matrix()` did not return a symmetric matrix, when a `selection` was given
This PR fixes these issues.