### PR TITLE
Selenocysteine support for FASTA and GenBank files

### DIFF
--- a/src/biotite/sequence/io/fasta/convert.py
+++ b/src/biotite/sequence/io/fasta/convert.py
@@ -20,7 +20,9 @@ def get_sequence(fasta_file, header=None):
     """
     Get a sequence from a :class:`FastaFile` instance.
 
-    The type of sequence is guessed from the sequence string.
+    The type of sequence is guessed from the sequence string:
+    First, a conversion into a :class:`NucleotideSequence` and
+    second a conversion into a :class:`ProteinSequence` is tried.
     
     Parameters
     ----------
@@ -63,7 +65,9 @@ def get_sequences(fasta_file):
     Get dictionary from a :class:`FastaFile` instance,
     where headers are keys and sequences are values.
 
-    The type of sequence is guessed from the sequence string.
+    The type of sequence is guessed from the sequence string:
+    First, a conversion into a :class:`NucleotideSequence` and
+    second a conversion into a :class:`ProteinSequence` is tried.
     
     Parameters
     ----------

--- a/src/biotite/sequence/io/fasta/convert.py
+++ b/src/biotite/sequence/io/fasta/convert.py
@@ -193,25 +193,27 @@ def _convert_to_sequence(seq_str):
     # Biotite alphabets for nucleotide and proteins
     # do not accept lower case letters
     seq_str = seq_str.upper()
-    # For nucleotides uracil is represented by thymine
-    # and theres is only one letter for completely unknown nucleotides
-    nuc_seq_str = seq_str.replace("U","T").replace("X","N")
     try:
-        return NucleotideSequence(nuc_seq_str, ambiguous=False)
+        # For nucleotides uracil is represented by thymine and
+        # there is is only one letter for completely unknown nucleotides
+        return NucleotideSequence(seq_str.replace("U","T").replace("X","N"))
     except AlphabetError:
         pass
     try:
         if "U" in seq_str:
+            warn = True
+            seq_str = seq_str.replace("U", "C")
+        else:
+            warn = False
+        prot_seq = ProteinSequence(seq_str)
+        # Raise Warning after conversion into 'ProteinSequence'
+        # to wait for potential 'AlphabetError'
+        if warn:
             warnings.warn(
                 "ProteinSequence objects do not support selenocysteine (U), "
                 "occurrences were substituted by cysteine (C)"
             )
-            seq_str = seq_str.replace("U", "C")
-        return ProteinSequence(seq_str)
-    except AlphabetError:
-        pass
-    try:
-        return NucleotideSequence(nuc_seq_str, ambiguous=True)
+        return prot_seq
     except AlphabetError:
         raise ValueError("FASTA data cannot be converted either to "
                          "'NucleotideSequence' nor to 'ProteinSequence'")

--- a/src/biotite/sequence/io/fasta/convert.py
+++ b/src/biotite/sequence/io/fasta/convert.py
@@ -5,6 +5,7 @@
 __name__ = "biotite.sequence.io.fasta"
 __author__ = "Patrick Kunzmann"
 
+import warnings
 from collections import OrderedDict
 from ...sequence import Sequence
 from ...alphabet import AlphabetError, LetterAlphabet
@@ -200,6 +201,12 @@ def _convert_to_sequence(seq_str):
     except AlphabetError:
         pass
     try:
+        if "U" in seq_str:
+            warnings.warn(
+                "ProteinSequence objects do not support selenocysteine (U), "
+                "occurrences were substituted by cysteine (C)"
+            )
+            seq_str = seq_str.replace("U", "C")
         return ProteinSequence(seq_str)
     except AlphabetError:
         pass

--- a/src/biotite/sequence/io/genbank/sequence.py
+++ b/src/biotite/sequence/io/genbank/sequence.py
@@ -8,7 +8,7 @@ Functions for converting a sequence from/to a GenBank file.
 
 __name__ = "biotite.sequence.io.genbank"
 __author__ = "Patrick Kunzmann"
-__all__ = ["get_sequence", "get_annotated_sequence",
+__all__ = ["get_raw_sequence", "get_sequence", "get_annotated_sequence",
            "set_sequence", "set_annotated_sequence"]
 
 import re
@@ -22,6 +22,31 @@ from .annotation import get_annotation, set_annotation
 _SYMBOLS_PER_CHUNK = 10
 _SEQ_CHUNKS_PER_LINE = 6
 _SYMBOLS_PER_LINE = _SYMBOLS_PER_CHUNK * _SEQ_CHUNKS_PER_LINE
+
+
+def get_raw_sequence(gb_file):
+    """
+    Get the raw sequence string from the *ORIGIN* field
+    of a GenBank file.
+
+    Parameters
+    ----------
+    gb_file : GenBankFile
+        The GenBank file to read the *ORIGIN* field from.
+    
+    Returns
+    -------
+    seq_str: str
+        The unaltered sequence as string.
+        Sequence positions and whitespace characters are removed.
+    """
+    fields = gb_file.get_fields("ORIGIN")
+    if len(fields) == 0:
+        raise InvalidFileError("File has no 'ORIGIN' field")
+    if len(fields) > 1:
+        raise InvalidFileError("File has multiple 'ORIGIN' fields")
+    lines, _ = fields[0]
+    return _field_to_seq_string(lines)
 
 
 def get_sequence(gb_file, format="gb"):
@@ -42,14 +67,7 @@ def get_sequence(gb_file, format="gb"):
     sequence : NucleotideSequence or ProteinSequence
         The reference sequence in the file.
     """
