### PR TITLE
Improve 'base_stacking()'

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -1,4 +1,4 @@
-{   
+{
     "biotite" : {
         "File classes" : [
             "File",
@@ -13,7 +13,7 @@
             "AdaptiveFancyArrow"
         ]
     },
-    
+
     "biotite.application" : {
         "Application classes" : [
             "Application",
@@ -36,7 +36,7 @@
             "fetch_single_file"
         ]
     },
-    
+
     "biotite.database.rcsb" : {
         "Queries" : [
             "Query",
@@ -241,7 +241,8 @@
             "annotate_sse",
             "hbond",
             "hbond_frequency",
-            "base_pairs"
+            "base_pairs",
+            "base_stacking"
         ]
     }
 }

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -502,9 +502,9 @@ def base_pairs(atom_array, min_atoms_per_base = 3, unique = True):
     )
 
     # Combine the two boolean masks
-    boolean_mask = np.logical_and(nucleotides_boolean, non_phosphate_boolean)
+    boolean_mask = nucleotides_boolean & non_phosphate_boolean
 
-    # Get only the nucleosides
+    # Get only nucleosides
     nucleosides = atom_array[boolean_mask]
 
 

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -309,9 +309,13 @@ def base_stacking(atom_array, min_atoms_per_base=3):
        "Finding and visualizing nucleic acid base stacking"
        J Mol Biol Graph, 14(1), 6-11 (1996).
     """
-    # Get the stacking candidates according to a N/O cutoff distance,
-    # where each base is identified as the first index of its respective
-    # residue
+    # Get the stacking candidates according to a cutoff distance, where
+    # each base is identified as the first index of its respective
+    # residue.
+    # The diameter from the C1'-sugar-atom across a purine base is ~5Å
+    # and the distance between the base centers can be at most 4.5Å.
+    # Thus, accounting for buffer, a cutoff of 15Å between the
+    # nucleotides' C1'-atoms was chosen.
     c1_mask = filter_nucleotides(atom_array) & (atom_array.atom_name == "C1'")
     stacking_candidates, _ = _get_proximate_residues(atom_array, c1_mask, 15)
 

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -310,9 +310,8 @@ def base_stacking(atom_array, min_atoms_per_base=3):
     # Get the stacking candidates according to a N/O cutoff distance,
     # where each base is identified as the first index of its respective
     # residue
-    stacking_candidates, _ = _get_proximate_basepair_candidates(
-        atom_array, cutoff=15
-    )
+    c1_mask = filter_nucleotides(atom_array) & (atom_array.atom_name == "C1'")
+    stacking_candidates, _ = _get_proximate_residues(atom_array, c1_mask, 15)
 
     # Contains the plausible pairs of stacked bases
     stacked_bases = []
@@ -506,8 +505,9 @@ def base_pairs(atom_array, min_atoms_per_base = 3, unique = True):
     # Get the basepair candidates according to a N/O cutoff distance,
     # where each base is identified as the first index of its respective
     # residue
-    basepair_candidates, n_o_matches = _get_proximate_basepair_candidates(
-        nucleosides
+    n_o_mask = np.isin(nucleosides.element, ["N", "O"])
+    basepair_candidates, n_o_matches = _get_proximate_residues(
+        nucleosides, n_o_mask, 3.6
     )
 
     # Contains the plausible basepairs
@@ -951,69 +951,65 @@ def map_nucleotide(residue, min_atoms_per_base=3, rmsd_cutoff=0.28):
     return best_base, False
 
 
-def _get_proximate_basepair_candidates(atom_array, cutoff = 3.6):
+def _get_proximate_residues(atom_array, boolean_mask, cutoff):
     """
-    Filter for potential basepairs based on the distance between the
-    nitrogen and oxygen atoms, as potential hydrogen donor/acceptor
-    pair.
+    Filter for residue pairs based on the distance between selected
+    atoms.
 
     Parameters
     ----------
