### PR TITLE
Add 'NetworkX' package as dependency

### DIFF
--- a/doc/examples/scripts/sequence/gpcr_evolution.py
+++ b/doc/examples/scripts/sequence/gpcr_evolution.py
@@ -76,51 +76,9 @@ distances = 1 - align.get_pairwise_sequence_identity(
 )
 # Create tree via neighbor joining
 tree = phylo.neighbor_joining(distances)
-
-# Convert the Biotite 'Tree' object into a NetworkX 'Graph' object
-# via a recursive function
-# Since NetworkX has no dedicated class for nodes, but accepts any
-# immutable Python object, the reference index of the node is used for
-# this
-def convert_node(graph, tree_node):
-    """
-    Add a tree node to a graph.
-
-    Parameters
-    ----------
-    graph : Graph
-        The graph where the node should be added.
-    tree_node : Node
-        The node to be added.
-    
-    Returns
-    -------
-    node_id : int or tuple
-        The identifier of the added node in the graph.
-        If the node is a leaf node, this is the reference index,
-        otherwise this is a tuple, containing the identifier of the
-        child nodes.
-    distance : float
-        The distance of the given node to its parent node.
-    """
-    if tree_node.is_leaf():
-        return tree_node.index, tree_node.distance
-    else:
-        child_ids = []
-        child_distances = []
-        for child_node in tree_node.children:
-            id, dist = convert_node(graph, child_node)
-            child_ids.append(id)
-            child_distances.append(dist)
-        this_id = tuple(child_ids)
-        for id, dist in zip(child_ids, child_distances):
-            # Add connection to children as edge in the graph
-            # Distance is added as attribute
-            graph.add_edge(this_id, id, distance=dist)
-        return this_id, tree_node.distance
-
-graph = nx.Graph()
-convert_node(graph, tree.root)
+# Convert to NetworkX graph
+#For the graph visualization, the edge directions are unnecessary
+graph = tree.as_graph().to_undirected()
 
 fig = plt.figure(figsize=(8.0, 8.0))
 ax = fig.gca()

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,8 @@ setup(
     
     install_requires = ["requests >= 2.12",
                         "numpy >= 1.13",
-                        "msgpack >= 0.5.6"],
+                        "msgpack >= 0.5.6",
+                        "networkx >= 2.0"],
     python_requires = ">=3.6",
     
     tests_require = ["pytest"],

--- a/src/biotite/sequence/phylo/tree.pyx
+++ b/src/biotite/sequence/phylo/tree.pyx
@@ -113,13 +113,14 @@ class Tree(Copyable):
 
         Returns
         -------
-        bond_set : Graph
-            A *NetworkX* :class:`Graph`.
+        bond_set : DiGraph
+            A *NetworkX* directed graph.
             For a leaf node the graph node is its reference index.
             For an intermediate and root node the graph node is a tuple
             containing it children nodes.
             Each edge has a ``"distance"`` attribute depicting the
             distance between the nodes.
+            Each edge starts from the parent ends at its child.
         
         Examples
         --------

--- a/src/biotite/sequence/phylo/tree.pyx
+++ b/src/biotite/sequence/phylo/tree.pyx
@@ -11,6 +11,7 @@ cimport numpy as np
 
 import copy
 import numpy as np
+import networkx as nx
 from ...file import InvalidFileError
 from ...copyable import Copyable
 
@@ -103,6 +104,98 @@ class Tree(Copyable):
     @property
     def leaves(self):
         return copy.copy(self._leaves)
