### PR TITLE
Fixes for 'PDBFile'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,11 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
-import sys
 import re
-import shlex
-import glob
 from os.path import join, abspath, dirname, normpath
 import fnmatch
 import os
 from setuptools import setup, find_packages, Extension
-from setuptools.command.test import test as TestCommand
 import numpy
 from Cython.Build import cythonize
 

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -364,7 +364,6 @@ class PDBFile(TextFile):
                     dtype=int
                 ))
             elif field == "charge":
-                print(charge_raw)
                 array.set_annotation("charge", np.array(
                     [0 if raw_number == " " else
                      (-float(raw_number) if sign == "-" else float(raw_number))
@@ -489,8 +488,8 @@ class PDBFile(TextFile):
         else:
             occupancy = np.ones(array.array_length())
         if "charge" in annot_categories:
-            charge = [ "+"+str(np.abs(charge)) if charge > 0 else
-                      ("-"+str(np.abs(charge)) if charge < 0 else
+            charge = [ str(np.abs(charge)) + "+" if charge > 0 else
+                      (str(np.abs(charge)) + "-" if charge < 0 else
                        "")
                       for charge in array.get_annotation("charge")]
         else:

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -72,10 +72,19 @@ class PDBFile(TextFile):
             The number of models.
         """
         model_count = 0
-        for line in (self.lines):
+        for line in self.lines:
             if line.startswith("MODEL"):
                 model_count += 1
-        return model_count
+        
+        if model_count == 0:
+            # It could be an empty file or a file with a single model,
+            # where the 'MODEL' line is missing
+            for line in self.lines:
+                if line.startswith(("ATOM", "HETATM")):
+                    return 1
+            return 0
+        else:
+            return model_count
     
 
     def get_coord(self, model=None):
@@ -355,6 +364,7 @@ class PDBFile(TextFile):
                     dtype=int
                 ))
             elif field == "charge":
+                print(charge_raw)
                 array.set_annotation("charge", np.array(
                     [0 if raw_number == " " else
                      (-float(raw_number) if sign == "-" else float(raw_number))

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -119,6 +119,11 @@ def test_extra_fields(hybrid36):
 
     with pytest.raises(ValueError):
         pdb_file.get_structure(extra_fields=["unsupported_field"])
+    
+    # Add non-neutral charge values,
+    # as the input PDB has only neutral charges
+    stack1.charge[0] = -1
+    stack1.charge[1] = 2
 
     pdb_file = pdb.PDBFile()
     pdb_file.set_structure(stack1, hybrid36=hybrid36)


### PR DESCRIPTION
This PR fixes two issues in 'structure.PDBFIle':

- 'get_model_count()' returns 0 if the file contains no `MODEL` line
- Formal charges are written in the format e.g. `+1` instead of the correct format `1+`