### PR TITLE
Fix bounds check for BondType

### DIFF
--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -150,21 +150,27 @@ class BondList(Copyable):
                     f"Index {np.max(bonds[:,:2])} in bonds is too large "
                     f"for atom count of {atom_count}"
                 )
+            self._bonds = np.zeros((bonds.shape[0], 3), dtype=np.uint32)
             if bonds.shape[1] == 3:
                 # Input contains bonds (index 0 and 1)
-                # including the bond type value (index 3)
-                # -> Simply copy input
-                self._bonds = _to_positive_index_array(bonds, atom_count) \
-                              .astype(np.uint32)
+                # including the bond type value (index 2)
+                # Bond indices:
+                self._bonds[:,:2] = np.sort(
+                    # Indices are sorted per bond
+                    # so that the lower index is at the first position
+                    _to_positive_index_array(bonds[:,:2], atom_count), axis=1
+                )
+                # Bond type:
+                self._bonds[:,2] = bonds[:, 2]
+
                 # Indices are sorted per bond
                 # so that the lower index is at the first position
-                self._bonds[:,:2] = np.sort(self._bonds[:,:2], axis=1)
             elif bonds.shape[1] == 2:
-                # input contains the bonds without bond type
+                # Input contains the bonds without bond type
                 # -> Default: Set bond type ANY (0)
-                self._bonds = np.zeros((bonds.shape[0], 3), dtype=np.uint32)
-                # Set and sort atom indices per bond
                 self._bonds[:,:2] = np.sort(
+                    # Indices are sorted per bond
+                    # so that the lower index is at the first position
                     _to_positive_index_array(bonds[:,:2], atom_count), axis=1
                 )
             else:

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -145,11 +145,9 @@ class BondList(Copyable):
         self._atom_count = atom_count
         
         if bonds is not None and len(bonds) > 0:
-            if (bonds[:,:2] >= atom_count).any():
-                raise ValueError(
-                    f"Index {np.max(bonds[:,:2])} in bonds is too large "
-                    f"for atom count of {atom_count}"
-                )
+            if bonds.ndim != 2:
+                raise ValueError("Expected a 2D-ndarray for input bonds")
+
             self._bonds = np.zeros((bonds.shape[0], 3), dtype=np.uint32)
             if bonds.shape[1] == 3:
                 # Input contains bonds (index 0 and 1)

--- a/tests/structure/test_bonds.py
+++ b/tests/structure/test_bonds.py
@@ -28,7 +28,7 @@ def bond_list(request):
 
 def test_creation(bond_list):
     """
-    Test creating a `BondList` on a known example.
+    Test creating a :class:`BondList` on a known example.
     """
     # Test includes redundancy removal and max bonds calculation
     assert bond_list.as_array().tolist() == [[0, 1, 0],
@@ -39,6 +39,56 @@ def test_creation(bond_list):
                                              [4, 6, 0]]
     assert bond_list._max_bonds_per_atom == 3
     assert bond_list._atom_count == 7
+
+
+def test_invalid_creation():
+    """
+    Check for appropriate errors when invalid input is given to the
+    :class:`BondLst` constructor.
+    """
+    # Test invalid input shapes
+    with pytest.raises(ValueError):
+        struc.BondList(
+            5,
+            np.array([
+                [1,2,3,4]
+            ])
+        )
+    with pytest.raises(ValueError):
+        struc.BondList(
+            5,
+            np.array([1,2])
+        )
+
+    # Test invalid atom indices
+    with pytest.raises(IndexError):
+        struc.BondList(
+            5,
+            np.array([
+                [1,2],
+                # 5 is an invalid index for an atom count of 5
+                [5,2]
+            ])
+        )
+    with pytest.raises(IndexError):
+        struc.BondList(
+            5,
+            np.array([
+                # Index -6 is invalid for an atom count of 5
+                [-6,3],
+                [3,4]
+            ])
+        )
+    
+    # Test invalid BondType
+    with pytest.raises(ValueError):
+        struc.BondList(
+            5,
+            np.array([
+                # BondType '6' does not exist
+                [1,2,6]
+            ])
+        )
 
 
 def test_modification(bond_list):


### PR DESCRIPTION
In the constructor of `BondList` the provided `bonds` parameter is checked for out-of-bounds values regarding the `atom_count`.
Previously however, not only the bond indices but also the `BondType` were checked, which does not make sense, since the `BondType` values are not restrained by `atom_bount`, but by the values in the `BondType` enum.

This subtle error has only effect in the rare occurence of an `AtomArray` with its length equal or smaller than one of its bond orders
*Cyanide* (`CN`) is such are rare case (#252): It contains 3 atoms but also a triple bond.

This PR fixes the bound check. Hence this PR also fixes #252.