### PR TITLE
Id check

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -228,6 +228,8 @@
         "Checks" : [
             "check_bond_continuity",
             "check_id_continuity",
+            "check_atom_id_continuity",
+            "check_res_id_continuity",
             "check_duplicate_atoms"
         ],
         "Residue level utility" : [

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -18,18 +18,19 @@ from .atoms import Atom, AtomArray, AtomArrayStack
 from .filter import filter_backbone
 from .box import coord_to_fraction
 
+
 def _check_continuity(array):
     diff = np.diff(array)
     discontinuity = np.where( ((diff != 0) & (diff != 1)) )
     return discontinuity[0] + 1
+
 
 def check_atom_id_continuity(array):
     """
     Check if the atom IDs are incremented by more than 1 or
     decremented, from one atom to the next one.
     
-    An increment by more than 1 is as strong clue for missing atoms,
-    a decrement means probably a start of a new chain.
+    An increment by more than 1 is as strong clue for missing atoms.
     
     Parameters
     ----------
@@ -175,17 +176,16 @@ def check_in_box(array):
 
 def renumber_atom_ids(array, start=None):
     """
-    Renumbers the atom IDs of the given array.
+    Renumber the atom IDs of the given array.
 
     Parameters
     ----------
     array : AtomArray or AtomArrayStack
         The array to be checked.
     start : int
-        The starting index for renumbering. Defaults to the first ID in the
-        array.
+        The starting index for renumbering. Defaults to the first ID in
+        the array.
 
-    
     Returns
     -------
     array : AtomArray or AtomArrayStack
@@ -199,15 +199,15 @@ def renumber_atom_ids(array, start=None):
 
 def renumber_res_ids(array):
     """
-    Renumbers the residue IDs of the given array.
+    Renumber the residue IDs of the given array.
 
     Parameters
     ----------
     array : AtomArray or AtomArrayStack
         The array to be checked.
     start : int
-        The starting index for renumbering. Defaults to the first ID in the
-        array.
+        The starting index for renumbering. Defaults to the first ID in
+        the array.
 
     
     Returns

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -197,7 +197,7 @@ def renumber_atom_ids(array, start=None):
     return array
     
 
-def renumber_res_ids(array, start=None):
+def renumber_res_ids(array):
     """
     Renumbers the residue IDs of the given array.
 

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -8,9 +8,9 @@ errors in the structure.
 """
 
 __name__ = "biotite.structure"
-__author__ = "Patrick Kunzmann"
-__all__ = ["check_id_continuity", "check_bond_continuity",
-           "check_duplicate_atoms"]
+__author__ = "Patrick Kunzmann, Daniel Bauer"
+__all__ = ["check_atom_id_continuity", "check_res_id_continuity",
+           "check_bond_continuity", "check_duplicate_atoms"]
 
 import numpy as np
 from .atoms import Atom, AtomArray, AtomArrayStack
@@ -18,7 +18,31 @@ from .filter import filter_backbone
 from .box import coord_to_fraction
 
 
-def check_id_continuity(array):
+def check_atom_id_continuity(array):
+    """
+    Check if the atom IDs are incremented by more than 1 or
+    decremented, from one atom to the next one.
+    
+    An increment by more than 1 is as strong clue for missing atoms,
+    a decrement means probably a start of a new chain.
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The array to be checked.
+    
+    Returns
+    -------
+    discontinuity : ndarray, dtype=bool
+        Contains the indices of atoms after a discontinuity
+    """
+    ids = array.atom_id
+    diff = np.diff(ids)
+    discontinuity = np.where( ((diff != 0) & (diff != 1)) )
+    return discontinuity[0] + 1
+
+
+def check_res_id_continuity(array):
     """
     Check if the residue IDs are incremented by more than 1 or
     decremented, from one atom to the next one.

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -18,6 +18,10 @@ from .atoms import Atom, AtomArray, AtomArrayStack
 from .filter import filter_backbone
 from .box import coord_to_fraction
 
+def _check_continuity(array):
+    diff = np.diff(array)
+    discontinuity = np.where( ((diff != 0) & (diff != 1)) )
+    return discontinuity[0] + 1
 
 def check_atom_id_continuity(array):
     """
@@ -38,9 +42,7 @@ def check_atom_id_continuity(array):
         Contains the indices of atoms after a discontinuity
     """
     ids = array.atom_id
-    diff = np.diff(ids)
-    discontinuity = np.where( ((diff != 0) & (diff != 1)) )
-    return discontinuity[0] + 1
+    return _check_continuity(ids)
 
 
 def check_res_id_continuity(array):
@@ -62,9 +64,7 @@ def check_res_id_continuity(array):
         Contains the indices of atoms after a discontinuity
     """
     ids = array.res_id
-    diff = np.diff(ids)
-    discontinuity = np.where( ((diff != 0) & (diff != 1)) )
-    return discontinuity[0] + 1
+    return _check_continuity(ids)
 
 
 def check_bond_continuity(array, min_len=1.2, max_len=1.8):

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -208,7 +208,6 @@ def renumber_res_ids(array):
     start : int
         The starting index for renumbering. Defaults to the first ID in
         the array.
-
     
     Returns
     -------
@@ -217,6 +216,6 @@ def renumber_res_ids(array):
     """
     diff = np.diff(array.res_id)
     diff[diff != 0] = 1
-    new_res_ids =  np.hstack((array.res_id[0], diff)).cumsum()
+    new_res_ids =  np.concatenate(([array.res_id[0]], diff)).cumsum()
     array.res_id = new_res_ids
     return array

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -10,7 +10,8 @@ errors in the structure.
 __name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann, Daniel Bauer"
 __all__ = ["check_atom_id_continuity", "check_res_id_continuity",
-           "check_bond_continuity", "check_duplicate_atoms"]
+           "check_bond_continuity", "check_duplicate_atoms",
+           "renumber_atom_ids", "renumber_res_ids"]
 
 import numpy as np
 from .atoms import Atom, AtomArray, AtomArrayStack
