### PR TITLE
Add molecule-level functionalities

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -231,6 +231,11 @@
             "get_chain_count",
             "chain_iter"
         ],
+        "Molecule level utility" : [
+            "get_molecule_indices",
+            "get_molecule_masks",
+            "molecule_iter"
+        ],
         "Structure comparison" : [
             "average",
             "rmsd",

--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -111,6 +111,7 @@ from .geometry import *
 from .hbond import *
 from .integrity import *
 from .mechanics import *
+from .molecules import *
 from .pseudoknots import *
 from .rdf import *
 from .residues import *

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -606,10 +606,10 @@ class AtomArray(_AtomArrayBase):
     coord : ndarray, dtype=float, shape=(n,3)
         ndarray containing the x, y and z coordinate of the
         atoms.
-    bonds: BondList or None
+    bonds : BondList or None
         A :class:`BondList`, specifying the indices of atoms
         that form a chemical bond.
-    box: ndarray, dtype=float, shape=(3,3) or None
+    box : ndarray, dtype=float, shape=(3,3) or None
         The surrounding box. May represent a MD simulation box
         or a crystallographic unit cell.
     shape : tuple of int

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1600,9 +1600,9 @@ def find_connected(bond_list, uint32 root, bint as_mask=False):
 
 
 cdef _find_connected(bond_list,
-                     uint32 index,
+                     int32 index,
                      uint8[:] is_connected_mask,
-                     uint32[:,:] all_bonds):
+                     int32[:,:] all_bonds):
     if is_connected_mask[index]:
         # This atom has already been visited
         # -> exit condition
