### PR TITLE
Add support for adding RNA sequences in FASTA/FASTQ

### DIFF
--- a/src/biotite/sequence/io/fasta/convert.py
+++ b/src/biotite/sequence/io/fasta/convert.py
@@ -85,7 +85,7 @@ def get_sequences(fasta_file):
     return seq_dict
 
 
-def set_sequence(fasta_file, sequence, header=None):
+def set_sequence(fasta_file, sequence, header=None, as_rna=False):
     """
     Set a sequence in a :class:`FastaFile` instance.
     
@@ -97,19 +97,22 @@ def set_sequence(fasta_file, sequence, header=None):
         The sequence to be set.
     header : str, optional
         The header for the sequence. Default is ``'sequence'``.
+    as_rna : bool, optional
+        If set to true, ``'T'`` will be replaced by ``'U'``,
+        if a :class:`NucleotideSequence` was given.
     
     Raises
     ------
     ValueError
         If the sequence's alphabet uses symbols other than single
-        letters.
+        characters.
     """
     if header is None:
         header = "sequence"
-    fasta_file[header] = _convert_to_string(sequence)
+    fasta_file[header] = _convert_to_string(sequence, as_rna)
 
 
-def set_sequences(fasta_file, sequence_dict):
+def set_sequences(fasta_file, sequence_dict, as_rna=False):
     """
     Set sequences in a :class:`FastaFile` instance from a dictionary.
     
@@ -119,16 +122,19 @@ def set_sequences(fasta_file, sequence_dict):
         The :class:`FastaFile` to be accessed.
     sequence_dict : dict
         A dictionary containing the sequences to be set.
-        Header are keys, :class:`Sequence` instances are values. 
+        Header are keys, :class:`Sequence` instances are values.
+    as_rna : bool, optional
+        If set to true, ``'T'`` will be replaced by ``'U'``,
+        if a :class:`NucleotideSequence` was given.
     
     Raises
     ------
     ValueError
         If the sequences alphabets uses symbols other than single
-        letters.
+        characters.
     """
     for header, sequence in sequence_dict.items():
-        fasta_file[header] = _convert_to_string(sequence)
+        fasta_file[header] = _convert_to_string(sequence, as_rna)
 
 
 def get_alignment(fasta_file, additional_gap_chars=("_",)):
@@ -215,8 +221,11 @@ def _convert_to_sequence(seq_str):
                          "'NucleotideSequence' nor to 'ProteinSequence'")
 
 
-def _convert_to_string(sequence):
+def _convert_to_string(sequence, as_rna):
     if not isinstance(sequence.get_alphabet(), LetterAlphabet):
         raise ValueError("Only sequences using single letter alphabets "
                          "can be stored in a FASTA file")
-    return(str(sequence))
+    if isinstance(sequence, NucleotideSequence) and as_rna:
+        return(str(sequence).replace("T", "U"))
+    else:
+        return(str(sequence))

--- a/src/biotite/sequence/io/fastq/convert.py
+++ b/src/biotite/sequence/io/fastq/convert.py
@@ -70,7 +70,7 @@ def get_sequences(fastq_file):
     return seq_dict
 
 
-def set_sequence(fastq_file, sequence, scores, header=None):
+def set_sequence(fastq_file, sequence, scores, header=None, as_rna=False):
     """
     Set a sequence and a quality score array in a `FastqFile` instance.
     
@@ -84,13 +84,16 @@ def set_sequence(fastq_file, sequence, scores, header=None):
         The quality scores to be set.
     header : str, optional
         The identifier for the sequence. Default is 'sequence'.
+    as_rna : bool, optional
+        If set to true, the sequence symbol ``'T'`` will be replaced
+        by ``'U'``.
     """
     if header is None:
         header = "sequence"
-    fastq_file[header] = str(sequence), scores
+    fastq_file[header] = _convert_to_string(sequence, as_rna), scores
 
 
-def set_sequences(fastq_file, sequence_dict):
+def set_sequences(fastq_file, sequence_dict, as_rna=False):
     """
     Set sequences in a `FastqFile` instance from a dictionary.
     
@@ -101,7 +104,17 @@ def set_sequences(fastq_file, sequence_dict):
     sequence_dict : dict
         A dictionary containing the sequences and scores to be set.
         Identifiers are keys,
-        (`NucleotideSequence`, `ndarray`) tuples are values. 
+        (`NucleotideSequence`, `ndarray`) tuples are values.
+    as_rna : bool, optional
+        If set to true, the sequence symbol ``'T'`` will be replaced
+        by ``'U'``.
     """
     for header, (sequence, scores) in sequence_dict.items():
-        fastq_file[header] = str(sequence), scores
+        fastq_file[header] = _convert_to_string(sequence, as_rna), scores
+
+
+def _convert_to_string(sequence, as_rna):
+    if as_rna:
+        return(str(sequence).replace("T", "U"))
+    else:
+        return(str(sequence))

--- a/tests/sequence/test_fasta.py
+++ b/tests/sequence/test_fasta.py
@@ -55,6 +55,16 @@ def test_sequence_conversion():
     with pytest.raises(ValueError):
         seq.NucleotideSequence(fasta.get_sequence(file5))
 
+
+def test_rna_conversion():
+    sequence = seq.NucleotideSequence("ACGT")
+    fasta_file = fasta.FastaFile()
+    fasta.set_sequence(fasta_file, sequence, "seq1", as_rna=False)
+    fasta.set_sequence(fasta_file, sequence, "seq2", as_rna=True)
+    assert fasta_file["seq1"] == "ACGT"
+    assert fasta_file["seq2"] == "ACGU"
+
+
 def test_alignment_conversion():
     path = os.path.join(data_dir("sequence"), "alignment.fasta")
     file = fasta.FastaFile.read(path)

--- a/tests/sequence/test_fastq.py
+++ b/tests/sequence/test_fastq.py
@@ -59,3 +59,13 @@ def test_conversion(chars_per_line):
         test_sequence, test_scores = content[identifier]
         assert test_sequence == ref_sequence
         assert np.array_equal(test_scores, ref_scores)
+
+
+def test_rna_conversion():
+    sequence = seq.NucleotideSequence("ACGT")
+    scores = np.array([0, 0, 0, 0])
+    fastq_file = fastq.FastqFile(offset="Sanger")
+    fastq.set_sequence(fastq_file, sequence, scores, "seq1", as_rna=False)
+    fastq.set_sequence(fastq_file, sequence, scores, "seq2", as_rna=True)
+    assert fastq_file["seq1"][0] == "ACGT" 
+    assert fastq_file["seq2"][0] == "ACGU"


### PR DESCRIPTION
This PR adds the `as_rna` parameter to the `set_sequence()` and `set_sequences()` functions in `sequence.io.fasta` and `sequence.io.fastq`.