@@ -170,3 +171,52 @@ def check_in_box(array):
     box = array.box
     fractions = coord_to_fraction(array, box)
     return np.where(((fractions >= 0) & (fractions < 1)).all(axis=-1))[0]
+
+
+def renumber_atom_ids(array, start=None):
+    """
+    Renumbers the atom IDs of the given array.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The array to be checked.
+    start : int
+        The starting index for renumbering. Defaults to the first ID in the
+        array.
+
+    
+    Returns
+    -------
+    array : AtomArray or AtomArrayStack
+        The renumbered array.
+    """
+    if start is None:
+        start = array.atom_id[0]
+    array.atom_id = np.arange(start, array.shape[-1]+1)
+    return array
+    
+
+def renumber_res_ids(array, start=None):
+    """
+    Renumbers the atom IDs of the given array.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The array to be checked.
+    start : int
+        The starting index for renumbering. Defaults to the first ID in the
+        array.
+
+    
+    Returns
+    -------
+    array : AtomArray or AtomArrayStack
+        The renumbered array.
+    """
+    diff = np.diff(array.res_id)
+    diff[diff != 0] = 1
+    new_res_ids =  np.hstack((array.res_id[0], diff)).cumsum()
+    array.res_id = new_res_ids
+    return array

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -34,6 +34,8 @@ def check_id_continuity(array):
     
     An increment by more than 1 is as strong clue for missing residues,
     a decrement means probably a start of a new chain.