+    
+    def as_graph(self):
+        """
+        as_graph()
+        
+        Obtain a graph representation of the :class:`Tree`.
+
+        Returns
+        -------
+        bond_set : Graph
+            A *NetworkX* :class:`Graph`.
+            For a leaf node the graph node is its reference index.
+            For an intermediate and root node the graph node is a tuple
+            containing it children nodes.
+            Each edge has a ``"distance"`` attribute depicting the
+            distance between the nodes.
+        
+        Examples
+        --------
+
+        >>> leaves = [TreeNode(index=i) for i in range(3)]
+        >>> intermediate = TreeNode([leaves[0], leaves[1]], [2.0, 3.0])
+        >>> root = TreeNode([intermediate, leaves[2]], [1.0, 5.0])
+        >>> tree = Tree(root)
+        >>> graph = tree.as_graph()
+        >>> for node_i, node_j in graph.edges:
+        ...     print(f"{str(node_i):12}  ->  {str(node_j):12}")
+        (0, 1)        ->  0           
+        (0, 1)        ->  1           
+        ((0, 1), 2)   ->  (0, 1)      
+        ((0, 1), 2)   ->  2
+        """
+        cdef tuple children
+        cdef bint children_already_handled
+        cdef TreeNode node, child, parent
+
+        graph = nx.DiGraph()
+        
+        # This dict maps a TreeNode to its corresponding int or tuple
+        cdef dict node_repr = {}
+
+        # A First-In-First-Out queue for iterative handling of each node
+        # Starting with all leaf nodes 
+        cdef list queue = copy.copy(self._leaves)
+        # A set representation of the same queue for efficient
+        # '__contains__()' operation
+        cdef set queue_set = set(self._leaves)
+        while len(queue) > 0:
+            node = queue.pop(0)
+            
+            if node.is_leaf():
+                node_repr[node] = node.index
+            else:
+                children = node.children
+                children_handled = True
+                for child in children:
+                    if child not in node_repr:
+                        children_handled = False
+                # If the node representation of any child of this node
+                # is not calculated yet, put this node to the end of the
+                # queue and handle it later
+                if not children_handled:
+                    queue.append(node)
+                    continue
+                else:
+                    repr = tuple(node_repr[child] for child in children)
+                    node_repr[node] = repr
+                    # Add adges to children in graph
+                    for child in children:
+                        graph.add_edge(
+                            repr, node_repr[child], distance=child.distance
+                        )
+            
+            # This leads finally to termination of the loop:
+            # When the root node is handled the last element in the
+            # queue is handled and no new node is added to the queue
+            if not node.is_root():
+                parent = node.parent
+                # The parent node might be already in the queue from
+                # handling another child node
+                if parent not in queue_set:
+                    queue.append(parent)
+                    queue_set.add(parent)
+            
+            # Node is handled
+            # -> not in 'queue' anymore
+            # -> remove also from 'queue_set'
+            queue_set.remove(node)
+        
+        return graph
+
+        
 
     def get_distance(self, index1, index2, bint topological=False):
         """
@@ -246,9 +339,7 @@ class Tree(Copyable):
 
 cdef class TreeNode:
     """
-    __init__(child1=None, child2=None,
-             child1_distance=None, child2_distance=None,
-             index=None)
+    __init__(children=None, distances=None, index=None)
     
     :class:`TreeNode` objects are part of a rooted tree
     (e.g. alignment guide tree).

--- a/src/biotite/sequence/phylo/tree.pyx
+++ b/src/biotite/sequence/phylo/tree.pyx
@@ -131,9 +131,9 @@ class Tree(Copyable):
         >>> graph = tree.as_graph()
         >>> for node_i, node_j in graph.edges:
         ...     print(f"{str(node_i):12}  ->  {str(node_j):12}")
