### PR TITLE
Add iterable parsing of FASTA/FASTQ files

### DIFF
--- a/src/biotite/file.py
+++ b/src/biotite/file.py
@@ -115,6 +115,40 @@ class TextFile(File, metaclass=abc.ABCMeta):
         file_object = cls(*args, **kwargs)
         file_object.lines = lines
         return file_object
+    
+    @staticmethod
+    def read_iter(file):
+        """
+        Create an iterator over each line of the given text file.
+        
+        Parameters
+        ----------
+        file : file-like object or str
+            The file to be read.
+            Alternatively a file path can be supplied.
+        
+        Yields
+        ------
+        line : str
+            The current line in the file.
+        """
+        # File name
+        if isinstance(file, str):
+            with open(file, "r") as f:
+                while True:
+                    line = f.readline()
+                    if not line:
+                        break
+                    yield line
+        # File object
+        else:
+            if not is_text(file):
+                raise TypeError("A file opened in 'text' mode is required")
+            while True:
+                line = file.readline()
+                if not line:
+                    break
+                yield line
 
     def write(self, file):
         """

--- a/tests/sequence/test_fasta.py
+++ b/tests/sequence/test_fasta.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+import glob
 import biotite.sequence as seq
 import biotite.sequence.io.fasta as fasta
 import numpy as np
@@ -67,3 +68,14 @@ def test_alignment_conversion():
     fasta.set_alignment(file2, alignment, seq_names=["seq1","seq2","seq3"])
     alignment2 = fasta.get_alignment(file2)
     assert str(alignment) == str(alignment2)
+
+@pytest.mark.parametrize(
+    "file_name",
+    glob.glob(os.path.join(data_dir("sequence"), "*.fasta"))
+)
+def test_read_iter(file_name):
+    ref_dict = dict(fasta.FastaFile.read(file_name).items())
+    
+    test_dict = dict(fasta.FastaFile.read_iter(file_name))
+
+    assert test_dict == ref_dict

--- a/tests/sequence/test_fastq.py
+++ b/tests/sequence/test_fastq.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+import glob
 from tempfile import TemporaryFile
 import biotite.sequence as seq
 import biotite.sequence.io.fastq as fastq
@@ -59,3 +60,19 @@ def test_conversion(chars_per_line):
         test_sequence, test_scores = content[identifier]
         assert test_sequence == ref_sequence
         assert np.array_equal(test_scores, ref_scores)
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    glob.glob(os.path.join(data_dir("sequence"), "*.fastq"))
+)
+def test_read_iter(file_name):
+    ref_dict = dict(fastq.FastqFile.read(file_name, offset="Sanger").items())
+    
+    test_dict = dict(fastq.FastqFile.read_iter(file_name, offset="Sanger"))
+
+    for (test_id, (test_seq, test_sc)), (ref_id, (ref_seq, ref_sc)) \
+        in zip(test_dict.items(), ref_dict.items()):
+            assert test_id == ref_id
+            assert test_seq == ref_seq
+            assert (test_sc == ref_sc).all()


### PR DESCRIPTION
Currently, the only way to read FASTA/FASTQ files requires parsing the entire files and storing the lines in a `TextFile` object.
However, these files might contain a large number of entries, so this may become a major memory issue. This PR adds the `read_iter()` static method to both files classes, allowing element-wise iteration without storing the entire file.