### PR TITLE
Refectored altloc ID handling

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -222,7 +222,8 @@
             "filter_solvent",
             "filter_monoatomic_ions",
             "filter_intersection",
-            "filter_altloc"
+            "filter_first_altloc",
+            "filter_highest_occupancy_altloc"
         ],
         "Checks" : [
             "check_bond_continuity",

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -42,12 +42,19 @@ def get_chain_starts(array, add_exclusive_stop=False):
     --------
     get_residue_starts
     """
-    chain_ids = array.chain_id
-    chain_changes = np.where((chain_ids[:-1] != chain_ids[1:]))[0] + 1
-    chain_starts = np.append([0], chain_changes)
+    # This mask is 'true' at indices where the value changes
+    chain_id_changes = (array.chain_id[1:] != array.chain_id[:-1])
+    
+    # Convert mask to indices
+    # Add 1, to shift the indices from the end of a chain
+    # to the start of a new chain
+    chain_starts = np.where(chain_id_changes)[0] +1
+    
+    # The first chain is not included yet -> Insert '[0]'
     if add_exclusive_stop:
-        chain_starts = np.append(chain_starts, [array.array_length()])
-    return chain_starts
+        return np.concatenate(([0], chain_starts, [array.array_length()]))
+    else:
+        return np.concatenate(([0], chain_starts))
 
 
 def get_chains(array):

--- a/src/biotite/structure/filter.py
+++ b/src/biotite/structure/filter.py
@@ -67,6 +67,27 @@ def filter_solvent(array):
     return np.in1d(array.res_name, _solvent_list)
 
 
+def filter_nucleotides(array):
+    """
+    Filter all atoms of one array that belong to nucleotides.
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The array to be filtered.
+    
+    Returns
+    -------
+    filter : ndarray, dtype=bool
+        This array is `True` for all indices in `array`, where the atom
+        belongs to a nucleotide.
+    """
+    return (
+        np.in1d(array.res_name, _ext_nucleotide_list) 
+        & (array.res_id != -1)
+    )
+
+
 def filter_amino_acids(array):
     """
     Filter all atoms of one array that belong to amino acid residues.
@@ -214,25 +235,3 @@ def filter_altloc(atoms, altlocs, selected_altlocs):
         altloc_filter |= residue_filter & (altlocs == altloc)
         
     return altloc_filter
-
-
-def filter_nucleotides(array):
-    """
-    Filter all atoms of one array that belong to nucleotides.
-    
-    Parameters
-    ----------
-    array : AtomArray or AtomArrayStack
-        The array to be filtered.
-    
-    Returns
-    -------
-    filter : ndarray, dtype=bool
-        This array is `True` for all indices in `array`, where the atom
-        belongs to a nucleotide.
-    """
-    return (
-        np.in1d(array.res_name, _ext_nucleotide_list) 
-        & (array.res_id != -1)
-    )
-

--- a/src/biotite/structure/filter.py
+++ b/src/biotite/structure/filter.py
@@ -207,7 +207,7 @@ def filter_altloc(atoms, altlocs, selected_altlocs):
 
             - A chain ID, specifying the residue
             - A residue ID, specifying the residue
-            - The desired *altoc* ID for the specified residue
+            - The desired *altloc* ID for the specified residue
 
         For each of the given residues only those atoms of `atoms` are
         filtered where the *altloc* ID matches the respective *altloc*
@@ -224,7 +224,7 @@ def filter_altloc(atoms, altlocs, selected_altlocs):
     altloc_filter = np.in1d(altlocs, [".","?","A"," ",""])
     
     for loc in selected_altlocs:
-        chain, residue, altoc = loc
+        chain, residue, altloc = loc
         residue_filter = (
             (atoms.chain_id == chain) &
             (atoms.res_id == residue)

--- a/src/biotite/structure/filter.py
+++ b/src/biotite/structure/filter.py
@@ -182,46 +182,55 @@ def filter_intersection(array, intersect):
 
 def filter_first_altloc(atoms, altloc_ids):
     """
-    Filter all atoms having the desired altloc.
+    Filter all atoms, that have the first *altloc* ID appearing in a
+    residue.
     
     Structure files (PDB, PDBx, MMTF) allow for duplicate atom records,
-    in case a residue is found in multiple alternative locations
+    in case a residue is found in multiple alternate locations
     (*altloc*).
-    This function is used to filter the atoms with the desired *altloc*
-    at this position with other *altlocs* are removed.    
-    
-    The function will be rarely used by the end user, since this kind
-    of filtering is automatically performed, when the structure is
-    loaded from a file.
-    In the final atom array (stack) duplicate atoms are not allowed.
+    This function is used to remove such duplicate atoms by choosing a
+    single *altloc ID* for an atom with other *altlocs* being removed.    
     
     Parameters
     ----------
     atoms : AtomArray, shape=(n,) or AtomArrayStack, shape=(m,n)
-        The unfiltered atom array to be filtered.
-    altlocs : array-like, shape=(n,)
-        An array containing the alternative location codes for each
-        atom in the unfiltered atom array.
-        Can contain '.', '?', ' ', '' or a letter at each position.
-    selected_altlocs : iterable object of tuple (str, int, str) or (str, int, str, str)
-        Each tuple consists of the following elements:
-
-            - A chain ID, specifying the residue.
-            - A residue ID, specifying the residue.
-            - *(optional)* An insertion code, specifying the residue.
-              If it is omitted, the residue without the insertion code
-              is selected.
-            - The desired *altloc* ID for the specified residue.
-
-        For each of the given residues only those atoms of `atoms` are
-        filtered where the *altloc* ID matches the respective *altloc*
-        ID in `altlocs`.
-        By default the location with the *altloc* ID "A" is used.
+        The unfiltered structure to be filtered.
+    altloc_ids : ndarray, shape=(n,), dtype='U1'
+        An array containing the alternate location IDs for each
+        atom in `atoms`.
+        Can contain `'.'`, `'?'`, `' '`, `''` or a letter at each
+        position.
     
     Returns
     -------
     filter : ndarray, dtype=bool
-        The combined inscode and altloc filters.
+        For each residue, this array is True in the following cases:
+
+            - The atom has no altloc ID (`'.'`, `'?'`, `' '`, `''`).
+            - The atom has the same altloc ID (e.g. `'A'`, `'B'`, etc.)
+              as the first atom in the residue that has an altloc ID.
+    
+    Notes
+    -----
+    The function will be rarely used by the end user, since this kind
+    of filtering is usually automatically performed, when the structure
+    is loaded from a file.
+    The exception are structures that were read with `altloc` set to
+    `True`.
+
+    Examples
+    --------
+
+    >>> atoms = array([
+    ...     Atom(coord=[1, 2, 3], res_id=1, atom_name="CA"),
+    ...     Atom(coord=[4, 5, 6], res_id=1, atom_name="CB"),
+    ...     Atom(coord=[6, 5, 4], res_id=1, atom_name="CB")
+    ... ])
+    >>> altloc_ids = np.array([".", "A", "B"])
+    >>> filtered = atoms[filter_first_altloc(atoms, altloc_ids)]
+    >>> print(filtered)
+                1      CA               1.000    2.000    3.000
+                1      CB               4.000    5.000    6.000
     """
     # Filter all atoms without altloc code
     altloc_filter = np.in1d(altloc_ids, [".", "?", " ", ""])
@@ -241,6 +250,65 @@ def filter_first_altloc(atoms, altloc_ids):
 
 
 def filter_highest_occupancy_altloc(atoms, altloc_ids, occupancies):
+    """
+    For each residue, filter all atoms, that have the *altloc* ID
+    with the highest occupancy for this residue.
+    
+    Structure files (PDB, PDBx, MMTF) allow for duplicate atom records,
+    in case a residue is found in multiple alternate locations
+    (*altloc*).
+    This function is used to remove such duplicate atoms by choosing a
+    single *altloc ID* for an atom with other *altlocs* being removed.    
+    
+    Parameters
+    ----------
+    atoms : AtomArray, shape=(n,) or AtomArrayStack, shape=(m,n)
+        The unfiltered structure to be filtered.
+    altloc_ids : ndarray, shape=(n,), dtype='U1'
+        An array containing the alternate location IDs for each
+        atom in `atoms`.
+        Can contain `'.'`, `'?'`, `' '`, `''` or a letter at each
+        position.
+    occupancies : ndarray, shape=(n,), dtype=float
+        An array containing the occupancy values for each atom in
+        `atoms`.
+    
+    Returns
+    -------
+    filter : ndarray, dtype=bool
+        For each residue, this array is True in the following cases:
+
+            - The atom has no altloc ID
+              (``'.'``, ``'?'``, ``' '``, ``''``).
+            - The atom has the altloc ID (e.g. ``'A'``, ``'B'``, etc.),
+              of which the corresponding occupancy values are highest
+              for the **entire** residue.
+    
+    Notes
+    -----
+    The function will be rarely used by the end user, since this kind
+    of filtering is usually automatically performed, when the structure
+    is loaded from a file.
+    The exception are structures that were read with ``altloc`` set to
+    ``True``.
+
+    Examples
+    --------
+
+    >>> atoms = array([
+    ...     Atom(coord=[1, 2, 3], res_id=1, atom_name="CA"),
+    ...     Atom(coord=[4, 5, 6], res_id=1, atom_name="CB"),
+    ...     Atom(coord=[6, 5, 4], res_id=1, atom_name="CB")
+    ... ])
+    >>> altloc_ids = np.array([".", "A", "B"])
+    >>> occupancies = np.array([1.0, 0.1, 0.9])
+    >>> filtered = atoms[filter_highest_occupancy_altloc(
+    ...     atoms, altloc_ids, occupancies
+    ... )]
+    >>> print(filtered)
+                1      CA               1.000    2.000    3.000
+                1      CB               6.000    5.000    4.000
+    """
     # Filter all atoms without altloc code
     altloc_filter = np.in1d(altloc_ids, [".", "?", " ", ""])
     

--- a/src/biotite/structure/io/mmtf/convertfile.pyx
+++ b/src/biotite/structure/io/mmtf/convertfile.pyx
@@ -46,18 +46,16 @@ def get_structure(file, model=None, altloc="first",
         If this parameter is omitted, an :class:`AtomArrayStack` containing all
         models will be returned, even if the structure contains only one
         model.
-    altloc : list of tuple, optional
-        In case the structure contains *altloc* entries, those can be
-        specified here:
-        Each tuple consists of the following elements:
-
-            - A chain ID, specifying the residue
-            - A residue ID, specifying the residue
-            - The desired *altoc* ID for the specified residue
-
-        For each of the given residues the atoms with the given *altloc*
-        ID are filtered.
-        By default the location with the *altloc* ID "A" is used.
+    altloc : {'first', 'occupancy', 'all'}
+        This parameter defines how *altloc* IDs are handled:
+            - ``'first'`` - Use atoms that have the first *altloc* ID
+              appearing in a residue.
+            - ``'occupancy'`` - Use atoms that have the *altloc* ID
+              with the highest occupancy for a residue.
+            - ``'all'`` - Use all atoms.
+              Note that this leads to duplicate atoms.
+              When this option is chosen, the ``altloc_id`` annotation
+              array is added to the returned structure.
     extra_fields : list of str, optional
         The strings in the list are optional annotation categories
         that should be stored in the output array or stack.

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -32,18 +32,16 @@ def get_structure(pdb_file, model=None, altloc="first", extra_fields=[]):
         If this parameter is omitted, an :class:`AtomArrayStack`
         containing all models will be returned, even if the
         structure contains only one model.
-    altloc : list of tuple, optional
-        In case the structure contains *altloc* entries, those can be
-        specified here:
-        Each tuple consists of the following elements:
-
-            - A chain ID, specifying the residue
-            - A residue ID, specifying the residue
-            - The desired *altoc* ID for the specified residue
-
-        For each of the given residues the atoms with the given *altloc*
-        ID are filtered.
-        By default the location with the *altloc* ID "A" is used.
+    altloc : {'first', 'occupancy', 'all'}
+        This parameter defines how *altloc* IDs are handled:
+            - ``'first'`` - Use atoms that have the first *altloc* ID
+              appearing in a residue.
+            - ``'occupancy'`` - Use atoms that have the *altloc* ID
+              with the highest occupancy for a residue.
+            - ``'all'`` - Use all atoms.
+              Note that this leads to duplicate atoms.
+              When this option is chosen, the ``altloc_id`` annotation
+              array is added to the returned structure.
     extra_fields : list of str, optional
         The strings in the list are optional annotation categories
         that should be stored in the output array or stack.

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -12,7 +12,7 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["get_structure", "set_structure"]
 
 
-def get_structure(pdb_file, model=None, altloc=[], extra_fields=[]):
+def get_structure(pdb_file, model=None, altloc="first", extra_fields=[]):
     """
     Create an :class:`AtomArray` or :class:`AtomArrayStack` from a
     :class:`PDBFile`.

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -11,7 +11,7 @@ from ...atoms import AtomArray, AtomArrayStack
 from ...box import vectors_from_unitcell, unitcell_from_vectors
 from ....file import TextFile, InvalidFileError
 from ...error import BadStructureError
-from ...filter import filter_altloc
+from ...filter import filter_first_altloc, filter_highest_occupancy_altloc
 from .hybrid36 import encode_hybrid36, decode_hybrid36, max_hybrid36_number
 import copy
 from warnings import warn
@@ -193,7 +193,7 @@ class PDBFile(TextFile):
             return coord
 
 
-    def get_structure(self, model=None, altloc=[], extra_fields=[]):
+    def get_structure(self, model=None, altloc="first", extra_fields=[]):
         """
         Get an :class:`AtomArray` or :class:`AtomArrayStack` from the PDB file.
         
@@ -279,30 +279,70 @@ class PDBFile(TextFile):
             annot_i = coord_i = atom_line_i[line_filter]
             array = AtomArray(len(coord_i))
         
-        # Create altloc array for the final filtering
-        altloc_array = np.zeros(array.array_length(), dtype="U1")
-        
-        # Add optional annotation arrays
-        for field in extra_fields:
-            if field in ["atom_id", "charge"]:
-                array.add_annotation(field, dtype=int)
-            elif field in ["occupancy", "b_factor"]:
-                array.add_annotation(field, dtype=float)
-            else:
-                raise ValueError(f"Unknown extra field: {field}")
-        
-        # Fill in annotation
+        # Create mandatory and optional annotation arrays
+        chain_id  = np.zeros(array.array_length(), array.chain_id.dtype)
+        res_id    = np.zeros(array.array_length(), array.res_id.dtype)
+        ins_code  = np.zeros(array.array_length(), array.ins_code.dtype)
+        res_name  = np.zeros(array.array_length(), array.res_name.dtype)
+        hetero    = np.zeros(array.array_length(), array.hetero.dtype)
+        atom_name = np.zeros(array.array_length(), array.atom_name.dtype)
+        element   = np.zeros(array.array_length(), array.element.dtype)
+
+        atom_id_raw = np.zeros(array.array_length(), "U5")
+        charge_raw  = np.zeros(array.array_length(), "U2")
+        occupancy = np.zeros(array.array_length(), float)
+        b_factor  = np.zeros(array.array_length(), float)
+
+        altloc_id = np.zeros(array.array_length(), dtype="U1")
+
+        # Fill annotation array
         # i is index in array, line_i is line index
         for i, line_i in enumerate(annot_i):
             line = self.lines[line_i]
-            altloc_array[i] = line[16]
-            array.chain_id[i] = line[21].upper().strip()
-            array.res_id[i] = decode_hybrid36(line[22:26])
-            array.ins_code[i] = line[26].strip()
-            array.res_name[i] = line[17:20].strip()
-            array.hetero[i] = (False if line[0:4] == "ATOM" else True)
-            array.atom_name[i] = line[12:16].strip()
-            array.element[i] = line[76:78].strip()
+            
+            chain_id[i] = line[21].upper().strip()
+            res_id[i] = decode_hybrid36(line[22:26])
+            ins_code[i] = line[26].strip()
+            res_name[i] = line[17:20].strip()
+            hetero[i] = (False if line[0:4] == "ATOM" else True)
+            atom_name[i] = line[12:16].strip()
+            element[i] = line[76:78].strip()
+
+            altloc_id[i] = line[16]
+
+            atom_id_raw[i] = line[6:11]
+            charge_raw[i] = line[78:80]
+            occupancy[i] = float(line[54:60].strip())
+            b_factor[i] = float(line[60:66].strip())
+        
+        # Add annotation arrays to atom array (stack)
+        array.chain_id = chain_id
+        array.res_id = res_id
+        array.ins_code = ins_code
+        array.res_name = res_name
+        array.hetero = hetero
+        array.atom_name = atom_name
+        array.element = element
+
+        for field in (extra_fields if extra_fields is not None else []):
+            if field == "atom_id":
+                array.set_annotation("atom_id", np.array(
+                    [decode_hybrid36(raw_id.item()) for raw_id in atom_id_raw],
+                    dtype=int
+                ))
+            elif field == "charge":
+                array.set_annotation("charge", np.array(
+                    [0 if raw_number == " " else
+                     (-float(raw_number) if sign == "-" else float(raw_number))
+                     for raw_number, sign in charge_raw],
+                    dtype=int
+                ))
+            elif field == "occupancy":
+                array.set_annotation("occupancy", occupancy)
+            elif field == "b_factor":
+                array.set_annotation("b_factor", b_factor)
+            else:
+                raise ValueError(f"Unknown extra field: {field}")
 
         # Replace empty strings for elements with guessed types
         # This is used e.g. for PDB files created by Gromacs
@@ -319,20 +359,6 @@ class PDBFile(TextFile):
                     array.element[idx] = guess_element(atom_name)
                     rep_num += 1
             warn("{} elements were guessed from atom_name.".format(rep_num))
-                            
-        if extra_fields:
-            for i, line_i in enumerate(annot_i):
-                line = self.lines[line_i]
-                if "atom_id" in extra_fields:
-                    array.atom_id[i] = decode_hybrid36(line[6:11])
-                if "occupancy" in extra_fields:
-                    array.occupancy[i] = float(line[54:60].strip())
-                if "b_factor" in extra_fields:
-                    array.b_factor[i] = float(line[60:66].strip())
-                if "charge" in extra_fields:
-                    sign = -1 if line[79] == "-" else 1
-                    array.charge[i] = (0 if line[78] == " "
-                                       else int(line[78]) * sign)
         
         # Fill in coordinates
         if isinstance(array, AtomArray):
@@ -378,8 +404,21 @@ class PDBFile(TextFile):
                     )
                 break
 
-        # Apply final filter and return
-        return array[..., filter_altloc(array, altloc_array, altloc)]
+        # Filter altloc IDs and return
+        if altloc_id is None:
+            return array
+        elif altloc == "occupancy":
+            return array[
+                ...,
+                filter_highest_occupancy_altloc(array, altloc_id, occupancy)
+            ]
+        elif altloc == "first":
+            return array[..., filter_first_altloc(array, altloc_id)]
+        elif altloc == "all":
+            array.set_annotation("altloc_id", altloc_id)
+            return array
+        else:
+            raise ValueError(f"'{altloc}' is not a valid 'altloc' option")
 
 
 

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -88,7 +88,7 @@ class PDBFile(TextFile):
         the atom array (stack) from the corresponding
         :func:`get_structure()` call has.
         The reason for this is, that :func:`get_structure()` filters
-        *altlocs*, while `get_coord()` does not.
+        *altloc* IDs, while `get_coord()` does not.
         
         Examples
         --------
@@ -209,18 +209,16 @@ class PDBFile(TextFile):
             If this parameter is omitted, an :class:`AtomArrayStack`
             containing all models will be returned, even if the
             structure contains only one model.
-        altloc : list of tuple, optional
-            In case the structure contains *altloc* entries, those can be
-            specified here:
-            Each tuple consists of the following elements:
-
-                - A chain ID, specifying the residue
-                - A residue ID, specifying the residue
-                - The desired *altoc* ID for the specified residue
-
-            For each of the given residues the atoms with the given *altloc*
-            ID are filtered.
-            By default the location with the *altloc* ID "A" is used.
+        altloc : {'first', 'occupancy', 'all'}
+            This parameter defines how *altloc* IDs are handled:
+                - ``'first'`` - Use atoms that have the first *altloc* ID
+                appearing in a residue.
+                - ``'occupancy'`` - Use atoms that have the *altloc* ID
+                with the highest occupancy for a residue.
+                - ``'all'`` - Use all atoms.
+                Note that this leads to duplicate atoms.
+                When this option is chosen, the ``altloc_id`` annotation
+                array is added to the returned structure.
         extra_fields : list of str, optional
             The strings in the list are optional annotation categories
             that should be stored in the output array or stack.

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -28,12 +28,12 @@ _other_type_list = ["cyclic-pseudo-peptide", "other", "peptide nucleic acid",
 def get_sequence(pdbx_file, data_block=None):
     """
     Get the protein and nucleotide sequences from the
-    `entity_poly.pdbx_seq_one_letter_code_can` entry.
+    ``entity_poly.pdbx_seq_one_letter_code_can`` entry.
 
-    Supported polymer types (`_entity_poly.type`) are: polypeptide(D),
-    polypeptide(L), polydeoxyribonucleotide, polyribonucleotide,
-    polydeoxyribonucleotide/polyribonucleotide hybrid
-
+    Supported polymer types (``_entity_poly.type``) are:
+    ``'polypeptide(D)'``, ``'polypeptide(L)'``,
+    ``'polydeoxyribonucleotide'``, ``'polyribonucleotide'`` and
+    ``'polydeoxyribonucleotide/polyribonucleotide hybrid'``.
     Uracil is converted to Thymine.
     
     Parameters
@@ -85,18 +85,16 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
     data_block : str, optional
         The name of the data block. Default is the first
         (and most times only) data block of the file.
-    altloc : list of tuple, optional
-        In case the structure contains *altloc* entries, those can be
-        specified here:
-        Each tuple consists of the following elements:
-
-            - A chain ID, specifying the residue
-            - A residue ID, specifying the residue
-            - The desired *altoc* ID for the specified residue
-
-        For each of the given residues the atoms with the given *altloc*
-        ID are filtered.
-        By default the location with the *altloc* ID "A" is used.
+    altloc : {'first', 'occupancy', 'all'}
+        This parameter defines how *altloc* IDs are handled:
+            - ``'first'`` - Use atoms that have the first *altloc* ID
+              appearing in a residue.
+            - ``'occupancy'`` - Use atoms that have the *altloc* ID
+              with the highest occupancy for a residue.
+            - ``'all'`` - Use all atoms.
+              Note that this leads to duplicate atoms.
+              When this option is chosen, the ``altloc_id`` annotation
+              array is added to the returned structure.
     extra_fields : list of str, optional
         The strings in the list are entry names, that are
         additionally added as annotation arrays.
@@ -519,18 +517,16 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
         The name of the data block.
         Defaults to the first (and most times only) data block of the
         file.
-    altloc : list of tuple, optional
-        In case the structure contains *altloc* entries, those can be
-        specified here:
-        Each tuple consists of the following elements:
-
-            - A chain ID, specifying the residue
-            - A residue ID, specifying the residue
-            - The desired *altoc* ID for the specified residue
-
-        For each of the given residues the atoms with the given *altloc*
-        ID are filtered.
-        By default the location with the *altloc* ID "A" is used.
+    altloc : {'first', 'occupancy', 'all'}
+        This parameter defines how *altloc* IDs are handled:
+            - ``'first'`` - Use atoms that have the first *altloc* ID
+              appearing in a residue.
+            - ``'occupancy'`` - Use atoms that have the *altloc* ID
+              with the highest occupancy for a residue.
+            - ``'all'`` - Use all atoms.
+              Note that this leads to duplicate atoms.
+              When this option is chosen, the ``altloc_id`` annotation
+              array is added to the returned structure.
     extra_fields : list of str, optional
         The strings in the list are entry names, that are
         additionally added as annotation arrays.

--- a/tests/structure/test_filter.py
+++ b/tests/structure/test_filter.py
@@ -10,27 +10,77 @@ from ..util import data_dir
 import pytest
 
 @pytest.fixture
-def sample_array():
-    return strucio.load_structure(join(data_dir("structure"), "3o5r.mmtf"))
-
-def test_solvent_filter(sample_array):
-    assert len(sample_array[struc.filter_solvent(sample_array)]) == 287
-
-def test_amino_acid_filter(sample_array):
-    assert len(sample_array[struc.filter_amino_acids(sample_array)]) == 982
-
-def test_backbone_filter(sample_array):
-    assert len(sample_array[struc.filter_backbone(sample_array)]) == 384
-
-def test_intersection_filter(sample_array):
-    assert len(sample_array[:200][
-               struc.filter_intersection(sample_array[:200],sample_array[100:])
-           ]) == 100
-
-def test_nucleotide_filter():
-    nuc_sample_array = strucio.load_structure(
-        join(data_dir("structure"), "5ugo.pdb")
+def sample_protein():
+    return strucio.load_structure(
+        join(data_dir("structure"), "3o5r.mmtf"),
+        extra_fields = ["atom_id"]
     )
 
-    assert len(nuc_sample_array[struc.filter_nucleotides(nuc_sample_array)
-            ]) == 651
+@pytest.fixture
+def sample_nucleotide():
+    return strucio.load_structure(
+        join(data_dir("structure"), "5ugo.mmtf")
+    )
+
+@pytest.fixture
+def sample_all_atloc_structure():
+    return strucio.load_structure(
+        join(data_dir("structure"), "1o1z.mmtf"),
+        altloc="all"
+    )
+
+def test_solvent_filter(sample_protein):
+    assert len(sample_protein[struc.filter_solvent(sample_protein)]) == 287
+
+def test_amino_acid_filter(sample_protein):
+    assert len(sample_protein[struc.filter_amino_acids(sample_protein)]) == 982
+
+def test_backbone_filter(sample_protein):
+    assert len(sample_protein[struc.filter_backbone(sample_protein)]) == 384
+
+def test_intersection_filter(sample_protein):
+    assert len(sample_protein[:200][
+        struc.filter_intersection(sample_protein[:200],sample_protein[100:])
+    ]) == 100
+
+def test_nucleotide_filter(sample_nucleotide):
+
+    assert len(
+        sample_nucleotide[struc.filter_nucleotides(sample_nucleotide)]
+    ) == 651
+
+def test_filter_first_altloc(sample_all_atloc_structure):
+    """
+    For a correctly altloc filtered structure no atom should be missing
+    and no atom should be present twice.
+    """
+    ref_atom_set = set()
+    for atom_tuple in zip(
+        sample_all_atloc_structure.chain_id,
+        sample_all_atloc_structure.res_id,
+        sample_all_atloc_structure.ins_code,
+        sample_all_atloc_structure.atom_name
+    ):
+        ref_atom_set.add(atom_tuple)
+    
+    filtered_structure = sample_all_atloc_structure[struc.filter_first_altloc(
+        sample_all_atloc_structure,
+        sample_all_atloc_structure.altloc_id
+    )]
+    test_atom_set = set()
+    for atom_tuple in zip(
+        filtered_structure.chain_id,
+        filtered_structure.res_id,
+        filtered_structure.ins_code,
+        filtered_structure.atom_name
+    ):
+        try:
+            # No atom should be present twice
+            assert atom_tuple not in test_atom_set
+        except AssertionError:
+            print(f"Atom {atom_tuple} is present twice")
+            raise
+        test_atom_set.add(atom_tuple)
+    
+    # No atom should be missing
+    assert test_atom_set == ref_atom_set

--- a/tests/structure/test_gro.py
+++ b/tests/structure/test_gro.py
@@ -47,6 +47,13 @@ def test_pdb_consistency(path):
     a1 = pdb_file.get_structure(model=1)
     gro_file = gro.GROFile.read(path)
     a2 = gro_file.get_structure(model=1)
+    ###
+    print(a1[a1.res_id == 12])
+    #print(np.where(a1.atom_name != a2.atom_name[:len(a1)]))
+    #print(a1[a1.atom_name != a2.atom_name[:len(a1)]])
+    #print()
+    #print(a2[a1.atom_name != a2.atom_name])
+    ###
 
     assert a1.array_length() == a2.array_length()
 


### PR DESCRIPTION
This PR closes #194, by introducing a new *altloc* ID handling when reading structures:
Instead of selecting the *altloc* IDs for each residue individually, three options would be available for the `'altloc'` parameter:

- `'first'` - Use atoms that have the first *altloc* ID appearing in a residue.
- `'occupancy'` - Use atoms that have the *altloc* ID with the highest occupancy for a residue.
- `'all'` - Use all atoms. When this option is chosen, the `altloc_id` annotation array is added to the returned structure to enable the user to filter the required *altloc* IDs in a custom way.

This PR adds the `filter_first_altloc()` and `filter_highest_occupancy_altloc()` functions for the `'first'` and `'occupancy'` option, respectively.
The old `filter_altloc()` function is removed.

These new functions use `get_residue_starts()`, of which the efficiency is improved.