### PR TITLE
Fix #264

### DIFF
--- a/src/biotite/application/dssp/app.py
+++ b/src/biotite/application/dssp/app.py
@@ -9,7 +9,8 @@ __all__ = ["DsspApp"]
 from tempfile import NamedTemporaryFile
 from ..localapp import LocalApp, cleanup_tempfile
 from ..application import AppState, requires_state
-from ...structure.io.pdb import PDBFile
+from ...structure.io.pdbx.file import PDBxFile
+from ...structure.io.pdbx.convert import set_structure
 import numpy as np
 
 
@@ -53,13 +54,31 @@ class DsspApp(LocalApp):
     
     def __init__(self, atom_array, bin_path="mkdssp"):
         super().__init__(bin_path)
-        self._array = atom_array
-        self._in_file  = NamedTemporaryFile("w", suffix=".pdb",  delete=False)
+
+        # mkdssp requires also the
+        # 'occupancy', 'b_factor' and 'charge' fields
+        # -> Add these annotations to a copy of the input structure
+        self._array = atom_array.copy()
+        categories = self._array.get_annotation_categories()
+        if "charge" not in categories:
+            self._array.set_annotation(
+                "charge", np.zeros(self._array.array_length(), dtype=int)
+            )
+        if "b_factor" not in categories:
+            self._array.set_annotation(
+                "b_factor", np.zeros(self._array.array_length(), dtype=float)
+            )
+        if "occupancy" not in categories:
+            self._array.set_annotation(
+                "occupancy", np.ones(self._array.array_length(), dtype=float)
+            )
+
+        self._in_file  = NamedTemporaryFile("w", suffix=".cif",  delete=False)
         self._out_file = NamedTemporaryFile("r", suffix=".dssp", delete=False)
 
     def run(self):
-        in_file = PDBFile()
-        in_file.set_structure(self._array)
+        in_file = PDBxFile()
+        set_structure(in_file, self._array, data_block="DSSP_INPUT")
         in_file.write(self._in_file)
         self._in_file.flush()
         self.set_arguments(

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -498,6 +498,12 @@ class PDBFile(TextFile):
             warn(f"Residue IDs exceed {max_residues:,}")
         if np.isnan(array.coord).any():
             raise ValueError("Coordinates contain 'NaN' values")
+        if any([len(name) > 1 for name in array.chain_id]):
+            raise ValueError("Some chain IDs exceed 1 character")
+        if any([len(name) > 3 for name in array.res_name]):
+            raise ValueError("Some residue names exceed 3 characters")
+        if any([len(name) > 4 for name in array.atom_name]):
+            raise ValueError("Some atom names exceed 4 characters")
 
         if hybrid36:
             pdb_atom_id = [encode_hybrid36(i, 5).rjust(5) for i in atom_id]

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -416,7 +416,7 @@ def set_structure(pdbx_file, array, data_block=None):
     atom_site_dict["auth_atom_id"] = atom_site_dict["label_atom_id"]
     
     if "atom_id" in annot_categories:
-        atom_site_dict["id"] = array.atom_id.astype("U6")
+        atom_site_dict["id"] = np.array([str(e) for e in array.atom_id])
     else:
         atom_site_dict["id"] = None
     if "b_factor" in annot_categories:

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -408,9 +408,7 @@ def set_structure(pdbx_file, array, data_block=None):
     atom_site_dict["label_comp_id"] = np.copy(array.res_name)
     atom_site_dict["label_asym_id"] = np.copy(array.chain_id)
     atom_site_dict["label_entity_id"] = _determine_entity_id(array.chain_id)
-    atom_site_dict["label_seq_id"] = np.array(
-        ["." if e == -1 else str(e) for e in array.res_id]
-    )
+    atom_site_dict["label_seq_id"] = np.array([str(e) for e in array.res_id])
     atom_site_dict["pdbx_PDB_ins_code"] = array.ins_code
     atom_site_dict["auth_seq_id"] = atom_site_dict["label_seq_id"]
     atom_site_dict["auth_comp_id"] = atom_site_dict["label_comp_id"]

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -18,14 +18,15 @@ class PDBxFile(TextFile, MutableMapping):
     This class represents a PDBx/mmCIF file.
     
     The categories of the file can be accessed using the
-    `get_category()`/`set_category()` methods. The content of each
-    category is represented by a dictionary. The dictionary contains
-    the entry (e.g. *label_entity_id* in *atom_site*) as key. The
-    corresponding values are either strings in *non-looped* categories,
-    or 1-D numpy arrays of string objects in case of *looped*
-    categories.
+    :meth:`get_category()`/:meth:`set_category()` methods.
+    The content of each category is represented by a dictionary.
+    The dictionary contains the entry
+    (e.g. *label_entity_id* in *atom_site*) as key.
+    The corresponding values are either strings in *non-looped*
+    categories, or 1-D numpy arrays of string objects in case of
+    *looped* categories.
     
-    A category can be changed or added using `set_category()`:
+    A category can be changed or added using :meth:`set_category()`:
     If a string-valued dictionary is provided, a *non-looped* category
     will be created; if an array-valued dictionary is given, a
     *looped* category will be created. In case of arrays, it is
@@ -45,7 +46,7 @@ class PDBxFile(TextFile, MutableMapping):
     This class uses a lazy category dictionary creation: When reading
     the file only the line positions of all categories are checked. The
     time consuming task of dictionary creation is done when
-    `get_category()` is called.
+    :meth:`get_category()` is called.
     
     Examples
     --------


### PR DESCRIPTION
This PR fixes #264. It introduces the following changes:

- Raise an error when a PDB file is created with multi-character chain ID
- Use mmCIF files for `mkdssp` input
- A `-1` residue ID is not converted to `.` in PDBx/mmCIF files anymore, to account for structures with negative residue IDs