### PR TITLE
Fix 3D plot axis lengths in `plot_atoms()`

### DIFF
--- a/doc/examples/scripts/structure/watson_crick.py
+++ b/doc/examples/scripts/structure/watson_crick.py
@@ -92,6 +92,12 @@ for purine, pyrimidine in pairs:
         x, y, z = zip(hydrogen_coord, acceptor_coord)
         ax.plot(x, y, z, linestyle=":", color="gold", linewidth=2)
 
+# Label heavy atoms
+heavy_atoms = atoms[atoms.element != "H"]
+for name, coord in zip(heavy_atoms.atom_name, heavy_atoms.coord):
+    coord = coord + [0.3, 0.15, 0]
+    ax.text(*coord, name, fontsize="4")
+
 # Label bases
 for pair in pairs:
     for base in pair:

--- a/src/biotite/structure/graphics/atoms.py
+++ b/src/biotite/structure/graphics/atoms.py
@@ -130,3 +130,7 @@ def _set_box(axes, coord, center, size, zoom):
     axes.set_xlim(center[0] - size/(2*zoom), center[0] + size/(2*zoom))
     axes.set_ylim(center[1] - size/(2*zoom), center[1] + size/(2*zoom))
     axes.set_zlim(center[2] - size/(2*zoom), center[2] + size/(2*zoom))
+    # Make the axis lengths of the 'plot box' equal
+    # The 'plot box' is not visible due to 'axes.axis("off")'
+    
+    axes.set_box_aspect([1,1,1])


### PR DESCRIPTION
In the current version of *Matplotlib* the axis lenghts of the 3D plot box are not guaranteed to be equal. In fact, the z-axis is usually shorter than the x- and y-axis. This leads to distortions of the plotted structure in the z-direction in `plot_atoms()`. To overcome this problem this PR sets the box aspect ratio to the same value in all three dimensions in `plot_atoms()`.