@@ -1617,7 +1617,7 @@ cdef _find_connected(bond_list,
             # Ignore padding values
             continue
         _find_connected(
-            bond_list, <uint32>connected_index, is_connected_mask, all_bonds
+            bond_list, connected_index, is_connected_mask, all_bonds
         )
 
     

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1533,7 +1533,7 @@ def _connect_inter_residue(atoms, residue_starts):
 def find_connected(bond_list, uint32 root, bint as_mask=False):
     """
     Get indices to all atoms that are directly or inderectly connected
-    to the atom indicated by the given index.
+    to the root atom indicated by the given index.
 
     An atom is *connected* to the `root` atom, if that atom is reachable
     by traversing an arbitrary number of bonds, starting from the
@@ -1579,38 +1579,45 @@ def find_connected(bond_list, uint32 root, bint as_mask=False):
     >>> print(find_connected(bonds, 3))
     [3]
     """
+    all_bonds, _ = bond_list.get_all_bonds()
+
     if root >= bond_list.get_atom_count():
         raise ValueError(
             f"Root atom index {root} is out of bounds for bond list "
             f"representing {bond_list.get_atom_count()} atoms"
         )
     
-    cdef uint8[:] all_connected_mask = np.zeros(
+    cdef uint8[:] is_connected_mask = np.zeros(
         bond_list.get_atom_count(), dtype=np.uint8
     )
-    # Find connections in a recursive way
-    _find_connected(bond_list, root, all_connected_mask)
+    # Find connections in a recursive way,
+    # by visiting all atoms that are reachable by a bonds
+    _find_connected(bond_list, root, is_connected_mask, all_bonds)
     if as_mask:
-        return all_connected_mask
+        return is_connected_mask
     else:
-        return np.where(np.asarray(all_connected_mask))[0]
+        return np.where(np.asarray(is_connected_mask))[0]
 
 
 cdef _find_connected(bond_list,
-                     uint32 root,
-                     uint8[:] all_connected_mask):
-    if all_connected_mask[root]:
-        # Connections for this atom habe already been calculated
+                     uint32 index,
+                     uint8[:] is_connected_mask,
+                     uint32[:,:] all_bonds):
+    if is_connected_mask[index]:
+        # This atom has already been visited
         # -> exit condition
         return
-    all_connected_mask[root] = True
+    is_connected_mask[index] = True
     
-    bonds, _ = bond_list.get_bonds(root)
-    cdef uint32[:] connected = bonds
-    cdef int32 i
-    cdef uint32 atom_index
-    for i in range(connected.shape[0]):
-        atom_index = connected[i]
-        _find_connected(bond_list, atom_index, all_connected_mask)
+    cdef int32 j
+    cdef int32 connected_index
+    for j in range(all_bonds.shape[1]):
+        connected_index = all_bonds[index, j]
+        if connected_index == -1:
+            # Ignore padding values
+            continue
+        _find_connected(
+            bond_list, <uint32>connected_index, is_connected_mask, all_bonds
+        )
 
     

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -114,11 +114,10 @@ def chain_iter(array):
     array : AtomArray or AtomArrayStack
         The atom array (stack) to iterate over.
         
-    Returns
-    -------
-    count : generator of AtomArray or AtomArrayStack
-        A generator of subarrays or substacks (dependent on the input
-        type) containing each chain of the input `array`.
+    Yields
+    ------
+    chain : AtomArray or AtomArrayStack
+        A single chain of the input `array`.
     
     See also
     --------

--- a/src/biotite/structure/molecules.py
+++ b/src/biotite/structure/molecules.py
@@ -1,0 +1,352 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+"""
+This module provides utility for separating structures into single
+molecules.
+"""
+
+__name__ = "biotite.structure"
+__author__ = "Patrick Kunzmann"
+__all__ = ["get_molecule_indices", "get_molecule_masks", "molecule_iter"]
+
+import numpy as np
+from .atoms import AtomArray, AtomArrayStack
+from .bonds import BondList, find_connected
+
+
+def get_molecule_indices(array):
+    """
+    Get an index array for each molecule in the given structure.
+
+    A molecule is defined as a group of atoms that are directly or
+    indirectly connected via covalent bonds.
+    In this function a single atom, that has no connection to any other
+    atom (e.g. an ion), also qualifies as a molecule.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack or BondList
+        The input structure with an associated :class:`BondList`.
+        Alternatively, the :class:`BondList` can be directly supplied.
+    
+    Returns
+    -------
+    indices : list of ndarray, dtype=int
+        Each element in the list is an index array referring to the
+        atoms of a single molecule.
+        Consequently, the length of this list is equal to the number of
+        molecules in the input `array`.
+    
+    See also
+    --------
+    get_molecule_masks
+    molecule_iter
+
+    Example
+    -------
+    Get an :class:`AtomArray` for ATP and show that it is a single
+    molecule:
+
+    >>> atp = residue("ATP")
+    >>> indices = get_molecule_indices(atp)
+    >>> print(len(indices))
+    1
+
+    Separate ATP into two molecules by breaking the glycosidic bond
+    to the triphosphate:
+
+    >>> i, j = np.where(np.isin(atp.atom_name, ("O5'", "PA")))[0]
+    >>> atp.bonds.remove_bond(i, j)
+    >>> indices = get_molecule_indices(atp)
+    >>> print(len(indices))
+    2
+    >>> print(atp[indices[0]])
+    HET         0  ATP PG     P         1.200   -0.226   -6.850
+    HET         0  ATP O1G    O         1.740    1.140   -6.672
+    HET         0  ATP O2G    O         2.123   -1.036   -7.891
+    HET         0  ATP O3G    O        -0.302   -0.139   -7.421
+    HET         0  ATP PB     P         0.255   -0.130   -4.446
+    HET         0  ATP O1B    O         0.810    1.234   -4.304
+    HET         0  ATP O2B    O        -1.231   -0.044   -5.057
+    HET         0  ATP O3B    O         1.192   -0.990   -5.433
+    HET         0  ATP PA     P        -0.745    0.068   -2.071
+    HET         0  ATP O1A    O        -2.097    0.143   -2.669
+    HET         0  ATP O2A    O        -0.125    1.549   -1.957
+    HET         0  ATP O3A    O         0.203   -0.840   -3.002
+    HET         0  ATP HOG2   H         2.100   -0.546   -8.725
+    HET         0  ATP HOG3   H        -0.616   -1.048   -7.522
+    HET         0  ATP HOB2   H        -1.554   -0.952   -5.132
+    HET         0  ATP HOA2   H         0.752    1.455   -1.563
+    >>> print(atp[indices[1]])
+    HET         0  ATP O5'    O        -0.844   -0.587   -0.604
+    HET         0  ATP C5'    C        -1.694    0.260    0.170
+    HET         0  ATP C4'    C        -1.831   -0.309    1.584
+    HET         0  ATP O4'    O        -0.542   -0.355    2.234
+    HET         0  ATP C3'    C        -2.683    0.630    2.465
+    HET         0  ATP O3'    O        -4.033    0.165    2.534
+    HET         0  ATP C2'    C        -2.011    0.555    3.856
+    HET         0  ATP O2'    O        -2.926    0.043    4.827
+    HET         0  ATP C1'    C        -0.830   -0.418    3.647
+    HET         0  ATP N9     N         0.332    0.015    4.425
+    HET         0  ATP C8     C         1.302    0.879    4.012
+    HET         0  ATP N7     N         2.184    1.042    4.955
+    HET         0  ATP C5     C         1.833    0.300    6.033
+    HET         0  ATP C6     C         2.391    0.077    7.303
+    HET         0  ATP N6     N         3.564    0.706    7.681
+    HET         0  ATP N1     N         1.763   -0.747    8.135
+    HET         0  ATP C2     C         0.644   -1.352    7.783
+    HET         0  ATP N3     N         0.088   -1.178    6.602
+    HET         0  ATP C4     C         0.644   -0.371    5.704
+    HET         0  ATP H5'1   H        -2.678    0.312   -0.296
+    HET         0  ATP H5'2   H        -1.263    1.259    0.221
+    HET         0  ATP H4'    H        -2.275   -1.304    1.550
+    HET         0  ATP H3'    H        -2.651    1.649    2.078
+    HET         0  ATP HO3'   H        -4.515    0.788    3.094
+    HET         0  ATP H2'    H        -1.646    1.537    4.157
+    HET         0  ATP HO2'   H        -3.667    0.662    4.867
+    HET         0  ATP H1'    H        -1.119   -1.430    3.931
+    HET         0  ATP H8     H         1.334    1.357    3.044
+    HET         0  ATP HN61   H         3.938    0.548    8.562
+    HET         0  ATP HN62   H         4.015    1.303    7.064
+    HET         0  ATP H2     H         0.166   -2.014    8.490
+    """
+    if isinstance(array, BondList):
+        bonds = array
+    elif isinstance(array, (AtomArray, AtomArrayStack)):
+        if array.bonds is None:
+            raise ValueError("An associated BondList is required")
+        bonds = array.bonds
+    else:
+        raise TypeError(
+            f"Expected a 'BondList', 'AtomArray' or 'AtomArrayStack', "
+            f"not '{type(array).__name__}'"
+        )
+    
+    molecule_indices = []
+    visited_mask = np.zeros(bonds.get_atom_count(), dtype=bool)
+    while not visited_mask.all():
+        root = np.argmin(visited_mask)
+        connected = find_connected(bonds, root)
+        visited_mask[connected] = True
+        molecule_indices.append(connected)
+    return molecule_indices
+
+
+def get_molecule_masks(array):
+    """
+    Get a boolean mask for each molecule in the given structure.
+
+    A molecule is defined as a group of atoms that are directly or
+    indirectly connected via covalent bonds.
+    In this function a single atom, that has no connection to any other
+    atom (e.g. an ion), also qualifies as a molecule.
+
+    Parameters
+    ----------
+    array : AtomArray, shape=(n,) or AtomArrayStack, shape=(m,n) or BondList
+        The input structure with an associated :class:`BondList`.
+        Alternatively, the :class:`BondList` can be directly supplied.
+    
+    Returns
+    -------
+    masks : ndarray, shape=(k,n), dtype=bool, 
+        Each element in the array is a boolean mask referring to the
+        atoms of a single molecule.
+        Consequently, the length of this list is equal to the number of
+        molecules in the input `array`.
+    
+    See also
+    --------
+    get_molecule_indices
+    molecule_iter
+
+    Example
+    -------
+    Get an :class:`AtomArray` for ATP and show that it is a single
+    molecule:
+
+    >>> atp = residue("ATP")
+    >>> masks = get_molecule_masks(atp)
+    >>> print(len(masks))
+    1
+
+    Separate ATP into two molecules by breaking the glycosidic bond
+    to the triphosphate:
+
+    >>> i, j = np.where(np.isin(atp.atom_name, ("O5'", "PA")))[0]
+    >>> atp.bonds.remove_bond(i, j)
+    >>> masks = get_molecule_masks(atp)
+    >>> print(len(masks))
+    2
+    >>> print(atp[masks[0]])
+    HET         0  ATP PG     P         1.200   -0.226   -6.850
+    HET         0  ATP O1G    O         1.740    1.140   -6.672
+    HET         0  ATP O2G    O         2.123   -1.036   -7.891
+    HET         0  ATP O3G    O        -0.302   -0.139   -7.421
+    HET         0  ATP PB     P         0.255   -0.130   -4.446
+    HET         0  ATP O1B    O         0.810    1.234   -4.304
+    HET         0  ATP O2B    O        -1.231   -0.044   -5.057
+    HET         0  ATP O3B    O         1.192   -0.990   -5.433
+    HET         0  ATP PA     P        -0.745    0.068   -2.071
+    HET         0  ATP O1A    O        -2.097    0.143   -2.669
+    HET         0  ATP O2A    O        -0.125    1.549   -1.957
+    HET         0  ATP O3A    O         0.203   -0.840   -3.002
+    HET         0  ATP HOG2   H         2.100   -0.546   -8.725
+    HET         0  ATP HOG3   H        -0.616   -1.048   -7.522
+    HET         0  ATP HOB2   H        -1.554   -0.952   -5.132
+    HET         0  ATP HOA2   H         0.752    1.455   -1.563
+    >>> print(atp[masks[1]])
+    HET         0  ATP O5'    O        -0.844   -0.587   -0.604
+    HET         0  ATP C5'    C        -1.694    0.260    0.170
+    HET         0  ATP C4'    C        -1.831   -0.309    1.584
+    HET         0  ATP O4'    O        -0.542   -0.355    2.234
+    HET         0  ATP C3'    C        -2.683    0.630    2.465
+    HET         0  ATP O3'    O        -4.033    0.165    2.534
+    HET         0  ATP C2'    C        -2.011    0.555    3.856
+    HET         0  ATP O2'    O        -2.926    0.043    4.827
+    HET         0  ATP C1'    C        -0.830   -0.418    3.647
+    HET         0  ATP N9     N         0.332    0.015    4.425
+    HET         0  ATP C8     C         1.302    0.879    4.012
+    HET         0  ATP N7     N         2.184    1.042    4.955
+    HET         0  ATP C5     C         1.833    0.300    6.033
+    HET         0  ATP C6     C         2.391    0.077    7.303
+    HET         0  ATP N6     N         3.564    0.706    7.681
+    HET         0  ATP N1     N         1.763   -0.747    8.135
+    HET         0  ATP C2     C         0.644   -1.352    7.783
+    HET         0  ATP N3     N         0.088   -1.178    6.602
+    HET         0  ATP C4     C         0.644   -0.371    5.704
+    HET         0  ATP H5'1   H        -2.678    0.312   -0.296
+    HET         0  ATP H5'2   H        -1.263    1.259    0.221
+    HET         0  ATP H4'    H        -2.275   -1.304    1.550
+    HET         0  ATP H3'    H        -2.651    1.649    2.078
+    HET         0  ATP HO3'   H        -4.515    0.788    3.094
+    HET         0  ATP H2'    H        -1.646    1.537    4.157
+    HET         0  ATP HO2'   H        -3.667    0.662    4.867
+    HET         0  ATP H1'    H        -1.119   -1.430    3.931
+    HET         0  ATP H8     H         1.334    1.357    3.044
+    HET         0  ATP HN61   H         3.938    0.548    8.562
+    HET         0  ATP HN62   H         4.015    1.303    7.064
+    HET         0  ATP H2     H         0.166   -2.014    8.490
+    """
+    if isinstance(array, BondList):
+        bonds = array
+    elif isinstance(array, (AtomArray, AtomArrayStack)):
+        if array.bonds is None:
+            raise ValueError("An associated BondList is required")
+        bonds = array.bonds
+    else:
+        raise TypeError(
+            f"Expected a 'BondList', 'AtomArray' or 'AtomArrayStack', "
+            f"not '{type(array).__name__}'"
+        )
+    
+    molecule_indices = get_molecule_indices(bonds)
+    molecule_masks = np.zeros(
+        (len(molecule_indices), bonds.get_atom_count()),
+        dtype=bool
+    )
+    for i in range(len(molecule_indices)):
+        molecule_masks[i, molecule_indices[i]] = True
+    return molecule_masks
+
+
+def molecule_iter(array):
+    """
+    Iterate over each molecule in a input structure.
+
+    A molecule is defined as a group of atoms that are directly or
+    indirectly connected via covalent bonds.
+    In this function a single atom, that has no connection to any other
+    atom (e.g. an ion), also qualifies as a molecule.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The input structure with an associated :class:`BondList`.
+    
+    Yields
+    ------
+    molecule : AtomArray or AtomArrayStack
+        A single molecule of the input `array`.
+    
+    See also
+    --------
+    get_molecule_indices
+    get_molecule_masks
+
+    Example
+    -------
+    Get an :class:`AtomArray` for ATP and break it into two molecules
+    at the glycosidic bond to the triphosphate:
+
+    >>> atp = residue("ATP")
+    >>> i, j = np.where(np.isin(atp.atom_name, ("O5'", "PA")))[0]
+    >>> atp.bonds.remove_bond(i, j)
+    >>> for molecule in molecule_iter(atp):
+    ...     print("New molecule")
+    ...     print(molecule)
+    ...     print()
+    New molecule
+    HET         0  ATP PG     P         1.200   -0.226   -6.850
+    HET         0  ATP O1G    O         1.740    1.140   -6.672
+    HET         0  ATP O2G    O         2.123   -1.036   -7.891
+    HET         0  ATP O3G    O        -0.302   -0.139   -7.421
+    HET         0  ATP PB     P         0.255   -0.130   -4.446
+    HET         0  ATP O1B    O         0.810    1.234   -4.304
+    HET         0  ATP O2B    O        -1.231   -0.044   -5.057
+    HET         0  ATP O3B    O         1.192   -0.990   -5.433
+    HET         0  ATP PA     P        -0.745    0.068   -2.071
+    HET         0  ATP O1A    O        -2.097    0.143   -2.669
+    HET         0  ATP O2A    O        -0.125    1.549   -1.957
+    HET         0  ATP O3A    O         0.203   -0.840   -3.002
+    HET         0  ATP HOG2   H         2.100   -0.546   -8.725
+    HET         0  ATP HOG3   H        -0.616   -1.048   -7.522
+    HET         0  ATP HOB2   H        -1.554   -0.952   -5.132
+    HET         0  ATP HOA2   H         0.752    1.455   -1.563
+    <BLANKLINE>
+    New molecule
+    HET         0  ATP O5'    O        -0.844   -0.587   -0.604
+    HET         0  ATP C5'    C        -1.694    0.260    0.170
+    HET         0  ATP C4'    C        -1.831   -0.309    1.584
+    HET         0  ATP O4'    O        -0.542   -0.355    2.234
+    HET         0  ATP C3'    C        -2.683    0.630    2.465
+    HET         0  ATP O3'    O        -4.033    0.165    2.534
+    HET         0  ATP C2'    C        -2.011    0.555    3.856
+    HET         0  ATP O2'    O        -2.926    0.043    4.827
+    HET         0  ATP C1'    C        -0.830   -0.418    3.647
+    HET         0  ATP N9     N         0.332    0.015    4.425
+    HET         0  ATP C8     C         1.302    0.879    4.012
+    HET         0  ATP N7     N         2.184    1.042    4.955
+    HET         0  ATP C5     C         1.833    0.300    6.033
+    HET         0  ATP C6     C         2.391    0.077    7.303
+    HET         0  ATP N6     N         3.564    0.706    7.681
+    HET         0  ATP N1     N         1.763   -0.747    8.135
+    HET         0  ATP C2     C         0.644   -1.352    7.783
+    HET         0  ATP N3     N         0.088   -1.178    6.602
+    HET         0  ATP C4     C         0.644   -0.371    5.704
+    HET         0  ATP H5'1   H        -2.678    0.312   -0.296
+    HET         0  ATP H5'2   H        -1.263    1.259    0.221
+    HET         0  ATP H4'    H        -2.275   -1.304    1.550
+    HET         0  ATP H3'    H        -2.651    1.649    2.078
+    HET         0  ATP HO3'   H        -4.515    0.788    3.094
+    HET         0  ATP H2'    H        -1.646    1.537    4.157
+    HET         0  ATP HO2'   H        -3.667    0.662    4.867
+    HET         0  ATP H1'    H        -1.119   -1.430    3.931
+    HET         0  ATP H8     H         1.334    1.357    3.044
+    HET         0  ATP HN61   H         3.938    0.548    8.562
+    HET         0  ATP HN62   H         4.015    1.303    7.064
+    HET         0  ATP H2     H         0.166   -2.014    8.490
+    <BLANKLINE>
+    """
+    if array.bonds is None:
+        raise ValueError("An associated BondList is required")
+    bonds = array.bonds
+    
+    visited_mask = np.zeros(bonds.get_atom_count(), dtype=bool)
+    while not visited_mask.all():
+        root = np.argmin(visited_mask)
+        connected = find_connected(bonds, root)
+        visited_mask[connected] = True
+        yield array[..., connected]

--- a/src/biotite/structure/residues.py
+++ b/src/biotite/structure/residues.py
@@ -554,11 +554,10 @@ def residue_iter(array):
     array : AtomArray or AtomArrayStack
         The atom array (stack) to iterate over.
         
-    Returns
-    -------
-    count : generator of AtomArray or AtomArrayStack
-        A generator of subarrays or substacks (dependent on the input
-        type) containing each residue of the input `array`.
+    Yields
+    ------
+    chain : AtomArray or AtomArrayStack
+        A single residue of the input `array`.
     
     Examples
     --------

--- a/tests/structure/test_molecules.py
+++ b/tests/structure/test_molecules.py
@@ -1,0 +1,126 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+import numpy as np
+import pytest
+import biotite.structure as struc
+import biotite.structure.info as info
+
+
+@pytest.fixture
+def array():
+    """
+    Create an :class:`AtomArray` containing a lot of different
+    molecules.
+    The atoms that belong to a single molecule are not adjacent in the
+    :class:`AtomArray`, but a are shuffled in random positions of the
+    :class:`AtomArray`.
+    """
+    MOL_NAMES = [
+        "ARG", # Molecule with multiple branches
+        "TRP", # Molecule with a cycle
+        "GLC", # Molecule with a cycle
+        "NA",  # A single atom
+        "ATP"  # Larger molecule
+    ]
+    N_MOLECULES = 20
+
+    np.random.seed(0)
+    
+    atom_array = struc.AtomArray(0)
+    for i, mol_name in enumerate(np.random.choice(MOL_NAMES, N_MOLECULES)):
+        molecule = info.residue(mol_name)
+        molecule.res_id[:] = i+1
+        atom_array += molecule
+    
+    reordered_indices = np.random.choice(
+        np.arange(atom_array.array_length()),
+        atom_array.array_length(),
+        replace=False
+    )
+    atom_array = atom_array[reordered_indices]
+
+    return atom_array
+
+
+@pytest.mark.parametrize(
+    "as_stack, as_bonds",
+    [
+        (False, False),
+        (True,  False),
+        (False, True )
+    ]
+)
+def test_get_molecule_indices(array, as_stack, as_bonds):
+    """
+    Multiple tests to :func:`get_molecule_indices()` on a
+    :class:`AtomArray` of random molecules.
+    """
+    if as_stack:
+        array = struc.stack([array])
+    
+    if as_bonds:
+        test_indices = struc.get_molecule_indices(array.bonds)
+    else:
+        test_indices = struc.get_molecule_indices(array)
+    
+    seen_atoms = 0
+    for indices in test_indices:
+        molecule = array[..., indices]
+        # Assert that all residue IDs in the molecule are equal
+        # -> all atoms from the same molecule
+        assert (molecule.res_id == molecule.res_id[0]).all()
+        # Assert that no atom is missing from the molecule
+        assert molecule.array_length() \
+            == info.residue(molecule.res_name[0]).array_length()
+        seen_atoms += molecule.array_length()
+    # Assert that all molecules are fond
+    assert seen_atoms == array.array_length()
+
+
+@pytest.mark.parametrize(
+    "as_stack, as_bonds",
+    [
+        (False, False),
+        (True,  False),
+        (False, True )
+    ]
+)
+def test_get_molecule_masks(array, as_stack, as_bonds):
+    """
+    Test whether the masks returned by :func:`get_molecule_masks()`
+    point to the same atoms as the indices returned by
+    :func:`get_molecule_indices()`.
+    """
+    if as_stack:
+        array = struc.stack([array])
+    
+    if as_bonds:
+        ref_indices = struc.get_molecule_indices(array.bonds)
+        test_masks = struc.get_molecule_masks(array.bonds)
+    else:
+        ref_indices = struc.get_molecule_indices(array)
+        test_masks = struc.get_molecule_masks(array)
+    
+    for i in range(len(test_masks)):
+        # Assert that the mask is 'True' for all indices
+        # and that these 'True' values are the only ones in the mask
+        assert (test_masks[i, ref_indices[i]] == True).all()
+        assert np.count_nonzero(test_masks[i]) == len(ref_indices[i])
+
+
+@pytest.mark.parametrize("as_stack", (False, True))
+def test_molecule_iter(array, as_stack):
+    """
+    Test whether :func:`molecule_iter()` gives the same molecules as
+    pointed by :func:`get_molecule_indices()`.
+    """
+    if as_stack:
+        array = struc.stack([array])
+
+    ref_indices = struc.get_molecule_indices(array)
+    test_iterator = struc.molecule_iter(array)
+
+    for i, molecule in enumerate(test_iterator):
+        assert molecule == array[..., ref_indices[i]]


### PR DESCRIPTION
This PR adds functions to work with atoms on molecule-level, i.e. groups of atoms that are connected via bonds in a `BondList`:

- `get_molecule_indices()`
- `get_molecule_masks()`
- `molecule_iter()`

Furthermore, the performance of `structure.find_connected()` is increased.