### PR TITLE
Adding note that 'hbond' requires hydrogen atoms

### DIFF
--- a/src/biotite/structure/hbond.py
+++ b/src/biotite/structure/hbond.py
@@ -24,11 +24,13 @@ def hbond(atoms, selection1=None, selection2=None, selection1_type='both',
     Find hydrogen bonds in a structure using the Baker-Hubbard
     algorithm. [1]_
 
-    This method identifies hydrogen bonds based on the bond angle
+    This function identifies hydrogen bonds based on the bond angle
     :math:`\theta` and the bond distance :math:`d_{H,A}`.
     The default criteria is :math:`\theta > 120^{\circ}`
     and :math:`d_{H,A} \le 2.5 \mathring{A}`.
-    .
+    Consequently, the given structure must have annotated hydrogen
+    atoms.
+    Otherwise, no hydrogen atoms will be found.
     
     Parameters
     ----------

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -672,6 +672,7 @@ def _parse_operation_expression(expression):
     # Cartesian product of operations
     return list(itertools.product(*operations))
 
+
     def _convert_string_to_sequence(string, stype):
         # Convert strings to ProteinSequence-Object if stype is
         # contained in _proteinseq_type_list or to NucleotideSequence-


### PR DESCRIPTION
Most structures in the PDB have no annotated hydrogen atoms. If such a structure without hydrogens is given to `hbond()` no hydrogen bonds will be found.
Since this mistake might happen quite often, this PR adds a note to the function's docstring that a structure with annotated hydrogen atoms is required.