### PR TITLE
Fix number of decimal places of B-factor in PDB files

### DIFF
--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -538,7 +538,7 @@ class PDBFile(TextFile):
                                   "{:>8.3f}".format(array.coord[i,1]) +
                                   "{:>8.3f}".format(array.coord[i,2]) +
                                   "{:>6.2f}".format(occupancy[i]) +
-                                  "{:>6.3f}".format(b_factor[i]) +
+                                  "{:>6.2f}".format(b_factor[i]) +
                                   (" " * 10) + 
                                   "{:2}".format(array.element[i]) +
                                   "{:2}".format(charge[i])


### PR DESCRIPTION
Prior to this PR `PDBFile` writes the B factor with 3 decimal places, although the specification states 2 decimal places. This PR fixes that.