### PR TITLE
Fix bugs in `base_pairs()`

### DIFF
--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -1199,7 +1199,7 @@ def _match_base(nucleotide, min_atoms_per_base):
     )
     nucleotide_matched = nucleotide_matched[unique_indices]
     # Only continue if minimum number of matching atoms is reached
-    if len(nucleotide_matched < min_atoms_per_base):
+    if len(nucleotide_matched) < min_atoms_per_base:
         return None
     # Reorder the atoms of the nucleotide to obtain the standard RCSB
     # PDB atom order.

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -1200,6 +1200,12 @@ def _match_base(nucleotide, min_atoms_per_base):
     nucleotide_matched = nucleotide_matched[unique_indices]
     # Only continue if minimum number of matching atoms is reached
     if len(nucleotide_matched) < min_atoms_per_base:
+        warnings.warn(
+            f"Nucleotide with res_id {nucleotide.res_id[0]} and "
+            f"chain_id {nucleotide.chain_id[0]} has less than 3 base "
+            f"atoms, unable to check for base pair.",
+            IncompleteStructureWarning
+        )
         return None
     # Reorder the atoms of the nucleotide to obtain the standard RCSB
     # PDB atom order.

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -1198,6 +1198,9 @@ def _match_base(nucleotide, min_atoms_per_base):
         nucleotide_matched.atom_name, return_index=True
     )
     nucleotide_matched = nucleotide_matched[unique_indices]
+    # Only continue if minimum number of matching atoms is reached
+    if len(nucleotide_matched < min_atoms_per_base):
+        return None
     # Reorder the atoms of the nucleotide to obtain the standard RCSB
     # PDB atom order.
     nucleotide_matched = nucleotide_matched[

--- a/src/biotite/structure/basepairs.py
+++ b/src/biotite/structure/basepairs.py
@@ -966,10 +966,10 @@ def base_pairs(atom_array, min_atoms_per_base = 3, unique = True):
         basepair_array = np.delete(basepair_array, to_remove, axis=0)
 
     # Remap values to original atom array
-    basepair_array = np.where(boolean_mask)[0][basepair_array]
-    for i, row in enumerate(basepair_array):
-        basepair_array[i] = get_residue_starts_for(atom_array, row)
-
+    if len(basepair_array) > 0:
+        basepair_array = np.where(boolean_mask)[0][basepair_array]
+        for i, row in enumerate(basepair_array):
+            basepair_array[i] = get_residue_starts_for(atom_array, row)
     return basepair_array
 
 

--- a/tests/structure/test_basepairs.py
+++ b/tests/structure/test_basepairs.py
@@ -4,6 +4,7 @@
 
 import pytest
 import json
+import warnings
 import numpy as np
 import biotite.structure as struc
 import biotite.structure.io as strucio
@@ -146,7 +147,8 @@ def test_base_pairs_incomplete_structure(nuc_sample_array):
             ['N1', 'C2', 'N3', 'C4', 'C5', 'C6', 'N7', 'C8', 'N9', 'O2']
         )
     ]
-    assert len(struc.base_pairs(nuc_sample_array)) == 0
+    with pytest.warns(struc.IncompleteStructureWarning):
+        assert len(struc.base_pairs(nuc_sample_array)) == 0
 
 @pytest.mark.parametrize("seed", range(10))
 def test_base_pairs_reordered(nuc_sample_array, seed):
@@ -202,7 +204,8 @@ def test_map_nucleotide():
     assert m7g_tuple[0] in purines
     assert m7g_tuple[1] == False
 
-    assert struc.map_nucleotide(residue('ALA')) == (None, False)
+    with pytest.warns(struc.IncompleteStructureWarning):
+        assert struc.map_nucleotide(residue('ALA')) == (None, False)
 
 
 def get_reference(pdb_id, suffix):

--- a/tests/structure/test_basepairs.py
+++ b/tests/structure/test_basepairs.py
@@ -131,6 +131,20 @@ def test_base_pairs_reverse_no_hydrogen(nuc_sample_array, basepairs):
         reversed_nuc_sample_array[computed_basepairs].res_id, basepairs
     )
 
+def test_base_pairs_incomplete_structure(nuc_sample_array):
+    """
+    Remove atoms belonging to the pyrimidine / purine ring of each base.
+    Test that no base pairs are detected as all bases have less than 3 
+    common atoms with their implemented reference base. Previously, 
+    input like this resulted in an exception.
+    """
+    nuc_sample_array = nuc_sample_array[
+        ~ np.isin(
+            nuc_sample_array.atom_name, 
+            ['N1', 'C2', 'N3', 'C4', 'C5', 'C6', 'N7', 'C8', 'N9']
+        )
+    ]
+    assert len(struc.base_pairs(nuc_sample_array)) == 0
 
 @pytest.mark.parametrize("seed", range(10))
 def test_base_pairs_reordered(nuc_sample_array, seed):

--- a/tests/structure/test_basepairs.py
+++ b/tests/structure/test_basepairs.py
@@ -134,12 +134,12 @@ def test_base_pairs_reverse_no_hydrogen(nuc_sample_array, basepairs):
 def test_base_pairs_incomplete_structure(nuc_sample_array):
     """
     Remove atoms belonging to the pyrimidine / purine ring of each base
-    and the ``O2`` contained in pyrimidine bases.
+    and the ``O2`` atom contained in pyrimidine bases.
 
     Test that no base pairs are detected as all bases have less than 3 
-    common atoms with their implemented reference base. Previously, 
-    input like this resulted in an exception.
+    common atoms with their implemented reference base. 
     """
+    
     nuc_sample_array = nuc_sample_array[
         ~ np.isin(
             nuc_sample_array.atom_name, 

--- a/tests/structure/test_basepairs.py
+++ b/tests/structure/test_basepairs.py
@@ -133,7 +133,9 @@ def test_base_pairs_reverse_no_hydrogen(nuc_sample_array, basepairs):
 
 def test_base_pairs_incomplete_structure(nuc_sample_array):
     """
-    Remove atoms belonging to the pyrimidine / purine ring of each base.
+    Remove atoms belonging to the pyrimidine / purine ring of each base
+    and the ``O2`` contained in pyrimidine bases.
+
     Test that no base pairs are detected as all bases have less than 3 
     common atoms with their implemented reference base. Previously, 
     input like this resulted in an exception.
@@ -141,7 +143,7 @@ def test_base_pairs_incomplete_structure(nuc_sample_array):
     nuc_sample_array = nuc_sample_array[
         ~ np.isin(
             nuc_sample_array.atom_name, 
-            ['N1', 'C2', 'N3', 'C4', 'C5', 'C6', 'N7', 'C8', 'N9']
+            ['N1', 'C2', 'N3', 'C4', 'C5', 'C6', 'N7', 'C8', 'N9', 'O2']
         )
     ]
     assert len(struc.base_pairs(nuc_sample_array)) == 0


### PR DESCRIPTION
This PR fixes the following bugs and adds a test function checking their presence:

- The `min_atoms_per_base` argument was only considered for non-canonical bases. This led to an exception being thrown if no atoms in a base with a canonical residue name matched the corresponding reference base.
- If no base pairs were found, an exception was thrown.