### PR TITLE
Setting an exisiting annotation does not change dtype

### DIFF
--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -146,7 +146,13 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
                 f"Expected array length {self._array_length}, "
                 f"but got {len(array)}"
             )
-        self._annot[category] = np.asarray(array)
+        if category in self._annot:
+            # Keep the dtype if the annotation already exists
+            self._annot[category] = np.asarray(
+                array, dtype=self._annot[category].dtype
+            )
+        else:
+            self._annot[category] = np.asarray(array)
         
     def get_annotation_categories(self):
         """

--- a/tests/structure/test_info.py
+++ b/tests/structure/test_info.py
@@ -44,11 +44,6 @@ def test_bonds(path):
     Test whether the bond data is consistent with the content of MMTF
     files.
     """
-    # Currently the file 1igy.mmtf uses outdated atom names, so this
-    # test would fail (see https://github.com/rcsb/mmtf/issues/47)
-    if "1igy.mmtf" in path:
-        pytest.skip("Temporarily disabled due to outdated atom names")
-
     bond_data = strucinfo.bond_dataset()
     mmtf_file = mmtf.MMTFFile.read(path)
     for group in mmtf_file["groupList"]:


### PR DESCRIPTION
Previously setting an annotation in an `AtomArray` via `set_annotation()` or `__setitem__()` uses the *dtype* of the given array, even if an array already exists for this category. This can lead to undesired dtypes when e.g. reading a structure from a file.
This PR changes this behavior: If an annotation array already exists for the annotation category, its dtype will also be used for the new array given by `set_annotation()` or `__setitem__()`.