-    fields = gb_file.get_fields("ORIGIN")
-    if len(fields) == 0:
-        raise InvalidFileError("File has no 'ORIGIN' field")
-    if len(fields) > 1:
-        raise InvalidFileError("File has multiple 'ORIGIN' fields")
-    lines, _ = fields[0]
-    seq_str = _field_to_seq_string(lines)
-    return _convert_seq_str(seq_str, format)
+    return _convert_seq_str(get_raw_sequence(gb_file), format)
 
 
 def get_annotated_sequence(gb_file, format="gb", include_only=None):
@@ -76,8 +94,7 @@ def get_annotated_sequence(gb_file, format="gb", include_only=None):
     if len(fields) > 1:
         raise InvalidFileError("File has multiple 'ORIGIN' fields")
     lines, _ = fields[0]
-    seq_str = _field_to_seq_string(lines)
-    sequence = _convert_seq_str(seq_str, format)
+    sequence = _convert_seq_str(_field_to_seq_string(lines), format)
     seq_start = _get_seq_start(lines)
     annotation = get_annotation(gb_file, include_only)
     return AnnotatedSequence(annotation, sequence, sequence_start=seq_start)

--- a/src/biotite/sequence/io/genbank/sequence.py
+++ b/src/biotite/sequence/io/genbank/sequence.py
@@ -95,8 +95,14 @@ def _convert_seq_str(seq_str, format):
     if len(seq_str) == 0:
         raise InvalidFileError("The file's 'ORIGIN' field is empty")
     if format == "gb":
-        return NucleotideSequence(seq_str)
+        return NucleotideSequence(seq_str.replace("U","T").replace("X","N"))
     elif format == "gp":
+        if "U" in seq_str:
+            warnings.warn(
+                "ProteinSequence objects do not support selenocysteine (U), "
+                "occurrences were substituted by cysteine (C)"
+            )
+            seq_str = seq_str.replace("U", "C")
         return ProteinSequence(seq_str)
     else:
         raise ValueError(f"Unknown format '{format}'")
@@ -118,7 +124,7 @@ def set_sequence(gb_file, sequence, sequence_start=1):
     ----------
     gb_file : GenBankFile
         The GenBank file to be edited.
-    sequence : NucleotideSequence or ProteinSequence
+    sequence : str or NucleotideSequence or ProteinSequence
         The sequence that is put into the GenBank file.
     sequence_start : int, optional
         The number of the first base of the sequence.

--- a/src/biotite/sequence/seqtypes.py
+++ b/src/biotite/sequence/seqtypes.py
@@ -40,8 +40,8 @@ class GeneralSequence(Sequence):
     
     def as_type(self, sequence):
         """
-        Convert the `GeneralSequence` into a sequence of another
-        `Sequence` type.
+        Convert the :class:`GeneralSequence` into a sequence of another
+        :class:`Sequence` type.
 
         This function simply replaces the sequence code of the given
         sequence with the sequence code of this object.
@@ -58,6 +58,12 @@ class GeneralSequence(Sequence):
         -------
         sequence : Sequence
             The input `sequence` with replaced sequence code.
+        
+        Raises
+        ------
+        AlphabetError
+            If the the :class:`Alphabet` of the input `sequence` does
+            not extend the :class:`Alphabet` of this sequence.
         """
         if not sequence.get_alphabet().extends(self._alphabet):
             raise AlphabetError(
@@ -317,6 +323,14 @@ class ProteinSequence(Sequence):
         string. May take upper or lower case letters. If a list is
         given, the list elements can be 1-letter or 3-letter amino acid
         representations. By default the sequence is empty.
+    
+    Notes
+    -----
+    The :class:`Alphabet` of this :class:`Sequence` class does not
+    support selenocysteine.
+    Please convert selenocysteine (``U``) into cysteine (``C``)
+    or use a custom :class:`Sequence` class, if the differentiation is
+    necessary.
     """
 
     _codon_table = None

--- a/tests/sequence/data/prot.fasta
+++ b/tests/sequence/data/prot.fasta
@@ -1,3 +1,4 @@
 >protein sequence, only a test 
-YAHGF
+YAHUGF
 RTGS
+

--- a/tests/sequence/test_fasta.py
+++ b/tests/sequence/test_fasta.py
@@ -69,7 +69,9 @@ def test_sequence_conversion():
     
     path = os.path.join(data_dir("sequence"), "prot.fasta")
     file4 = fasta.FastaFile.read(path)
-    assert seq.ProteinSequence("YAHGFRTGS") == fasta.get_sequence(file4)
+    # Expect a warning for selenocysteine conversion
+    with pytest.warns(UserWarning):
+        assert seq.ProteinSequence("YAHCGFRTGS") == fasta.get_sequence(file4)
     
     path = os.path.join(data_dir("sequence"), "invalid.fasta")
     file5 = fasta.FastaFile.read(path)


### PR DESCRIPTION
This PR adds weak support for selenocysteine (`U`) symbols in FASTA and GenBank files:
When an `U` appears in a protein sequence, it is automatically converted into cysteine (`C`) and a warning is raised.

To allow simple handling of unaltered sequences in GenBank files, the function `genbank.get_raw_sequence()` is added, returning the sequence as string. This is not necessary in the `fasta` subpackage, because the low-level API in `FastaFile`already provides this functionality.

Due to these changes, the automatic sequence type detection in `fasta.get_sequence()` and `fasta.get_sequences()` would almost always detect an ambiguous RNA sequene as protein sequence. Hence, now the conversion into a `NucleotideSequence` is tested at first and then the conversion into a `ProteinSequence` is tested.

This PR fixes #232.