### PR TITLE
Adding 'read_iter()' and 'read_iter_structure()' class methods to trajectory files

### DIFF
--- a/src/biotite/structure/io/dcd/file.py
+++ b/src/biotite/structure/io/dcd/file.py
@@ -16,11 +16,13 @@ class DCDFile(TrajectoryFile):
     This file class represents a DCD trajectory file.
     """
     
-    def traj_type(self):
+    @classmethod
+    def traj_type(cls):
         import mdtraj.formats as traj
         return traj.DCDTrajectoryFile
     
-    def process_read_values(self, read_values):
+    @classmethod
+    def process_read_values(cls, read_values):
         # .netcdf files use Angstrom
         coord = read_values[0]
         cell_lengths = read_values[1]
@@ -36,7 +38,8 @@ class DCDFile(TrajectoryFile):
             )
         return coord, box, None
     
-    def prepare_write_values(self, coord, box, time):
+    @classmethod
+    def prepare_write_values(cls, coord, box, time):
         xyz = coord.astype(np.float32, copy=False) \
               if coord is not None else None
         if box is None:

--- a/src/biotite/structure/io/netcdf/file.py
+++ b/src/biotite/structure/io/netcdf/file.py
@@ -16,11 +16,13 @@ class NetCDFFile(TrajectoryFile):
     This file class represents a NetCDF trajectory file.
     """
     
-    def traj_type(self):
+    @classmethod
+    def traj_type(cls):
         import mdtraj.formats as traj
         return traj.NetCDFTrajectoryFile
     
-    def process_read_values(self, read_values):
+    @classmethod
+    def process_read_values(cls, read_values):
         # .dcd files use Angstrom
         coord = read_values[0]
         time = read_values[1]
@@ -37,7 +39,8 @@ class NetCDFFile(TrajectoryFile):
             )
         return coord, box, None
     
-    def prepare_write_values(self, coord, box, time):
+    @classmethod
+    def prepare_write_values(cls, coord, box, time):
         coord = coord.astype(np.float32, copy=False) \
               if coord is not None else None
         time = time.astype(np.float32, copy=False) \

--- a/src/biotite/structure/io/tng/file.py
+++ b/src/biotite/structure/io/tng/file.py
@@ -15,11 +15,13 @@ class TNGFile(TrajectoryFile):
     This file class represents a TNG trajectory file.
     """
     
-    def traj_type(self):
+    @classmethod
+    def traj_type(cls):
         import mdtraj.formats as traj
         return traj.TNGTrajectoryFile
     
-    def process_read_values(self, read_values):
+    @classmethod
+    def process_read_values(cls, read_values):
         # nm to Angstrom
         coord = read_values[0] * 10
         box = read_values[2]
@@ -28,7 +30,8 @@ class TNGFile(TrajectoryFile):
         time = read_values[1]
         return coord, box, time
     
-    def prepare_write_values(self, coord, box, time):
+    @classmethod
+    def prepare_write_values(cls, coord, box, time):
         # Angstrom to nm
         xyz = np.divide(coord, 10, dtype=np.float32) \
               if coord is not None else None

--- a/src/biotite/structure/io/trr/file.py
+++ b/src/biotite/structure/io/trr/file.py
@@ -15,11 +15,13 @@ class TRRFile(TrajectoryFile):
     This file class represents a TRR trajectory file.
     """
     
-    def traj_type(self):
+    @classmethod
+    def traj_type(cls):
         import mdtraj.formats as traj
         return traj.TRRTrajectoryFile
     
-    def process_read_values(self, read_values):
+    @classmethod
+    def process_read_values(cls, read_values):
         # nm to Angstrom
         coord = read_values[0] * 10
         box = read_values[3]
@@ -28,7 +30,8 @@ class TRRFile(TrajectoryFile):
         time = read_values[1]
         return coord, box, time
     
-    def prepare_write_values(self, coord, box, time):
+    @classmethod
+    def prepare_write_values(cls, coord, box, time):
         # Angstrom to nm
         xyz = np.divide(coord, 10, dtype=np.float32) \
               if coord is not None else None

--- a/src/biotite/structure/io/xtc/file.py
+++ b/src/biotite/structure/io/xtc/file.py
@@ -15,11 +15,13 @@ class XTCFile(TrajectoryFile):
     This file class represents a XTC trajectory file.
     """
     
-    def traj_type(self):
+    @classmethod
+    def traj_type(cls):
         import mdtraj.formats as traj
         return traj.XTCTrajectoryFile
 
-    def process_read_values(self, read_values):
+    @classmethod
+    def process_read_values(cls, read_values):
         # nm to Angstrom
         coord = read_values[0] * 10
         box = read_values[3]
@@ -28,7 +30,8 @@ class XTCFile(TrajectoryFile):
         time = read_values[1]
         return coord, box, time
     
-    def prepare_write_values(self, coord, box, time):
+    @classmethod
+    def prepare_write_values(cls, coord, box, time):
         # Angstrom to nm
         xyz = np.divide(coord, 10, dtype=np.float32) \
               if coord is not None else None

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -177,6 +177,8 @@ def test_get_assembly(single_model):
     Test whether the :func:`get_assembly()` function produces the same
     number of peptide chains as the
     ``_pdbx_struct_assembly.oligomeric_count`` field indicates.
+    Furthermore, check if the number of atoms in the entire assembly
+    is a multiple of the numbers of atoms in a monomer.
     """
     model = 1 if single_model else None
 
