### PR TITLE
Include formal bond order in aromatic bond type

### DIFF
--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -55,7 +55,8 @@ class BondType(IntEnum):
     DOUBLE = 2
     TRIPLE = 3
     QUADRUPLE = 4
-    AROMATIC = 5
+    AROMATIC_SINGLE = 5
+    AROMATIC_DOUBLE = 6
 
 
 @cython.boundscheck(False)
@@ -155,12 +156,12 @@ class BondList(Copyable):
     ...     benzene.array_length(),
     ...     np.array([
     ...         # Bonds between carbon atoms in the ring
-    ...         (0,  1, BondType.AROMATIC),
-    ...         (1,  2, BondType.AROMATIC),
-    ...         (2,  3, BondType.AROMATIC),
-    ...         (3,  4, BondType.AROMATIC),
-    ...         (4,  5, BondType.AROMATIC),
-    ...         (5,  0, BondType.AROMATIC),
+    ...         (0,  1, BondType.AROMATIC_SINGLE),
+    ...         (1,  2, BondType.AROMATIC_DOUBLE),
+    ...         (2,  3, BondType.AROMATIC_SINGLE),
+    ...         (3,  4, BondType.AROMATIC_DOUBLE),
+    ...         (4,  5, BondType.AROMATIC_SINGLE),
+    ...         (5,  0, BondType.AROMATIC_DOUBLE),
     ...         # Bonds between carbon and hydrogen
     ...         (0,  6, BondType.SINGLE),
     ...         (1,  7, BondType.SINGLE),
@@ -175,12 +176,12 @@ class BondList(Copyable):
     ...         f"{str(BondType(bond_type))} bond between "
     ...         f"{benzene.atom_name[i]} and {benzene.atom_name[j]}"
     ...     )
-    BondType.AROMATIC bond between C1 and C2
-    BondType.AROMATIC bond between C2 and C3
-    BondType.AROMATIC bond between C3 and C4
-    BondType.AROMATIC bond between C4 and C5
-    BondType.AROMATIC bond between C5 and C6
-    BondType.AROMATIC bond between C1 and C6
+    BondType.AROMATIC_SINGLE bond between C1 and C2
+    BondType.AROMATIC_DOUBLE bond between C2 and C3
+    BondType.AROMATIC_SINGLE bond between C3 and C4
+    BondType.AROMATIC_DOUBLE bond between C4 and C5
+    BondType.AROMATIC_SINGLE bond between C5 and C6
+    BondType.AROMATIC_DOUBLE bond between C1 and C6
     BondType.SINGLE bond between C1 and H1
     BondType.SINGLE bond between C2 and H2
     BondType.SINGLE bond between C3 and H3
@@ -211,8 +212,8 @@ class BondList(Copyable):
     ...         f"{str(BondType(bond_type))} bond between "
     ...         f"{half_benzene.atom_name[i]} and {half_benzene.atom_name[j]}"
     ...     )
-    BondType.AROMATIC bond between C4 and C5
-    BondType.AROMATIC bond between C5 and C6
+    BondType.AROMATIC_DOUBLE bond between C4 and C5
+    BondType.AROMATIC_SINGLE bond between C5 and C6
     BondType.SINGLE bond between C4 and H4
     BondType.SINGLE bond between C5 and H5
     BondType.SINGLE bond between C6 and H6
