### PR TITLE
Fixes #243

### DIFF
--- a/doc/tutorial/src/database.py
+++ b/doc/tutorial/src/database.py
@@ -149,7 +149,7 @@ print(entrez.get_database_name("Nucleotide"))
 # single file. This is achieved with the :func:`fetch_single_file()`
 # function.
 
-temp_file = NamedTemporaryFile(suffix=".fasta")
+temp_file = NamedTemporaryFile(suffix=".fasta", delete=False)
 file_path = entrez.fetch_single_file(
     ["1L2Y_A","1AKI_A"], temp_file.name, db_name="protein", ret_type="fasta"
 )

--- a/doc/tutorial/src/sequence.py
+++ b/doc/tutorial/src/sequence.py
@@ -263,7 +263,7 @@ fasta.set_sequence(fasta_file, dna_seq1, header="gibberish")
 # .. or dictionary style
 fasta_file["more gibberish"] = str(dna_seq2)
 print(fasta_file)
-temp_file = NamedTemporaryFile(suffix=".fasta")
+temp_file = NamedTemporaryFile(suffix=".fasta", delete=False)
 fasta_file.write(temp_file.name)
 temp_file.close()
 

--- a/doc/tutorial/src/structure.py
+++ b/doc/tutorial/src/structure.py
@@ -176,7 +176,7 @@ print(tc5b.shape)
 
 pdb_file = pdb.PDBFile()
 pdb_file.set_structure(tc5b)
-temp_file = NamedTemporaryFile(suffix=".pdb")
+temp_file = NamedTemporaryFile(suffix=".pdb", delete=False)
 pdb_file.write(temp_file.name)
 temp_file.close()
 
@@ -351,7 +351,7 @@ import biotite.structure.io as strucio
 
 stack_from_pdb = strucio.load_structure(pdb_file_path)
 stack_from_cif = strucio.load_structure(cif_file_path)
-temp_file = NamedTemporaryFile(suffix=".cif")
+temp_file = NamedTemporaryFile(suffix=".cif", delete=False)
 strucio.save_structure(temp_file.name, stack_from_pdb)
 temp_file.close()
 
@@ -371,7 +371,7 @@ import requests
 import biotite.structure.io.xtc as xtc
 
 # Download 1L2Y as XTC file for demonstration purposes