-        (0, 1)        ->  0           
-        (0, 1)        ->  1           
-        ((0, 1), 2)   ->  (0, 1)      
+        (0, 1)        ->  0
+        (0, 1)        ->  1
+        ((0, 1), 2)   ->  (0, 1)
         ((0, 1), 2)   ->  2
         """
         cdef tuple children

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -21,6 +21,7 @@ import numbers
 import itertools
 from enum import IntEnum
 import numpy as np
+import networkx as nx
 from ..copyable import Copyable
 
 ctypedef np.uint64_t ptr
@@ -349,6 +350,20 @@ class BondList(Copyable):
                 (all_bonds_v[i,0], all_bonds_v[i,1], all_bonds_v[i,2])
             )
         return bond_set
+    
+    def as_graph(self):
+        cdef int i
+
+        cdef uint32[:,:] all_bonds_v = self._bonds
+
+        g = nx.Graph()
+        cdef list edges = [None] * all_bonds_v.shape[0]
+        for i in range(all_bonds_v.shape[0]):
+            edges[i] = (
+                all_bonds_v[i,0], all_bonds_v[i,1], {"bond_type": all_bonds_v[i,2]}
+            )
+        g.add_edges_from(edges)
+        return g
     
     def get_atom_count(self):
         """

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -331,7 +331,7 @@ class BondList(Copyable):
         """
         as_set()
         
-        Obtain a set represetion of the :class:`BondList`.
+        Obtain a set representation of the :class:`BondList`.
 
         Returns
         -------
@@ -352,6 +352,34 @@ class BondList(Copyable):
         return bond_set
     
     def as_graph(self):
+        """
+        as_graph()
+        
+        Obtain a graph representation of the :class:`BondList`.
+
+        Returns
+        -------
+        bond_set : Graph
+            A *NetworkX* :class:`Graph`.
+            The atom indices are nodes, the bonds are edges.
+            Each edge has a ``"bond_type"`` attribute containing the
+            :class:`BondType`.
+        
+        Examples
+        --------
+
+        >>> bond_list = struc.BondList(5, np.array([(1,0,2), (1,3,1), (1,4,1)]))
+        >>> graph = bond_list.as_graph()
+        >>> print(graph.nodes)
+        [0, 1, 3, 4]
+        >>> print(graph.edges)
+        [(0, 1), (1, 3), (1, 4)]
+        >>> for i, j in graph.edges:
+        ...     print(i, j, graph.get_edge_data(i, j))
+        0 1 {'bond_type': <BondType.DOUBLE: 2>}
+        1 3 {'bond_type': <BondType.SINGLE: 1>}
+        1 4 {'bond_type': <BondType.SINGLE: 1>}
+        """
         cdef int i
 
         cdef uint32[:,:] all_bonds_v = self._bonds
@@ -360,7 +388,8 @@ class BondList(Copyable):
         cdef list edges = [None] * all_bonds_v.shape[0]
         for i in range(all_bonds_v.shape[0]):
             edges[i] = (
-                all_bonds_v[i,0], all_bonds_v[i,1], {"bond_type": all_bonds_v[i,2]}
+                all_bonds_v[i,0], all_bonds_v[i,1],
+                {"bond_type": BondType(all_bonds_v[i,2])}
             )
         g.add_edges_from(edges)
         return g

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -368,7 +368,7 @@ class BondList(Copyable):
         Examples
         --------
 
-        >>> bond_list = struc.BondList(5, np.array([(1,0,2), (1,3,1), (1,4,1)]))
+        >>> bond_list = BondList(5, np.array([(1,0,2), (1,3,1), (1,4,1)]))
         >>> graph = bond_list.as_graph()
         >>> print(graph.nodes)
         [0, 1, 3, 4]
@@ -796,7 +796,7 @@ class BondList(Copyable):
     
     def remove_bonds_to(self, int32 atom_index):
         """
-        remove_bonds_to(self, int32 atom_index)
+        remove_bonds_to(self, atom_index)
 
         Remove all bonds from the :class:`BondList` where the given atom
         is involved.
@@ -1723,8 +1723,8 @@ def find_rotatable_bonds(bonds):
     Examples
     --------
 
-    >>> molecule = info.residue("TYR")
-    >>> for i, j, _ in struc.find_rotatable_bonds(molecule.bonds).as_array():
+    >>> molecule = residue("TYR")
+    >>> for i, j, _ in find_rotatable_bonds(molecule.bonds).as_array():
     ...     print(molecule.atom_name[i], molecule.atom_name[j])
     N CA
     CA C

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -819,7 +819,7 @@ class BondList(Copyable):
             if (all_bonds_v[i,0] == index or all_bonds_v[i,1] == index):
                 mask_v[i] = False
         # Remove the bonds
-        self._bonds = self._bonds[mask.astype(np.bool, copy=False)]
+        self._bonds = self._bonds[mask.astype(bool, copy=False)]
         # The maximum bonds per atom is not recalculated
         # (see 'remove_bond()')
 
@@ -854,7 +854,7 @@ class BondList(Copyable):
                         mask_v[i] = False
         
         # Remove the bonds
-        self._bonds = self._bonds[mask.astype(np.bool, copy=False)]
+        self._bonds = self._bonds[mask.astype(bool, copy=False)]
         # The maximum bonds per atom is not recalculated
         # (see 'remove_bond()')
 
@@ -1126,7 +1126,7 @@ class BondList(Copyable):
                 free(<int*>ptrs_v[i])
         
         # Eventually remove redundant bonds
-        self._bonds = self._bonds[redundancy_filter.astype(np.bool,copy=False)]
+        self._bonds = self._bonds[redundancy_filter.astype(bool, copy=False)]
 
 
 cdef uint32 _to_positive_index(int32 index, uint32 array_length) except -1:
@@ -1229,7 +1229,7 @@ def _to_bool_mask(object index, uint32 length):
     Convert an index of arbitrary type into a boolean mask
     with given length.
     """
-    if isinstance(index, np.ndarray) and index.dtype == np.bool:
+    if isinstance(index, np.ndarray) and index.dtype == bool:
         # Index is already boolean mask -> simply return as uint8
         if len(index) != length:
             raise IndexError(

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1600,9 +1600,9 @@ def find_connected(bond_list, uint32 root, bint as_mask=False):
 
 
 cdef _find_connected(bond_list,
-                     uint32 index,
+                     int32 index,
                      uint8[:] is_connected_mask,
-                     uint32[:,:] all_bonds):
+                     int32[:,:] all_bonds):
     if is_connected_mask[index]:
         # This atom has already been visited
         # -> exit condition
@@ -1617,7 +1617,7 @@ cdef _find_connected(bond_list,
             # Ignore padding values
             continue
         _find_connected(
-            bond_list, <uint32>connected_index, is_connected_mask, all_bonds
+            bond_list, connected_index, is_connected_mask, all_bonds
         )
 
     

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1533,7 +1533,7 @@ def _connect_inter_residue(atoms, residue_starts):
 def find_connected(bond_list, uint32 root, bint as_mask=False):
     """
     Get indices to all atoms that are directly or inderectly connected
-    to the atom indicated by the given index.
+    to the root atom indicated by the given index.
 
     An atom is *connected* to the `root` atom, if that atom is reachable
     by traversing an arbitrary number of bonds, starting from the