@@ -521,12 +522,12 @@ class BondList(Copyable):
         ...     12,
         ...     np.array([
         ...         # Bonds between the carbon atoms in the ring
-        ...         (0,  1, BondType.AROMATIC),
-        ...         (1,  2, BondType.AROMATIC),
-        ...         (2,  3, BondType.AROMATIC),
-        ...         (3,  4, BondType.AROMATIC),
-        ...         (4,  5, BondType.AROMATIC),
-        ...         (5,  0, BondType.AROMATIC),
+        ...         (0,  1, BondType.AROMATIC_SINGLE),
+        ...         (1,  2, BondType.AROMATIC_DOUBLE),
+        ...         (2,  3, BondType.AROMATIC_SINGLE),
+        ...         (3,  4, BondType.AROMATIC_DOUBLE),
+        ...         (4,  5, BondType.AROMATIC_SINGLE),
+        ...         (5,  0, BondType.AROMATIC_DOUBLE),
         ...         # Bonds between carbon and hydrogen
         ...         (0,  6, BondType.SINGLE),
         ...         (1,  7, BondType.SINGLE),

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -195,7 +195,7 @@ class BondList(Copyable):
     >>> print(bonds)
     [1 5 6]
     >>> print(types)
-    [5 5 1]
+    [5 6 1]
     >>> print(f"C1 is bonded to {', '.join(benzene.atom_name[bonds])}")
     C1 is bonded to C2, C6, H1
 
@@ -552,12 +552,12 @@ class BondList(Copyable):
          [ 4 -1 -1]
          [ 5 -1 -1]]
         >>> print(types)
-        [[ 5  5  1]
-         [ 5  5  1]
-         [ 5  5  1]
-         [ 5  5  1]
-         [ 5  5  1]
-         [ 5  5  1]
+        [[ 5  6  1]
+         [ 5  6  1]
+         [ 6  5  1]
+         [ 5  6  1]
+         [ 6  5  1]
+         [ 5  6  1]
          [ 1 -1 -1]
          [ 1 -1 -1]
          [ 1 -1 -1]

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -48,7 +48,15 @@ ctypedef fused IndexType:
 
 class BondType(IntEnum):
     """
-    This enum type represents the type of a chemical bond. 
+    This enum type represents the type of a chemical bond.
+
+        - `ANY` - Used if the actual type is unknown
+        - `SINGLE` - Single bond
+        - `DOUBLE` - Double bond
+        - `TRIPLE` - Triple bond
+        - `QUADRUPLE` - A quadruple bond
+        - `AROMATIC_SINGLE` - Aromatic bond with a single formal bond
+        - `AROMATIC_DOUBLE` - Aromatic bond with a double formal bond
     """
     ANY = 0
     SINGLE = 1

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -403,6 +403,30 @@ class BondList(Copyable):
         g.add_edges_from(edges)
         return g
     
+    def remove_aromaticity(self):
+        """
+        Remove aromaticity from the bond types.
+        
+        :attr:`BondType.AROMATIC_SINGLE` is converted into
+        :attr:`BondType.SINGLE` and :attr:`BondType.AROMATIC_DOUBLE` is
+        converted into :attr:`BondType.DOUBLE`.
+
+        Examples
+        --------
+
+        >>> bond_list = BondList(3)
+        >>> bond_list.add_bond(0, 1, BondType.AROMATIC_SINGLE)
+        >>> bond_list.add_bond(1, 2, BondType.AROMATIC_DOUBLE)
+        >>> bond_list.remove_aromaticity()
+        >>> for i, j, bond_type in bond_list.as_array():
+        ...     print(i, j, BondType(bond_type))
+        0 1 BondType.SINGLE
+        1 2 BondType.DOUBLE
+        """
+        bonds = self._bonds
+        difference = BondType.AROMATIC_SINGLE - BondType.SINGLE
+        bonds[bonds[:, 2] >= BondType.AROMATIC_SINGLE, 2] -= difference
+    
     def get_atom_count(self):
         """
         get_atom_count()

--- a/src/biotite/structure/io/pdbqt/convert.py
+++ b/src/biotite/structure/io/pdbqt/convert.py
@@ -67,20 +67,20 @@ def set_structure(pdbqt_file, atoms, charges=None, atom_types=None,
         lines.
 
             - ``None`` - The molecule is handled as rigid receptor:
-            No ``ROOT``, ``BRANCH`` and ``ENDBRANCH`` lines will
-            be written.
+              No ``ROOT``, ``BRANCH`` and ``ENDBRANCH`` lines will
+              be written.
             - ``'rigid'`` - The molecule is handled as rigid ligand:
-            Only a ``ROOT`` line will be written.
+              Only a ``ROOT`` line will be written.
             - ``'all'`` - The molecule is handled as flexible 
-            ligand:
-            A ``ROOT`` line will be written and all rotatable
-            bonds are included using ``BRANCH`` and ``ENDBRANCH``
-            lines.
+              ligand:
+              A ``ROOT`` line will be written and all rotatable
+              bonds are included using ``BRANCH`` and ``ENDBRANCH``
+              lines.
             - :class:`BondList` - The molecule is handled as
-            flexible ligand:
-            A ``ROOT`` line will be written and all bonds in the
-            given :class:`BondList` are considered flexible via
-            ``BRANCH`` and ``ENDBRANCH`` lines.
+              flexible ligand:
+              A ``ROOT`` line will be written and all bonds in the
+              given :class:`BondList` are considered flexible via
+              ``BRANCH`` and ``ENDBRANCH`` lines.
         
     root : int, optional
         Specifies the index of the atom following the ``ROOT`` line.

--- a/src/biotite/structure/io/pdbqt/file.py
+++ b/src/biotite/structure/io/pdbqt/file.py
@@ -598,7 +598,10 @@ def convert_atoms(atoms, charges):
                     "Structure contains hydrogen with multiple bonds"
                 )
         elif element == "C":
-            if (all_bond_types[i] == BondType.AROMATIC).any():
+            if np.isin(
+                all_bond_types[i],
+                [BondType.AROMATIC_SINGLE, BondType.AROMATIC_DOUBLE]
+            ).any():
                 # Aromatic carbon
                 atom_types[i] = "A"
             else:

--- a/tests/structure/test_bonds.py
+++ b/tests/structure/test_bonds.py
@@ -102,8 +102,8 @@ def test_invalid_creation():
         struc.BondList(
             5,
             np.array([
-                # BondType '6' does not exist
-                [1,2,6]
+                # BondType '7' does not exist
+                [1,2,7]
             ])
         )
 


### PR DESCRIPTION
The current bond types are not able to distinguish between formal single or double bonds for aromatic bonds. This circumstance gives rise to some issues were this information would be relevant, e.g. for drawing structural formulas or determining if an aromatic nitrogen atom has a hydrogen or not.

This PR changes the `BondType` enum by splitting `BondType.AROMATIC` into `BondType.AROMATIC_SINGLE` and `BondType.AROMATIC_DOUBLE` which convey both informations: Whether a bond is part of an aromatic system and whether it is formally a single or double bond.