-    atom_array : AtomArray
+    atom_array : AtomArray, shape=(n,)
         The :class:`AtomArray`` to find basepair candidates in.
+    boolean_mask : ndarray, dtype=bool, shape=(n,)
+        The selection of atoms.
     cutoff : integer
-        The maximum distance of the N and O Atoms for two bases
-        to be considered a basepair candidate.
+        The maximum distance between the atoms of the two residues.
 
     Returns
     -------
-    basepair_candidates : ndarray, dtype=int, shape=(n,2)
+    pairs : ndarray, dtype=int, shape=(n,2)
         Contains the basepair candidates. Each row is equivalent to one
         potential basepair. bases are represented as the first indices
         of their corresponding residues.
-    n_o_pairs : ndarray, dtype=int, shape=(n,)
-        Contains the number of N/O pairs for each potential basepair.
+    count : ndarray, dtype=int, shape=(n,)
+        The number of atom pairs between the residues within the
+        specified cutoff
     """
-    # Get a boolean mask for the N and O atoms
-    n_o_mask = (filter_nucleotides(atom_array)
-              & np.isin(atom_array.element, ["N", "O"]))
 
-    # Get the indices of the N and O atoms that are within the maximum
-    # cutoff of each other
+    # Get the indices of the atoms that are within the maximum cutoff
+    # of each other
     indices = CellList(
-        atom_array, cutoff, selection=n_o_mask
-    ).get_atoms(atom_array.coord[n_o_mask], cutoff)
+        atom_array, cutoff, selection=boolean_mask
+    ).get_atoms(atom_array.coord[boolean_mask], cutoff)
 
     # Loop through the indices of potential partners
-    basepair_candidates = []
-    for candidate, partners in zip(np.argwhere(n_o_mask)[:, 0], indices):
+    pairs = []
+    for candidate, partners in zip(np.argwhere(boolean_mask)[:, 0], indices):
         for partner in partners:
             if partner != -1:
-                basepair_candidates.append((candidate, partner))
+                pairs.append((candidate, partner))
 
     # Get the residue starts for the indices of the candidate/partner
     # indices.
-    basepair_candidates = np.array(basepair_candidates)
-    basepair_candidates_shape = basepair_candidates.shape
-    basepair_candidates = get_residue_starts_for(
-        atom_array, basepair_candidates.flatten()
+    pairs = np.array(pairs)
+    basepair_candidates_shape = pairs.shape
+    pairs = get_residue_starts_for(
+        atom_array, pairs.flatten()
     ).reshape(basepair_candidates_shape)
 
-    # Remove candidates where the N/O pairs are from the same residue
-    basepair_candidates = np.delete(
-        basepair_candidates, np.where(
-            basepair_candidates[:,0] == basepair_candidates[:,1]
+    # Remove candidates where the pairs are from the same residue
+    pairs = np.delete(
+        pairs, np.where(
+            pairs[:,0] == pairs[:,1]
         ), axis=0
     )
-    # Sort the residue starts for each potential basepair
-    for i, candidate in enumerate(basepair_candidates):
-        basepair_candidates[i] = sorted(candidate)
-    # Make sure each base pair candidate is only listed once
-    basepair_candidates, n_o_pairs = np.unique(
-        basepair_candidates, axis=0, return_counts=True
-    )
+    # Sort the residue starts for each pair
+    for i, candidate in enumerate(pairs):
+        pairs[i] = sorted(candidate)
+    # Make sure each pair is only listed once, count the occurrences
+    pairs, count = np.unique(pairs, axis=0, return_counts=True)
 
-    return basepair_candidates, n_o_pairs
+    return pairs, count
 
 
 def _filter_atom_type(atom_array, atom_names):

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -546,7 +546,7 @@ def base_pairs(atom_array, min_atoms_per_base = 3, unique = True):
             # Each N/O-pair is detected twice. Thus, the number of
             # matches must be divided by two.
             hbonds = n_o_pairs/2
-        if not hbonds == -1:
+        if hbonds != -1:
             basepairs.append((base1_index, base2_index))
             if unique:
                 basepairs_hbonds.append(hbonds)

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -277,6 +277,7 @@ def base_stacking(atom_array, min_atoms_per_base=3):
     --------
     Compute the stacking interactions for a DNA-double-helix (PDB ID
     1BNA):
+
     >>> from os.path import join
     >>> dna_helix = load_structure(join(path_to_structures, "1bna.pdb"))
     >>> stacking_interactions = base_stacking(dna_helix)

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -272,6 +272,7 @@ def base_stacking(atom_array, min_atoms_per_base=3):
     -----
     Please note that ring normal vectors are assumed to be equal to the
     base normal vectors.
+
     Examples
     --------
     Compute the stacking interactions for a DNA-double-helix (PDB ID


### PR DESCRIPTION
This PR improves the pre-selection of potential stacking partners in  `base_stacking()`. 

`_get_proximate_basepair_candidates()` was renamed to `_get_proximate_residues()`. Also the function is now more generalized:
- The selection of atoms whose distances should be compared is now specified by a boolean mask
- The default cutoff value was removed

Previously `base_stacking()` pre-selected potential stacking candidates using `_get_proximate_basepair_candidates()`, with a cutoff distance between N/O atoms pairs of 15Å. The function was originally implemented for pre-selecting potential basepair candidates for `base_pairs()` based on the plausibility of hydrogen bonds. In this case the function was used to approximate the distance between the bases. 

However, in order to approximate the bases distance one atom per base can be sufficient. In this PR the preselection of potential stacking candidates is done using only the C1'-Atom of the bases glycosidic bonds with the same cutoff of 15Å. 