### PR TITLE
Checking file mode when reading/writing files

### DIFF
--- a/src/biotite/file.py
+++ b/src/biotite/file.py
@@ -109,7 +109,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
                 lines = f.read().splitlines()
         # File object
         else:
-            if not isinstance(file, io.TextIOBase):
+            if not is_text(file):
                 raise TypeError("A file opened in 'text' mode is required")
             lines = file.read().splitlines()
         file_object = cls(*args, **kwargs)
@@ -131,7 +131,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
             with open(file, "w") as f:
                 f.write("\n".join(self.lines) + "\n")
         else:
-            if not isinstance(file, io.TextIOBase):
+            if not is_text(file):
                 raise TypeError("A file opened in 'text' mode is required")
             file.write("\n".join(self.lines) + "\n")
     
@@ -150,3 +150,23 @@ class InvalidFileError(Exception):
     because the file is malformed.
     """
     pass
+
+
+def is_binary(file):
+    if isinstance(file, io.BufferedIOBase):
+        return True
+    # for file wrappers, e.g. 'TemporaryFile'
+    elif hasattr(file, "file") and isinstance(file.file, io.BufferedIOBase):
+        return True
+    else:
+        return False
+
+
+def is_text(file):
+    if isinstance(file, io.TextIOBase):
+        return True
+    # for file wrappers, e.g. 'TemporaryFile'
+    elif hasattr(file, "file") and isinstance(file.file, io.TextIOBase):
+        return True
+    else:
+        return False

--- a/src/biotite/file.py
+++ b/src/biotite/file.py
@@ -131,7 +131,9 @@ class TextFile(File, metaclass=abc.ABCMeta):
             with open(file, "w") as f:
                 f.write("\n".join(self.lines) + "\n")
         else:
-           file.write("\n".join(self.lines) + "\n")
+            if not isinstance(file, io.TextIOBase):
+                raise TypeError("A file opened in 'text' mode is required")
+            file.write("\n".join(self.lines) + "\n")
     
     def __copy_fill__(self, clone):
         super().__copy_fill__(clone)

--- a/src/biotite/file.py
+++ b/src/biotite/file.py
@@ -7,6 +7,7 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["File", "TextFile", "InvalidFileError"]
 
 import abc
+import io
 import warnings
 from .copyable import Copyable
 import copy
@@ -108,6 +109,8 @@ class TextFile(File, metaclass=abc.ABCMeta):
                 lines = f.read().splitlines()
         # File object
         else:
+            if not isinstance(file, io.TextIOBase):
+                raise TypeError("A file opened in 'text' mode is required")
             lines = file.read().splitlines()
         file_object = cls(*args, **kwargs)
         file_object.lines = lines

--- a/src/biotite/structure/io/mmtf/file.py
+++ b/src/biotite/structure/io/mmtf/file.py
@@ -6,6 +6,7 @@ __name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 __all__ = ["MMTFFile"]
 
+import io
 from collections.abc import MutableMapping
 import struct
 import copy
@@ -73,6 +74,8 @@ class MMTFFile(File, MutableMapping):
                 )
         # File object
         else:
+            if not isinstance(file, io.BufferedIOBase):
+                raise TypeError("A file opened in 'binary' mode is required")
             mmtf_file._content = msgpack.unpackb(
                 file.read(), use_list=True, raw=False
             )

--- a/src/biotite/structure/io/mmtf/file.py
+++ b/src/biotite/structure/io/mmtf/file.py
@@ -12,7 +12,7 @@ import struct
 import copy
 import numpy as np
 import msgpack
-from ....file import File
+from ....file import File, is_binary
 from ...error import BadStructureError
 from .decode import decode_array
 from .encode import encode_array
@@ -74,7 +74,7 @@ class MMTFFile(File, MutableMapping):
                 )
         # File object
         else:
-            if not isinstance(file, io.BufferedIOBase):
+            if not is_binary(file):
                 raise TypeError("A file opened in 'binary' mode is required")
             mmtf_file._content = msgpack.unpackb(
                 file.read(), use_list=True, raw=False
@@ -98,7 +98,7 @@ class MMTFFile(File, MutableMapping):
             with open(file, "wb") as f:
                 f.write(packed_bytes)
         else:
-            if not isinstance(file, io.BufferedIOBase):
+            if not is_binary(file):
                 raise TypeError("A file opened in 'binary' mode is required")
             file.write(packed_bytes)
     

--- a/src/biotite/structure/io/mmtf/file.py
+++ b/src/biotite/structure/io/mmtf/file.py
@@ -98,6 +98,8 @@ class MMTFFile(File, MutableMapping):
             with open(file, "wb") as f:
                 f.write(packed_bytes)
         else:
+            if not isinstance(file, io.BufferedIOBase):
+                raise TypeError("A file opened in 'binary' mode is required")
             file.write(packed_bytes)
     
     def __copy_fill__(self, clone):

--- a/src/biotite/structure/io/npz/file.py
+++ b/src/biotite/structure/io/npz/file.py
@@ -9,7 +9,7 @@ __all__ = ["NpzFile"]
 import numpy as np
 from ...atoms import Atom, AtomArray, AtomArrayStack
 from ...bonds import BondList
-from ....file import File
+from ....file import File, is_binary
 
 
 class NpzFile(File):
@@ -71,7 +71,7 @@ class NpzFile(File):
                 npz_file._data_dict = dict(np.load(f, allow_pickle=False))
         # File object
         else:
-            if not isinstance(file, io.BufferedIOBase):
+            if not is_binary(file):
                 raise TypeError("A file opened in 'binary' mode is required")
             npz_file._data_dict = dict(np.load(file, allow_pickle=False))
         return npz_file
@@ -90,7 +90,7 @@ class NpzFile(File):
             with open(file, "wb") as f:
                 np.savez(f, **self._data_dict)
         else:
-            if not isinstance(file, io.BufferedIOBase):
+            if not is_binary(file):
                 raise TypeError("A file opened in 'binary' mode is required")
             np.savez(file, **self._data_dict)
     

--- a/src/biotite/structure/io/npz/file.py
+++ b/src/biotite/structure/io/npz/file.py
@@ -90,6 +90,8 @@ class NpzFile(File):
             with open(file, "wb") as f:
                 np.savez(f, **self._data_dict)
         else:
+            if not isinstance(file, io.BufferedIOBase):
+                raise TypeError("A file opened in 'binary' mode is required")
             np.savez(file, **self._data_dict)
     
     def get_structure(self):

--- a/src/biotite/structure/io/npz/file.py
+++ b/src/biotite/structure/io/npz/file.py
@@ -71,6 +71,8 @@ class NpzFile(File):
                 npz_file._data_dict = dict(np.load(f, allow_pickle=False))
         # File object
         else:
+            if not isinstance(file, io.BufferedIOBase):
+                raise TypeError("A file opened in 'binary' mode is required")
             npz_file._data_dict = dict(np.load(file, allow_pickle=False))
         return npz_file
                 


### PR DESCRIPTION
A common mistake when reading file-like objects with `biotite.File.read()` is that the file object might be opened in the correct mode (text/binary). An example is issue #193. The current errors raised in this case are not easily understandable, as it occurs somewhere within the the file parsing procedure, when a `str` is expected but `bytes` is given (or vice versa). In order to catch the mistake before it, this PR adds a file mode check in `read()` and `write()` in `TextFile`, `MMTFFile` and `NpzFile`.