### PR TITLE
Read and write bonds from/to PDB files

### DIFF
--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -427,6 +427,12 @@ class BondList(Copyable):
         difference = BondType.AROMATIC_SINGLE - BondType.SINGLE
         bonds[bonds[:, 2] >= BondType.AROMATIC_SINGLE, 2] -= difference
     
+    def remove_bond_order(self):
+        """
+        Convert all bonds to :attr:`BondType.ANY`.
+        """
+        self._bonds[:,2] = BondType.ANY
+    
     def get_atom_count(self):
         """
         get_atom_count()
@@ -1331,9 +1337,10 @@ _DEFAULT_DISTANCE_RANGE = {
     ("SI", "SE") : (2.359 - 2*0.012,  2.359 + 2*0.012),
 }
 
-def connect_via_distances(atoms, dict distance_range=None):
+def connect_via_distances(atoms, dict distance_range=None,
+                          atom_mask=None, bint inter_residue=True):
     """
-    connect_via_distances(atoms, distance_range=None)
+    connect_via_distances(atoms, distance_range=None, atom_mask=None, inter_residue=True)
 
     Create a :class:`BondList` for a given atom array, based on
     pairwise atom distances.
@@ -1360,6 +1367,12 @@ def connect_via_distances(atoms, dict distance_range=None):
         Hence, the default bond distances for missing element pairs are
         still taken from the default dictionary.
         The default bond distances are taken from :footcite:`Allen1987`.
+    atom_mask : ndarray, dtype=bool, shape=(n,), optional
+        If set, only the atoms, where this mask is ``True``, are
+        connected.
+    inter_residue : bool, optional
+        If true, connections between consecutive amino acids and
+        nucleotides are also added.
     
     Returns
     -------
@@ -1388,6 +1401,7 @@ def connect_via_distances(atoms, dict distance_range=None):
     from .atoms import AtomArray
 
     cdef list bonds = []
+    cdef uint8[:] mask = _prepare_mask(atom_mask, atoms.array_length())
     cdef int i
     cdef int curr_start_i, next_start_i
     cdef np.ndarray coord = atoms.coord
@@ -1398,7 +1412,7 @@ def connect_via_distances(atoms, dict distance_range=None):
     cdef np.ndarray elements_in_res
     cdef int index_in_res1, index_in_res2
     cdef int atom_index1, atom_index2
-    cdef dict dist_ranges
+    cdef dict dist_ranges = {}
     cdef tuple dist_range
     cdef float min_dist, max_dist
 
@@ -1406,7 +1420,6 @@ def connect_via_distances(atoms, dict distance_range=None):
         raise TypeError(f"Expected 'AtomArray', not '{type(atoms).__name__}'")
 
     # Prepare distance dictionary...
-    dist_ranges = {}
     if distance_range is None:
         distance_range = {}
     # Merge default and custom entries
@@ -1433,6 +1446,9 @@ def connect_via_distances(atoms, dict distance_range=None):
         )
         for atom_index1 in range(len(elements_in_res)):
             for atom_index2 in range(atom_index1):
