### PR TITLE
Fix too large cell radius

### DIFF
--- a/src/biotite/structure/celllist.pyx
+++ b/src/biotite/structure/celllist.pyx
@@ -416,16 +416,16 @@ cdef class CellList:
             = _prepare_vectorization(coord, radius, np.float32)
         if is_multi_radius:
             sq_radii = radius * radius
-            cell_radii = np.floor_divide(
-                radius, self._cellsize
-            ).astype(np.int32) + 1
+            cell_radii = np.ceil(radius / self._cellsize).astype(np.int32)
         else:
             # All radii are equal
             sq_radii = np.full(
                 len(coord), radius[0]*radius[0], dtype=np.float32
             )
             cell_radii = np.full(
-                len(coord), int(radius[0]/self._cellsize)+1, dtype=np.int32
+                len(coord),
+                int(np.ceil(radius[0] / self._cellsize)),
+                dtype=np.int32
             )
 
         # Get indices for adjacent atoms, based on a cell radius


### PR DESCRIPTION
In the current implementation `CellList.get_atoms()` and `CellList.get_adjacency_matrix()` check two adjacent cells if the `radius` is exactly the `cell_size`. However, checking the direct adjacent cell is sufficient in this case. This PR fixes that. The results are the same, but the performance increases in this common case.