### PR TITLE
Fix #273

### DIFF
--- a/src/biotite/application/application.py
+++ b/src/biotite/application/application.py
@@ -111,7 +111,6 @@ class Application(metaclass=abc.ABCMeta):
         This can only be done from the *CREATED* state.
         """
         self.run()
-        self._start_time = time.time()
         self._state = AppState.RUNNING
     
     @requires_state(AppState.RUNNING | AppState.FINISHED)
@@ -138,6 +137,7 @@ class Application(metaclass=abc.ABCMeta):
         TimeoutError
             If the joining process exceeds the `timeout` value.
         """
+        start_time = time.time()
         time.sleep(self.wait_interval())
         while self.get_app_state() != AppState.FINISHED:
             if timeout is not None and time.time()-self._start_time > timeout:

--- a/src/biotite/application/localapp.py
+++ b/src/biotite/application/localapp.py
@@ -9,8 +9,8 @@ __all__ = ["LocalApp"]
 import abc
 import copy
 from os import chdir, getcwd, remove
-from .application import Application, AppState, requires_state
-from subprocess import Popen, PIPE, SubprocessError
+from .application import Application, AppState, AppStateError, requires_state
+from subprocess import Popen, PIPE, SubprocessError, TimeoutExpired
 
 class LocalApp(Application, metaclass=abc.ABCMeta):
     """
@@ -172,7 +172,7 @@ class LocalApp(Application, metaclass=abc.ABCMeta):
         code : int
             The exit code.
         """
-        return self._code
+        return self._process.returncode
     
     @requires_state(AppState.FINISHED | AppState.JOINED)
     def get_stdout(self):
@@ -216,12 +216,40 @@ class LocalApp(Application, metaclass=abc.ABCMeta):
         if code == None:
             return False
         else:
-            self._code = code
             self._stdout, self._stderr = self._process.communicate()
             return True
     
+    @requires_state(AppState.RUNNING | AppState.FINISHED)
+    def join(self, timeout=None):
+        # Override method as repetitive calls of 'is_finished()'
+        # are not necessary as 'communicate()' already waits for the
+        # finished application
+        try:
+            self._stdout, self._stderr = self._process.communicate(
+                timeout=timeout
+            )
+        except TimeoutExpired:
+            self.cancel()
+            raise TimeoutError(
+                f"The application expired its timeout ({timeout:.1f} s)"
+            )
+        self._state = AppState.FINISHED
+        
+        try:
+            self.evaluate()
+        except AppStateError:
+            raise
+        except:
+            self._state = AppState.CANCELLED
+            raise
+        else:
+            self._state = AppState.JOINED
+        self.clean_up()
+    
+    
     def wait_interval(self):
-        return 0.01
+        # Not used in this implementation of 'join()'
+        raise NotImplementedError()
     
     def evaluate(self):
         super().evaluate()

--- a/src/biotite/application/localapp.py
+++ b/src/biotite/application/localapp.py
@@ -8,8 +8,6 @@ __all__ = ["LocalApp"]
 
 import abc
 import copy
-import time
-import io
 from os import chdir, getcwd, remove
 from .application import Application, AppState, requires_state
 from subprocess import Popen, PIPE, SubprocessError
@@ -35,8 +33,6 @@ class LocalApp(Application, metaclass=abc.ABCMeta):
         self._options = []
         self._exec_dir = getcwd()
         self._process = None
-        self._stdout_file_path = None
-        self._stdout_file = None
         self._command = None
     
     @requires_state(AppState.CREATED)

--- a/src/biotite/application/mafft/app.py
+++ b/src/biotite/application/mafft/app.py
@@ -59,6 +59,7 @@ class MafftApp(MSAApp):
     
     def run(self):
         args = [
+            "--quiet",
             "--auto",
             "--treeout",
             # Get the reordered alignment in order for

--- a/src/biotite/application/muscle/app.py
+++ b/src/biotite/application/muscle/app.py
@@ -66,6 +66,7 @@ class MuscleApp(MSAApp):
     
     def run(self):
         args = [
+            "-quiet",
             "-in",    self.get_input_file_path(),
             "-out",   self.get_output_file_path(),
             "-tree1", self._out_tree1_file.name,


### PR DESCRIPTION
This PR fixes #273 by introducing the following changes:

- `LocalApp.join()` will use `subprocess.communicate()` which continuously reads the output until the application finishes
- `MuscleApp` and `MafftApp` will use the `-quiet` parameter to stop it from outputting progress messages to *stderr*