### PR TITLE
Fix unordered bond pairs after indexing BondList with unordered array

### DIFF
--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -849,7 +849,6 @@ class BondList(Copyable):
         return merged_bond_list
 
     def __getitem__(self, index):
-
         ## Variables for both, integer and boolean index arrays
         cdef uint32[:,:] all_bonds_v
         cdef int32 new_index
@@ -905,9 +904,14 @@ class BondList(Copyable):
                         # At least one atom in bond is not included
                         # -> remove bond
                         removal_filter_v[i] = False
+                
                 copy._bonds = copy._bonds[
                     removal_filter.astype(bool, copy=False)
                 ]
+                # Again, sort indices per bond
+                # as the correct order is not guaranteed anymore
+                # for unsorted index arrays
+                copy._bonds[:,:2] = np.sort(copy._bonds[:,:2], axis=1)
                 copy._atom_count = len(index)
                 copy._max_bonds_per_atom = copy._get_max_bonds_per_atom()
                 return copy

--- a/tests/structure/test_bonds.py
+++ b/tests/structure/test_bonds.py
@@ -366,11 +366,11 @@ def test_unsorted_array_indexing():
     # Use a set for simpler comparison between the sorted and unsorted variant
     # Omit the bond type -> 'bonds.as_array()[:, :2]'
     test_integer_pairs = set([
-        (unsorted_indexed_integers[i], unsorted_indexed_integers[j])
+        frozenset((unsorted_indexed_integers[i], unsorted_indexed_integers[j]))
         for i, j in test_bonds.as_array()[:, :2]
     ])
     ref_integer_pairs = set([
-        (sorted_indexed_integers[i], sorted_indexed_integers[j])
+        frozenset((sorted_indexed_integers[i], sorted_indexed_integers[j]))
         for i, j in ref_bonds.as_array()[:, :2]
     ])
 
@@ -379,6 +379,10 @@ def test_unsorted_array_indexing():
     assert test_bonds.as_array().tolist() != ref_bonds.as_array().tolist()
     # But the actual bonded 'atom' pairs, should still be the same
     assert test_integer_pairs == ref_integer_pairs
+    # Additionally, check whether in each bond the lower atom index 
+    # comes first
+    for i, j, _ in test_bonds.as_array():
+        assert i < j
 
 
 def test_atom_array_consistency():


### PR DESCRIPTION
After indexing a `BondList` with an undordered index array, the new `BondList` may contain bonds, where the atom indices are not sorted anymore. However, many methods of `BondList` rely on the assumption, that the indices in each bond are sorted. Therefore, these methods may return wrong results with such an invalid `BondList`.

This PR fixes this issue, by sorting all bonds after indexing with an index array.