@@ -191,6 +193,7 @@ def test_get_assembly(single_model):
         assembly_category["id"],
         assembly_category["oligomeric_count"]
     ):    
+        print("Assembly ID:", id)
         assembly = pdbx.get_assembly(pdbx_file, assembly_id=id, model=model)
         protein_assembly = assembly[..., struc.filter_amino_acids(assembly)]
         test_oligomer_count = struc.get_chain_count(protein_assembly)
@@ -200,3 +203,8 @@ def test_get_assembly(single_model):
         else:
             assert isinstance(assembly, struc.AtomArrayStack)
         assert test_oligomer_count == int(ref_oligomer_count)
+
+        # The atom count of the entire assembly should be a multiple
+        # a monomer,
+        monomer_atom_count = pdbx.get_structure(pdbx_file).array_length()
+        assert assembly.array_length() % monomer_atom_count == 0

--- a/tests/structure/test_trajectory.py
+++ b/tests/structure/test_trajectory.py
@@ -158,11 +158,9 @@ def test_read_iter(format, start, stop, step):
         traj_file_cls = dcd.DCDFile
     if format == "netcdf":
         traj_file_cls = netcdf.NetCDFFile
+    file_name = join(data_dir("structure"), f"1l2y.{format}")
     
-    traj_file = traj_file_cls.read(
-        join(data_dir("structure"), f"1l2y.{format}"),
-        start, stop, step
-    )
+    traj_file = traj_file_cls.read(file_name, start, stop, step)
     ref_coord = traj_file.get_coord()
     ref_box = traj_file.get_box()
     ref_time = traj_file.get_time()
@@ -170,10 +168,7 @@ def test_read_iter(format, start, stop, step):
     test_coord = []
     test_box = []
     test_time = []
-    for coord, box, time in traj_file.read_iter(
-        join(data_dir("structure"), f"1l2y.{format}"),
-        start, stop, step
-    ):
+    for coord, box, time in traj_file.read_iter(file_name, start, stop, step):
         test_coord.append(coord)
         test_box.append(box)
         test_time.append(time)
@@ -193,3 +188,55 @@ def test_read_iter(format, start, stop, step):
         assert (test_time == None).all()
     else:
         assert test_time.tolist() == ref_time.tolist()
+
+
+@pytest.mark.skipif(
+    cannot_import("mdtraj"),
+    reason="MDTraj is not installed"
+)
+@pytest.mark.parametrize(
+    "format, start, stop, step",
+    itertools.product(
+        ["trr", "xtc", "tng", "dcd", "netcdf"],
+        [None, 2],
+        [None, 17],
+        [None, 2]
+    )
+)
+def test_read_iter_structure(format, start, stop, step):
+    """
+    Compare aggregated yields of :func:`read_iter_structure()` with the
+    return value of :func:`get_structure()` from a corresponding
+    :class:`TrajectoryFile` object.
+    """
+    if format == "netcdf" and step is not None:
+        # Currently, there is an inconsistency in in MDTraj's
+        # NetCDFTrajectoryFile class:
+        # In this class the number of frames in the output arrays
+        # is dependent on the 'stride' parameter
+        return
+    
+    template = strucio.load_structure(join(data_dir("structure"), "1l2y.mmtf"))
+    
+    if format == "trr":
+        traj_file_cls = trr.TRRFile
+    if format == "xtc":
+        traj_file_cls = xtc.XTCFile
+    if format == "tng":
+        traj_file_cls = tng.TNGFile
+    if format == "dcd":
+        traj_file_cls = dcd.DCDFile
+    if format == "netcdf":
+        traj_file_cls = netcdf.NetCDFFile
+    file_name = join(data_dir("structure"), f"1l2y.{format}")
+    
+    traj_file = traj_file_cls.read(file_name, start, stop, step)
+    ref_traj = traj_file.get_structure(template)
+    
+    test_traj = struc.stack(
+        [frame for frame in traj_file_cls.read_iter_structure(
+            file_name, template, start, stop, step
+        )]
+    )
+    
+    assert test_traj == ref_traj


### PR DESCRIPTION
The new functions `read_iter()` and `read_iter_structure()` allow frame-wise iteration over trajectory files.
This is especially useful for trajectory files, that are too large to fit into memory.