### PR TITLE
Catch error if 'CRYST1' record is corrupt in PDBfile

### DIFF
--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -71,6 +71,8 @@ def get_structure(pdb_file, model=None, altloc="first", extra_fields=[],
         If set to true, a :class:`BondList` will be created for the
         resulting :class:`AtomArray` containing the bond information
         from the file.
+        All bonds have :attr:`BondType.ANY`, since the PDB format
+        does not support bond orders.
         
     Returns
     -------

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -266,6 +266,8 @@ class PDBFile(TextFile):
             If set to true, a :class:`BondList` will be created for the
             resulting :class:`AtomArray` containing the bond information
             from the file.
+            All bonds have :attr:`BondType.ANY`, since the PDB format
+            does not support bond orders.
         
         Returns
         -------
@@ -722,6 +724,7 @@ class PDBFile(TextFile):
 
 
     def _set_bonds(self, bond_list, atom_ids):
+        # Bond type is unused since PDB does not support bond orders
         bonds, _ = bond_list.get_all_bonds()
 
         for center_i, bonded_indices in enumerate(bonds):

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -6,6 +6,7 @@ __name__ = "biotite.structure.io.pdb"
 __author__ = "Patrick Kunzmann, Daniel Bauer"
 __all__ = ["PDBFile"]
 
+import warnings
 import numpy as np
 from ...atoms import AtomArray, AtomArrayStack
 from ...bonds import BondList, connect_via_residue_names
@@ -433,15 +434,22 @@ class PDBFile(TextFile):
         # record so we can extract it directly
         for line in self.lines:
             if line.startswith("CRYST1"):
-                len_a = float(line[6:15])
-                len_b = float(line[15:24])
-                len_c = float(line[24:33])
-                alpha = np.deg2rad(float(line[33:40]))
-                beta = np.deg2rad(float(line[40:47]))
-                gamma = np.deg2rad(float(line[47:54]))
-                box = vectors_from_unitcell(
-                    len_a, len_b, len_c, alpha, beta, gamma
-                )
+                try:
+                    len_a = float(line[6:15])
+                    len_b = float(line[15:24])
+                    len_c = float(line[24:33])
+                    alpha = np.deg2rad(float(line[33:40]))
+                    beta = np.deg2rad(float(line[40:47]))
+                    gamma = np.deg2rad(float(line[47:54]))
+                    box = vectors_from_unitcell(
+                        len_a, len_b, len_c, alpha, beta, gamma
+                    )
+                except ValueError:
+                    # File contains invalid 'CRYST1' record
+                    warnings.warn(
+                        "File contains invalid 'CRYST1' record, box is ignored"
+                    )
+                    box = None
 
                 if isinstance(array, AtomArray):
                     array.box = box

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -314,3 +314,21 @@ def test_hybrid36_codec(number, length):
 def test_max_hybrid36_number():
     assert hybrid36.max_hybrid36_number(4) == 2436111
     assert hybrid36.max_hybrid36_number(5) == 87440031
+
+
+def test_bond_parsing():
+    """
+    Compare parsing of bonds from PDB with output from
+    :func:`connect_via_residue_names()`.
+    """
+    # Choose a structure with CONECT records to test these as well
+    path = join(data_dir("structure"), "3o5r.pdb")
+    pdb_file = pdb.PDBFile.read(path)
+    atoms = pdb.get_structure(pdb_file, model=1, include_bonds=True)
+    
+    test_bonds = atoms.bonds
+
+    ref_bonds = struc.connect_via_residue_names(atoms)
+    ref_bonds.remove_bond_order()
+
+    assert test_bonds.as_set() == ref_bonds.as_set()


### PR DESCRIPTION
This PR adds a test and clarifies the docstring regarding the bond parsing from PDB files.