+                if not mask[atom_index1] or not mask[atom_index2]:
+                    # Do not connect atoms that were filtered out
+                    continue
                 dist_range = dist_ranges.get((
                     elements_in_res[atom_index1],
                     elements_in_res[atom_index2]
@@ -1453,19 +1469,20 @@ def connect_via_distances(atoms, dict distance_range=None):
 
     bond_list = BondList(atoms.array_length(), np.array(bonds))
     
-    inter_bonds = _connect_inter_residue(atoms, residue_starts)
-    # As all bonds should be of type ANY, convert also inter-residue
-    # bonds to ANY by creating a new BondList and omitting the BonType
-    # column
-    inter_bonds = BondList(atoms.array_length(), inter_bonds.as_array()[:, :2])
-    
-    return bond_list.merge(inter_bonds)
+    if inter_residue:
+        inter_bonds = _connect_inter_residue(atoms, residue_starts)
+        # As all bonds should be of type ANY, convert also
+        # inter-residue bonds to ANY
+        inter_bonds.remove_bond_order()
+        return bond_list.merge(inter_bonds)
+    else:
+        return bond_list
 
 
 
-def connect_via_residue_names(atoms):
+def connect_via_residue_names(atoms, atom_mask=None, bint inter_residue=True):
     """
-    connect_via_residue_names(atoms)
+    connect_via_residue_names(atoms, atom_mask=None, inter_residue=True)
 
     Create a :class:`BondList` for a given atom array (stack), based on
     the deposited bonds for each residue in the RCSB ``components.cif``
@@ -1477,8 +1494,15 @@ def connect_via_residue_names(atoms):
     
     Parameters
     ----------
-    atoms : AtomArray or AtomArrayStack
+    atoms : AtomArray, shape=(n,) or AtomArrayStack, shape=(m,n)
         The structure to create the :class:`BondList` for.
+    atom_mask : ndarray, dtype=bool, shape=(n,), optional
+        If set, only the atoms, where this mask is ``True``, are
+        connected.
+    inter_residue : bool, optional
+        If true, connections between consecutive amino acids and
+        nucleotides are also added.
+
     
     Returns
     -------
@@ -1504,6 +1528,7 @@ def connect_via_residue_names(atoms):
     from .info.bonds import bond_dataset
 
     cdef list bonds = []
+    cdef uint8[:] mask = _prepare_mask(atom_mask, atoms.array_length())
     cdef int i
     cdef int curr_start_i, next_start_i
     cdef np.ndarray atom_names = atoms.atom_name
@@ -1544,7 +1569,26 @@ def connect_via_residue_names(atoms):
              
     bond_list = BondList(atoms.array_length(), np.array(bonds))
     
-    return bond_list.merge(_connect_inter_residue(atoms, residue_starts))
+    if inter_residue:
+        inter_bonds = _connect_inter_residue(atoms, residue_starts)
+        return bond_list.merge(inter_bonds)
+    else:
+        return bond_list
+
+
+def _prepare_mask(atom_mask, array_length):
+    # Prepare masked atoms
+    cdef uint8[:] mask
+    if atom_mask is not None:
+        if len(atom_mask) != array_length:
+            raise IndexError(
+                f"Atom mask has length {len(atom_mask)}, "
+                f"but there are {array_length} atoms"
+            )
+        return np.frombuffer(atom_mask, dtype=np.uint8)
+    else:
+        return np.ones(array_length, dtype=np.uint8)
+
 
 
 _PEPTIDE_LINKS = ["PEPTIDE LINKING", "L-PEPTIDE LINKING", "D-PEPTIDE LINKING"]
@@ -1552,7 +1596,7 @@ _NUCLEIC_LINKS = ["RNA LINKING", "DNA LINKING"]
 
 def _connect_inter_residue(atoms, residue_starts):
     """
-    Create a :class:`BondList` containing the bonds between two adjacent
+    Create a :class:`BondList` containing the bonds between adjacent
     amino acid or nucleotide residues.
     
     Parameters

--- a/src/biotite/structure/io/mmtf/convertfile.pyx
+++ b/src/biotite/structure/io/mmtf/convertfile.pyx
@@ -82,10 +82,10 @@ def get_structure(file, model=None, altloc="first",
         that should be stored in the output array or stack.
         These are valid values:
         ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and ``'charge'``.
-    include_bonds : bool
-        If set to true, an :class:`BondList` will be created for the resulting
-        :class:`AtomArray` containing the bond information from the file.
-        (Default: False)
+    include_bonds : bool, optional
+        If set to true, a :class:`BondList` will be created for the
+        resulting :class:`AtomArray` containing the bond information
+        from the file.
     
     Returns
     -------

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -29,7 +29,8 @@ def get_model_count(pdb_file):
     return pdb_file.get_model_count()
 
 
-def get_structure(pdb_file, model=None, altloc="first", extra_fields=[]):
+def get_structure(pdb_file, model=None, altloc="first", extra_fields=[],
+                  include_bonds=False):
     """
     Create an :class:`AtomArray` or :class:`AtomArrayStack` from a
     :class:`PDBFile`.
@@ -66,6 +67,10 @@ def get_structure(pdb_file, model=None, altloc="first", extra_fields=[]):
         that should be stored in the output array or stack.
         These are valid values:
         ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and ``'charge'``.
+    include_bonds : bool, optional
+        If set to true, a :class:`BondList` will be created for the
+        resulting :class:`AtomArray` containing the bond information
+        from the file.
         
     Returns
     -------
@@ -73,7 +78,7 @@ def get_structure(pdb_file, model=None, altloc="first", extra_fields=[]):
         The return type depends on the `model` parameter.
     
     """
-    return pdb_file.get_structure(model, altloc, extra_fields)
+    return pdb_file.get_structure(model, altloc, extra_fields, include_bonds)
 
 
 def set_structure(pdb_file, array, hybrid36=False):
@@ -98,5 +103,11 @@ def set_structure(pdb_file, array, hybrid36=False):
         the stack will be in a separate model.
     hybrid36: boolean, optional
         Defines wether the file should be written in hybrid-36 format.
+
+    Notes
+    -----
+    If `array` has an associated :class:`BondList`, ``CONECT``
+    records are also written for all non-water hetero residues
+    and all inter-residue connections.
     """
     pdb_file.set_structure(array, hybrid36)

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -28,19 +28,22 @@ def test_get_model_count():
 
 
 @pytest.mark.parametrize(
-    "path, model, hybrid36",
+    "path, model, hybrid36, include_bonds",
     itertools.product(
         glob.glob(join(data_dir("structure"), "*.pdb")),
         [None, 1, -1],
+        [False, True],
         [False, True]
     )
 )
-def test_array_conversion(path, model, hybrid36):
+def test_array_conversion(path, model, hybrid36, include_bonds):
     pdb_file = pdb.PDBFile.read(path)
     # Test also the thin wrapper around the methods
     # 'get_structure()' and 'set_structure()'
     try:
-        array1 = pdb.get_structure(pdb_file, model=model)
+        array1 = pdb.get_structure(
+            pdb_file, model=model, include_bonds=include_bonds
+        )
     except biotite.InvalidFileError:
         if model is None:
             # The file cannot be parsed into an AtomArrayStack,
@@ -63,7 +66,9 @@ def test_array_conversion(path, model, hybrid36):
         pdb_file = pdb.PDBFile()
         pdb.set_structure(pdb_file, array1, hybrid36=hybrid36)
     
-    array2 = pdb.get_structure(pdb_file, model=model)
+    array2 = pdb.get_structure(
+        pdb_file, model=model, include_bonds=include_bonds
+    )
     
     if array1.box is not None:
         assert np.allclose(array1.box, array2.box)


### PR DESCRIPTION
This PR allows reading bonds from `CONECT` records in `PDBFile.get_structure()` if `include_bonds` is set to `True`. `PDBFile.set_structure()` automatically writes `CONECT` records if the `Atomarray` has an associated `BondList`.
Furthermore, `connect_via_distance()` and `connect_via_residue_names()` get the optional `atom_mask` and `inter_residue` parameters for more control over the created bonds.
Closes #329 .