### PR TITLE
Add separation between methods in the API reference

### DIFF
--- a/doc/static/biotite.css
+++ b/doc/static/biotite.css
@@ -53,6 +53,13 @@ div.body div.sphinx-sidebar li, div.body .toctree-wrapper li {
 }
 
 
+/* Separation between methods in the API reference */
+.method {
+    border-top: 1px solid #cccccc;
+    padding-top: 30px;
+    padding-bottom: 30px;
+}
+
 
 .sphx-glr-multi-img{
     max-width: 99% !important;

--- a/src/biotite/sequence/seqtypes.py
+++ b/src/biotite/sequence/seqtypes.py
@@ -302,10 +302,29 @@ class NucleotideSequence(Sequence):
     
     @staticmethod
     def unambiguous_alphabet():
+        """
+        Get the unambiguous nucleotide alphabet containing the symbols
+        ``A``,  ``C``,  ``G`` and  ``T``.
+
+        Returns
+        -------
+        alphabet : LetterAlphabet
+            The unambiguous nucleotide alphabet.
+        """
         return NucleotideSequence.alphabet_unamb
     
     @staticmethod
     def ambiguous_alphabet():
+        """
+        Get the ambiguous nucleotide alphabet containing the symbols
+        ``A``,  ``C``,  ``G`` and  ``T`` and symbols describing
+        ambiguous combinations of these.
+
+        Returns
+        -------
+        alphabet : LetterAlphabet
+            The ambiguous nucleotide alphabet.
+        """
         return NucleotideSequence.alphabet_amb
 
 


### PR DESCRIPTION
This PR adds a separator line and a small margin between the list of methods in the API reference section of the documentation. Furthermore it adds docstrings for two functions which have not got one, yet.