@@ -1579,38 +1579,45 @@ def find_connected(bond_list, uint32 root, bint as_mask=False):
     >>> print(find_connected(bonds, 3))
     [3]
     """
+    all_bonds, _ = bond_list.get_all_bonds()
+
     if root >= bond_list.get_atom_count():
         raise ValueError(
             f"Root atom index {root} is out of bounds for bond list "
             f"representing {bond_list.get_atom_count()} atoms"
         )
     
-    cdef uint8[:] all_connected_mask = np.zeros(
+    cdef uint8[:] is_connected_mask = np.zeros(
         bond_list.get_atom_count(), dtype=np.uint8
     )
-    # Find connections in a recursive way
-    _find_connected(bond_list, root, all_connected_mask)
+    # Find connections in a recursive way,
+    # by visiting all atoms that are reachable by a bonds
+    _find_connected(bond_list, root, is_connected_mask, all_bonds)
     if as_mask:
-        return all_connected_mask
+        return is_connected_mask
     else:
-        return np.where(np.asarray(all_connected_mask))[0]
+        return np.where(np.asarray(is_connected_mask))[0]
 
 
 cdef _find_connected(bond_list,
-                     uint32 root,
-                     uint8[:] all_connected_mask):
-    if all_connected_mask[root]:
-        # Connections for this atom habe already been calculated
+                     uint32 index,
+                     uint8[:] is_connected_mask,
+                     uint32[:,:] all_bonds):
+    if is_connected_mask[index]:
+        # This atom has already been visited
         # -> exit condition
         return
-    all_connected_mask[root] = True
+    is_connected_mask[index] = True
     
-    bonds, _ = bond_list.get_bonds(root)
-    cdef uint32[:] connected = bonds
-    cdef int32 i
-    cdef uint32 atom_index
-    for i in range(connected.shape[0]):
-        atom_index = connected[i]
-        _find_connected(bond_list, atom_index, all_connected_mask)
+    cdef int32 j
+    cdef int32 connected_index
+    for j in range(all_bonds.shape[1]):
+        connected_index = all_bonds[index, j]
+        if connected_index == -1:
+            # Ignore padding values
+            continue
+        _find_connected(
+            bond_list, <uint32>connected_index, is_connected_mask, all_bonds
+        )
 
     

--- a/src/biotite/structure/io/mmtf/convertfile.pyx
+++ b/src/biotite/structure/io/mmtf/convertfile.pyx
@@ -144,7 +144,7 @@ def get_structure(file, model=None, altloc="first",
     cdef int32 max_atoms_per_res = np.max(atoms_per_res)
     #Create the arrays
     cdef np.ndarray res_names = np.zeros(len(group_list), dtype="U3")
-    cdef np.ndarray hetero_res = np.zeros(len(group_list), dtype=np.bool)
+    cdef np.ndarray hetero_res = np.zeros(len(group_list), dtype=bool)
     cdef np.ndarray atom_names = np.zeros((len(group_list), max_atoms_per_res),
                                           dtype="U6")
     cdef np.ndarray elements = np.zeros((len(group_list), max_atoms_per_res),

--- a/tests/sequence/test_phylo.py
+++ b/tests/sequence/test_phylo.py
@@ -306,10 +306,3 @@ def test_equality(tree):
         ]
     ))
 
-
-def _show_tree(tree):
-    import biotite.sequence.graphics as graphics
-    import matplotlib.pyplot as plt
-    fig, ax = plt.subplots()
-    graphics.plot_dendrogram(ax, tree)
-    plt.show()

--- a/tests/structure/test_bonds.py
+++ b/tests/structure/test_bonds.py
@@ -480,6 +480,11 @@ def test_find_connected(bond_list):
             ("C15",  "S1" ),
             ("N3",   "S1" )
         ]),
+        ("LEO", [
+            ("C3",   "C8" ),
+            ("C6",   "C17"),
+            ("C17",  "C22"),
+        ]),
     ]
 )
 def test_find_rotatable_bonds(res_name, expected_bonds):

--- a/tests/structure/test_bonds.py
+++ b/tests/structure/test_bonds.py
@@ -6,6 +6,7 @@ from os.path import join
 import numpy as np
 import pytest
 import biotite.structure as struc
+import biotite.structure.info as info
 import biotite.structure.io as strucio
 import biotite.structure.io.mmtf as mmtf
 from ..util import data_dir
@@ -400,7 +401,7 @@ def test_atom_array_consistency():
     
     # Some random boolean mask as index,
     # but all bonded atoms are included
-    mask = np.array([1,1,1,1,0,1,0,0,1,1,0,1,1,0,0,1,1,0,1,1], dtype=np.bool)
+    mask = np.array([1,1,1,1,0,1,0,0,1,1,0,1,1,0,0,1,1,0,1,1], dtype=bool)
     masked_ca = ca[mask]
     test_ids = masked_ca.res_id[masked_ca.bonds.as_array()[:,:2].flatten()]
     
@@ -458,3 +459,48 @@ def test_find_connected(bond_list):
     for index in (0,1,2,3,4,6):
         assert struc.find_connected(bond_list, index).tolist() == [0,1,2,3,4,6]
     assert struc.find_connected(bond_list, 5).tolist() == [5]
+
+
+@pytest.mark.parametrize(
+    "res_name, expected_bonds",
+    [
+        # Easy ligand visualization at:
+        # https://www.rcsb.org/ligand/<ABC>
+        ("TYR", [
+            ("N",   "CA" ),
+            ("CA",  "C"  ),
+            ("CA",  "CB" ),
+            ("C",   "OXT"),
+            ("CB",  "CG" ),
+            ("CZ",  "OH" ),
+        ]),
+        ("CEL", [
+            ("C1",   "C4" ),
+            ("C8",   "C11"),
+            ("C15",  "S1" ),
+            ("N3",   "S1" )
+        ]),
+    ]
+)
+def test_find_rotatable_bonds(res_name, expected_bonds):
+    """
+    Check the :func:`find_rotatable_bonds()` function based on
+    known examples.
+    """
+    molecule = info.residue(res_name)
+    
+    ref_bond_set = {
+        tuple(sorted((name_i, name_j))) for name_i, name_j in expected_bonds
+    }
+
+    rotatable_bonds = struc.find_rotatable_bonds(molecule.bonds)
+    test_bond_set = set()
+    for i, j, _ in rotatable_bonds.as_array():
+        test_bond_set.add(
+            tuple(sorted((molecule.atom_name[i], molecule.atom_name[j])))
+        )
+    
+    # Compare with reference bonded atom names
+    assert test_bond_set == ref_bond_set
+    # All rotatable bonds must be single bonds
+    assert np.all(rotatable_bonds.as_array()[:, 2] == struc.BondType.SINGLE)

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -115,8 +115,11 @@ def test_doctest(package_name, context_package_names):
     # More information below
     package = import_module(package_name)
     runner = doctest.DocTestRunner(
-        verbose=False,
-        optionflags=doctest.ELLIPSIS | doctest.REPORT_ONLY_FIRST_FAILURE
+        verbose = False,
+        optionflags = 
+            doctest.ELLIPSIS |
+            doctest.REPORT_ONLY_FIRST_FAILURE |
+            doctest.NORMALIZE_WHITESPACE
     )
     for test in doctest.DocTestFinder(exclude_empty=False).find(
         package, package.__name__,


### PR DESCRIPTION
This PR add the `networkx` package as dependency to *Biotite* and uses it at several places in the source code:

- The new function `structure.find_rotatable_bonds`
- The method `structure.BondList.as_graph()`
- The method `structure.Tree.as_graph()`

*NetworkX* is an well supported, easily installable package that is already used in some examples in the gallery. Therefore, I think it is reasonable to add this package as additional dependency.