-temp_xtc_file = NamedTemporaryFile("wb", suffix=".xtc")
+temp_xtc_file = NamedTemporaryFile("wb", suffix=".xtc", delete=False)
 response = requests.get(
     "https://raw.githubusercontent.com/biotite-dev/biotite/master/"
     "tests/structure/data/1l2y.xtc"

--- a/src/biotite/application/clustalo/app.py
+++ b/src/biotite/application/clustalo/app.py
@@ -13,6 +13,7 @@ from ...sequence.seqtypes import NucleotideSequence, ProteinSequence
 from ...sequence.io.fasta.file import FastaFile
 from ...sequence.align.alignment import Alignment
 from ...sequence.phylo.tree import Tree
+from ..localapp import cleanup_tempfile
 from ..msaapp import MSAApp
 from ..application import AppState, requires_state
 
@@ -54,10 +55,18 @@ class ClustalOmegaApp(MSAApp):
         self._mbed = True
         self._dist_matrix = None
         self._tree = None
-        self._in_dist_matrix_file  = NamedTemporaryFile("w", suffix=".mat")
-        self._out_dist_matrix_file = NamedTemporaryFile("r", suffix=".mat")
-        self._in_tree_file         = NamedTemporaryFile("w", suffix=".tree")
-        self._out_tree_file        = NamedTemporaryFile("r", suffix=".tree")
+        self._in_dist_matrix_file = NamedTemporaryFile(
+            "w", suffix=".mat", delete=False
+        )
+        self._out_dist_matrix_file = NamedTemporaryFile(
+            "r", suffix=".mat", delete=False
+        )
+        self._in_tree_file = NamedTemporaryFile(
+            "w", suffix=".tree", delete=False
+        )
+        self._out_tree_file = NamedTemporaryFile(
+            "r", suffix=".tree", delete=False
+        )
     
     def run(self):
         args = [
@@ -130,10 +139,10 @@ class ClustalOmegaApp(MSAApp):
     
     def clean_up(self):
         super().clean_up()
-        self._in_dist_matrix_file.close()
-        self._out_dist_matrix_file.close()
-        self._in_tree_file.close()
-        self._out_tree_file.close()
+        cleanup_tempfile(self._in_dist_matrix_file)
+        cleanup_tempfile(self._out_dist_matrix_file)
+        cleanup_tempfile(self._in_tree_file)
+        cleanup_tempfile(self._out_tree_file)
     
     @requires_state(AppState.CREATED)
     def full_matrix_calculation(self):

--- a/src/biotite/application/dssp/app.py
+++ b/src/biotite/application/dssp/app.py
@@ -7,7 +7,7 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["DsspApp"]
 
 from tempfile import NamedTemporaryFile
-from ..localapp import LocalApp
+from ..localapp import LocalApp, cleanup_tempfile
 from ..application import AppState, requires_state
 from ...structure.io.pdb import PDBFile
 import numpy as np
@@ -54,8 +54,8 @@ class DsspApp(LocalApp):
     def __init__(self, atom_array, bin_path="mkdssp"):
         super().__init__(bin_path)
         self._array = atom_array
-        self._in_file  = NamedTemporaryFile("w", suffix=".pdb")
-        self._out_file = NamedTemporaryFile("r", suffix=".dssp")
+        self._in_file  = NamedTemporaryFile("w", suffix=".pdb",  delete=False)
+        self._out_file = NamedTemporaryFile("r", suffix=".dssp", delete=False)
 
     def run(self):
         in_file = PDBFile()
@@ -88,8 +88,8 @@ class DsspApp(LocalApp):
     
     def clean_up(self):
         super().clean_up()
-        self._in_file.close()
-        self._out_file.close()
+        cleanup_tempfile(self._in_file)
+        cleanup_tempfile(self._out_file)
     
     @requires_state(AppState.JOINED)
     def get_sse(self):

--- a/src/biotite/application/localapp.py
+++ b/src/biotite/application/localapp.py
@@ -10,7 +10,7 @@ import abc
 import copy
 import time
 import io
-from os import chdir, getcwd
+from os import chdir, getcwd, remove
 from .application import Application, AppState, requires_state
 from subprocess import Popen, PIPE, SubprocessError
 
@@ -241,3 +241,24 @@ class LocalApp(Application, metaclass=abc.ABCMeta):
     def clean_up(self):
         if self.get_app_state() == AppState.CANCELLED:
             self._process.kill()
+
+
+def cleanup_tempfile(temp_file):
+    """
+    Close a :class:`NamedTemporaryFile` and delete it manually,
+    if `delete` is set to ``False``.
+    This function is a small helper function intended for usage in
+    `LocalApp` subclasses. 
+
+    The manual deletion is necessary, as Windows does not allow to open
+    a :class:`NamedTemporaryFile` as second time
+    (e.g. by the file name), if `delete` is set to ``True``.
+
+    Parameters
+    ----------
+    temp_file : NamedTemporaryFile
+        The temporary file to be closed and deleted.
+    """
+    temp_file.close()
+    if not temp_file.delete:
+        remove(temp_file.name)

--- a/src/biotite/application/msaapp.py
+++ b/src/biotite/application/msaapp.py
@@ -10,7 +10,7 @@ import abc
 from tempfile import NamedTemporaryFile
 from collections import OrderedDict
 import numpy as np
-from .localapp import LocalApp
+from .localapp import LocalApp, cleanup_tempfile
 from .application import AppState, requires_state
 from ..sequence.sequence import Sequence
 from ..sequence.seqtypes import NucleotideSequence, ProteinSequence
@@ -120,9 +120,15 @@ class MSAApp(LocalApp, metaclass=abc.ABCMeta):
             self._matrix = MSAApp._map_matrix(matrix)
 
         self._sequences = sequences
-        self._in_file     = NamedTemporaryFile("w", suffix=".fa")
-        self._out_file    = NamedTemporaryFile("r", suffix=".fa")
-        self._matrix_file = NamedTemporaryFile("w", suffix=".mat")
+        self._in_file = NamedTemporaryFile(
+            "w", suffix=".fa", delete=False
+        )
+        self._out_file = NamedTemporaryFile(
+            "r", suffix=".fa", delete=False
+        )
+        self._matrix_file = NamedTemporaryFile(
+            "w", suffix=".mat", delete=False
+        )
 
     def run(self):
         sequences = self._sequences if not self._is_mapped \
@@ -154,9 +160,9 @@ class MSAApp(LocalApp, metaclass=abc.ABCMeta):
     
     def clean_up(self):
         super().clean_up()
-        self._in_file.close()
-        self._out_file.close()
-        self._matrix_file.close()
+        cleanup_tempfile(self._in_file)
+        cleanup_tempfile(self._out_file)
+        cleanup_tempfile(self._matrix_file)
     
     @requires_state(AppState.JOINED)
     def get_alignment(self):

--- a/src/biotite/application/muscle/app.py
+++ b/src/biotite/application/muscle/app.py
@@ -9,6 +9,7 @@ __all__ = ["MuscleApp"]
 import numbers
 import warnings
 from tempfile import NamedTemporaryFile
+from ..localapp import cleanup_tempfile
 from ..msaapp import MSAApp
 from ..application import AppState, requires_state
 from ...sequence.sequence import Sequence
@@ -56,8 +57,12 @@ class MuscleApp(MSAApp):
         self._terminal_penalty = None
         self._tree1 = None
         self._tree2 = None
-        self._out_tree1_file = NamedTemporaryFile("r", suffix=".tree")
-        self._out_tree2_file = NamedTemporaryFile("r", suffix=".tree")
+        self._out_tree1_file = NamedTemporaryFile(
+            "r", suffix=".tree", delete=False
+        )
+        self._out_tree2_file = NamedTemporaryFile(
+            "r", suffix=".tree", delete=False
+        )
     
     def run(self):
         args = [
@@ -104,8 +109,8 @@ class MuscleApp(MSAApp):
     
     def clean_up(self):
         super().clean_up()
-        self._out_tree1_file.close()
-        self._out_tree2_file.close()
+        cleanup_tempfile(self._out_tree1_file)
+        cleanup_tempfile(self._out_tree2_file)
     
     @requires_state(AppState.CREATED)
     def set_gap_penalty(self, gap_penalty):

--- a/src/biotite/application/sra/app.py
+++ b/src/biotite/application/sra/app.py
@@ -8,7 +8,7 @@ __all__ = ["FastqDumpApp"]
 
 import glob
 from tempfile import NamedTemporaryFile, gettempdir
-from ..localapp import LocalApp
+from ..localapp import LocalApp, cleanup_tempfile
 from ..application import AppState, requires_state
 from ...sequence.io.fastq.file import FastqFile
 from ...sequence.io.fastq.convert import get_sequences
@@ -46,6 +46,8 @@ class FastqDumpApp(LocalApp):
         self._uid = uid
         self._offset = offset
         if output_path_prefix is None:
+            # NamedTemporaryFile is only created to obtain prefix
+            # for FASTQ files
             self._out_file = NamedTemporaryFile("r")
             self._prefix = self._out_file.name
         else:


### PR DESCRIPTION
This PR addresses #243. It sets `delete` to `False` in the constructor of `NamedTemporaryFile` and manually deletes the temporay file in `Application.cleanup()`. This workaround was necessary as Windows does not allow to reopen temporary files a second time, if `delete` is `True`. However, reopening temporary files is required in the executed CLI programs.