### PR TITLE
Correct handling of ambiguous symbols when reading from FASTA/FASTQ

### DIFF
--- a/src/biotite/sequence/io/fasta/convert.py
+++ b/src/biotite/sequence/io/fasta/convert.py
@@ -18,6 +18,8 @@ __all__ = ["get_sequence", "get_sequences", "set_sequence", "set_sequences",
 def get_sequence(fasta_file, header=None):
     """
     Get a sequence from a :class:`FastaFile` instance.
+
+    The type of sequence is guessed from the sequence string.
     
     Parameters
     ----------
@@ -59,6 +61,8 @@ def get_sequences(fasta_file):
     """
     Get dictionary from a :class:`FastaFile` instance,
     where headers are keys and sequences are values.
+
+    The type of sequence is guessed from the sequence string.
     
     Parameters
     ----------
@@ -192,24 +196,15 @@ def _convert_to_sequence(seq_str):
     # and theres is only one letter for completely unknown nucleotides
     nuc_seq_str = seq_str.replace("U","T").replace("X","N")
     try:
-        code = NucleotideSequence.alphabet_unamb.encode_multiple(nuc_seq_str)
-        seq = NucleotideSequence()
-        seq.code = code
-        return seq
+        return NucleotideSequence(nuc_seq_str, ambiguous=False)
     except AlphabetError:
         pass
     try:
-        code = ProteinSequence.alphabet.encode_multiple(seq_str)
-        seq = ProteinSequence()
-        seq.code = code
-        return seq
+        return ProteinSequence(seq_str)
     except AlphabetError:
         pass
     try:
-        code = NucleotideSequence.alphabet_amb.encode_multiple(nuc_seq_str)
-        seq = NucleotideSequence()
-        seq.code = code
-        return seq
+        return NucleotideSequence(nuc_seq_str, ambiguous=True)
     except AlphabetError:
         raise ValueError("FASTA data cannot be converted either to "
                          "'NucleotideSequence' nor to 'ProteinSequence'")

--- a/src/biotite/sequence/io/fastq/convert.py
+++ b/src/biotite/sequence/io/fastq/convert.py
@@ -42,10 +42,8 @@ def get_sequence(fastq_file, header=None):
             break
         if seq_str is None:
             raise ValueError("File does not contain any sequences")
-    # Determine the sequence type:
-    # If NucleotideSequence can be created it is a DNA sequence,
-    # otherwise protein sequence
-    return NucleotideSequence(seq_str), scores
+    processed_seq_str = seq_str.replace("U","T").replace("X","N")
+    return NucleotideSequence(processed_seq_str), scores
 
 
 def get_sequences(fastq_file):
@@ -66,7 +64,8 @@ def get_sequences(fastq_file):
     """
     seq_dict = OrderedDict()
     for header, (seq_str, scores) in fastq_file.items():
-        seq_dict[header] = NucleotideSequence(seq_str), scores
+        processed_seq_str = seq_str.replace("U","T").replace("X","N")
+        seq_dict[header] = NucleotideSequence(processed_seq_str), scores
     return seq_dict
 
 

--- a/tests/sequence/data/nuc.fasta
+++ b/tests/sequence/data/nuc.fasta
@@ -6,3 +6,7 @@ A
 
 >third dna sequence
 ACGT
+>rna sequence
+ACGU
+>ambiguous rna sequence
+ACGUNN

--- a/tests/sequence/test_fasta.py
+++ b/tests/sequence/test_fasta.py
@@ -11,7 +11,7 @@ from ..util import data_dir
 import pytest
 
    
-def test_access():
+def test_access_low_level():
     path = os.path.join(data_dir("sequence"), "nuc.fasta")
     file = fasta.FastaFile.read(path)
     assert file["dna sequence"] == "ACGCTACGT"
@@ -20,16 +20,34 @@ def test_access():
     assert dict(file.items()) == {
         "dna sequence" : "ACGCTACGT",
         "another dna sequence" : "A",
-        "third dna sequence" : "ACGT"
+        "third dna sequence" : "ACGT",
+        "rna sequence" : "ACGU",
+        "ambiguous rna sequence" : "ACGUNN",
     }
     file["another dna sequence"] = "AA"
     del file["dna sequence"]
     file["yet another sequence"] = "ACGT"
     assert dict(file.items()) == {
         "another dna sequence" : "AA",
-        "third dna sequence"   : "ACGT",
-        "yet another sequence" : "ACGT"
+        "third dna sequence" : "ACGT",
+        "rna sequence" : "ACGU",
+        "ambiguous rna sequence" : "ACGUNN",
+        "yet another sequence" : "ACGT",
     }
+
+
+def test_access_high_level():
+    path = os.path.join(data_dir("sequence"), "nuc.fasta")
+    file = fasta.FastaFile.read(path)
+    sequences = fasta.get_sequences(file)
+    assert sequences == {
+        "dna sequence" : seq.NucleotideSequence("ACGCTACGT", False),
+        "another dna sequence" : seq.NucleotideSequence("A", False),
+        "third dna sequence" : seq.NucleotideSequence("ACGT", False),
+        "rna sequence" : seq.NucleotideSequence("ACGT", False),
+        "ambiguous rna sequence" : seq.NucleotideSequence("ACGTNN", True),
+    }
+
 
 def test_sequence_conversion():
     path = os.path.join(data_dir("sequence"), "nuc.fasta")
@@ -40,7 +58,10 @@ def test_sequence_conversion():
     file2 = fasta.FastaFile()
     fasta.set_sequences(file2, seq_dict)
     seq_dict2 = fasta.get_sequences(file2)
-    assert seq_dict == seq_dict2
+    # Cannot compare dicts directly, since the original RNA sequence is
+    # now guessed as protein sequence
+    for seq1, seq2 in zip(seq_dict.values(), seq_dict2.values()):
+        assert str(seq1) == str(seq2)
     
     file3 = fasta.FastaFile()
     fasta.set_sequence(file3, seq.NucleotideSequence("AACCTTGG"))


### PR DESCRIPTION
This PR fixes the the wrong handling of ambiguous nucleotide symbols in the high-level access functions of FASTA/FASTQ, as mentioned in #232.