+
+    DEPRECATED: Use :func:`check_res_id_continuity()` instead.
     
     Parameters
     ----------

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -199,7 +199,7 @@ def renumber_atom_ids(array, start=None):
 
 def renumber_res_ids(array, start=None):
     """
-    Renumbers the atom IDs of the given array.
+    Renumbers the residue IDs of the given array.
 
     Parameters
     ----------

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -9,11 +9,13 @@ errors in the structure.
 
 __name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann, Daniel Bauer"
-__all__ = ["check_atom_id_continuity", "check_res_id_continuity",
-           "check_bond_continuity", "check_duplicate_atoms",
+__all__ = ["check_id_continuity", "check_atom_id_continuity",
+           "check_res_id_continuity", "check_bond_continuity",
+           "check_duplicate_atoms",
            "renumber_atom_ids", "renumber_res_ids"]
 
 import numpy as np
+import warnings
 from .atoms import Atom, AtomArray, AtomArrayStack
 from .filter import filter_backbone
 from .box import coord_to_fraction
@@ -23,6 +25,32 @@ def _check_continuity(array):
     diff = np.diff(array)
     discontinuity = np.where( ((diff != 0) & (diff != 1)) )
     return discontinuity[0] + 1
+
+
+def check_id_continuity(array):
+    """
+    Check if the residue IDs are incremented by more than 1 or
+    decremented, from one atom to the next one.
+    
+    An increment by more than 1 is as strong clue for missing residues,
+    a decrement means probably a start of a new chain.
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The array to be checked.
+    
+    Returns
+    -------
+    discontinuity : ndarray, dtype=bool
+        Contains the indices of atoms after a discontinuity
+    """
+    warnings.warn(
+        "'check_id_continuity()' is deprecated, "
+        "use 'check_res_id_continuity()' instead",
+        DeprecationWarning
+    )
+    return check_res_id_continuity(array)
 
 
 def check_atom_id_continuity(array):

--- a/tests/structure/test_geometry.py
+++ b/tests/structure/test_geometry.py
@@ -94,7 +94,7 @@ def test_dihedral_backbone_result(file_name):
     
     for chain in struc.chain_iter(array):
         print("Chain: ", chain.chain_id[0])
-        if len(struc.check_id_continuity(chain)) != 0:
+        if len(struc.check_res_id_continuity(chain)) != 0:
             # Do not test discontinuous chains
             return
         test_phi, test_psi, test_ome = struc.dihedral_backbone(chain)

--- a/tests/structure/test_integrity.py
+++ b/tests/structure/test_integrity.py
@@ -17,6 +17,9 @@ def sample_array():
 
 @pytest.fixture
 def gapped_sample_array(sample_array):
+    atom_ids = np.arange(1, sample_array.shape[0]+1)
+    sample_array.add_annotation("atom_id", dtype=int)
+    sample_array.atom_id = atom_ids
     sample_array = sample_array[sample_array.res_id != 5]
     sample_array = sample_array[(sample_array.res_id != 9) |
                                 (sample_array.atom_name != "N")]
@@ -28,8 +31,13 @@ def duplicate_sample_array(sample_array):
     sample_array[234] = sample_array[123]
     return sample_array
 
-def test_id_continuity_check(gapped_sample_array):
-    discon = struc.check_id_continuity(gapped_sample_array)
+def test_atom_id_continuity_check(gapped_sample_array):
+    discon = struc.check_atom_id_continuity(gapped_sample_array)
+    discon_array = gapped_sample_array[discon]
+    assert discon_array.atom_id.tolist() == [93, 159]
+
+def test_res_id_continuity_check(gapped_sample_array):
+    discon = struc.check_res_id_continuity(gapped_sample_array)
     discon_array = gapped_sample_array[discon]
     assert discon_array.res_id.tolist() == [6]
 

--- a/tests/structure/test_integrity.py
+++ b/tests/structure/test_integrity.py
@@ -49,3 +49,15 @@ def test_bond_continuity_check(gapped_sample_array):
 def test_duplicate_atoms_check(duplicate_sample_array):
     discon = struc.check_duplicate_atoms(duplicate_sample_array)
     assert discon.tolist() == [42,234]
+
+def test_renum_res_ids(gapped_sample_array): 
+    renumbered_array = struc.renumber_res_ids(gapped_sample_array)
+    # if renumbering was successful, this should not raise
+    with pytest.raises(AssertionError):
+        test_res_id_continuity_check(renumbered_array)
+
+def test_renum_atom_ids(gapped_sample_array):
+    renumbered_array = struc.renumber_atom_ids(gapped_sample_array)
+    # if renumbering was successful, this should not raise
+    with pytest.raises(AssertionError):
+        test_atom_id_continuity_check(renumbered_array)


### PR DESCRIPTION
Here are some convenient functions I tend to use quite often on broken pdb files.

1) I noticed there is a function to check for gaps in residue ids, but not for atom ids. I added a method for this and renamed the other one so they are not ambigeous: `check_atom_id_continuity` and `check_res_id_continuity`


2) After a failed integrity check, you usually want to fix the errors in the array. I added two methods that allow to renumber the residues and atom ids which removes all gaps, but keep similar resids: `renumber_atom_ids` and `renumber_res_ids`:

i.e:
atom ids `[1,2,3,4,6,7]` would become `[1,2,3,4,5,6]` (yes, this is trivial)
residue ids `[1,1,2,2,4,4,5,4]` would become `[1,1,2,2,3,3,4,5]`