### PR TITLE
Documentation: API reference point to the source code on GitHub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Installing distribution
         run: pip install .//dist//*.whl
       - name: Testing code
-        run: pytest --ignore=tests//structure//test_trajectory.py --ignore=tests//sequence//align//test_statistics.py --ignore=tests//application --ignore=tests//database --ignore=tests//test_doctest.py
+        run: pytest --ignore=tests//structure//test_trajectory.py --ignore=tests//sequence//align//test_statistics.py --ignore=tests//application --ignore=tests//database --ignore=tests//test_doctest.py  --ignore=tests//test_modname.py
   
 
   test-thorough:

--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -90,6 +90,7 @@
             "align_ungapped",
             "align_optimal",
             "align_local_ungapped",
+            "align_local_gapped",
             "align_banded",
             "align_multiple"
         ],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,6 +54,9 @@ pybtex.plugin.register_plugin(
     "pybtex.style.formatting", "ieee", bibliography.IEEEStyle
 )
 
+#### Source code link ###
+
+linkcode_resolve = viewcode.linkcode_resolve
 
 #### General ####
 
@@ -71,7 +74,7 @@ extensions = ["sphinx.ext.autodoc",
               "sphinx.ext.autosummary",
               "sphinx.ext.doctest",
               "sphinx.ext.mathjax",
-              "sphinx.ext.viewcode",
+              "sphinx.ext.linkcode",
               "sphinxcontrib.bibtex",
               "sphinx_gallery.gen_gallery",
               "numpydoc"]
@@ -166,5 +169,3 @@ sphinx_gallery_conf = {
 
 def setup(app):
     app.connect("autodoc-skip-member", apidoc.skip_non_methods)
-    app.connect("viewcode-follow-imported", viewcode.find_actual_module)
-    app.connect("viewcode-find-source", viewcode.index_source)

--- a/doc/viewcode.py
+++ b/doc/viewcode.py
@@ -12,6 +12,25 @@ import biotite
 
 
 def _index_attributes(package_name, src_path):
+    """
+    Assign a Python module to each combination of (sub)package and
+    attribute (e.g. function, class, etc.) in a given (sub)package.
+
+    Parameters
+    ----------
+    package_name : str
+        Name of the (sub)package.
+    src_path : str
+        File path to `package_name`.
+    
+    Parameters
+    ----------
+    attribute_index : dict( tuple(str, str) -> str)
+        Maps the combintation of (sub)package name and attribute to
+        the name of a Python module.
+    file_index : dict( str -> str )
+        Maps a Python module to its file path.
+    """
     attribute_index = {}
     file_index = {}
     

--- a/doc/viewcode.py
+++ b/doc/viewcode.py
@@ -3,12 +3,13 @@
 # information.
 
 __author__ = "Patrick Kunzmann"
-__all__ = ["find_actual_module", "index_source"]
+__all__ = ["linkcode_resolve"]
 
+import sys
+from importlib import import_module
 from os.path import dirname, join, isdir, splitext
 from os import listdir
-from importlib import import_module
-import biotite
+import inspect
 
 
 def _index_attributes(package_name, src_path):
@@ -25,31 +26,35 @@ def _index_attributes(package_name, src_path):
     
     Parameters
     ----------
-    attribute_index : dict( tuple(str, str) -> str)
-        Maps the combintation of (sub)package name and attribute to
-        the name of a Python module.
-    file_index : dict( str -> str )
-        Maps a Python module to its file path.
+    attribute_index : dict( tuple(str, str) -> (str, bool))
+        Maps the combination of (sub)package name and attribute to
+        the name of a Python module and to a boolean value that
+        indicates, whether it is a Cython module.
+    cython_line_index : dict( tuple(str, str) -> tuple(int, int) ) )
+        Maps the combination of (sub)package name and attribute to
+        the first and last line in a Cython module.
+        Does not contain entries for attributes that are not part of a
+        Cython module.
     """
-    attribute_index = {}
-    file_index = {}
-    
     if not _is_package(src_path):
         # Directory is not a Python package/subpackage
         # -> Nothing to do
-        return attribute_index, file_index
+        return {}, {}
     
+    attribute_index = {}
+    cython_line_index = {}
+
     # Identify all subdirectories...
     directory_content = listdir(src_path)
     dirs = [f for f in directory_content if isdir(join(src_path, f))]
     # ... and index them recursively 
     for directory in dirs:
-        sub_attribute_index, sub_file_index = _index_attributes(
+        sub_attribute_index, sub_cython_line_index = _index_attributes(
             f"{package_name}.{directory}",
             join(src_path, directory),
         )
         attribute_index.update(sub_attribute_index)
-        file_index.update(sub_file_index)
+        cython_line_index.update(sub_cython_line_index)
     
     # Import all modules in directory and index attributes
     source_files = [
@@ -63,52 +68,23 @@ def _index_attributes(package_name, src_path):
     ]
     for source_file in source_files:
         module_name = f"{package_name}.{splitext(source_file)[0]}"
-        file_index[module_name] = join(src_path, source_file)
         module = import_module(module_name)
+        is_cython = source_file.endswith(".pyx")
         for attribute in module.__all__:
-            attribute_index[(package_name, attribute)] = module_name
+            attribute_index[(package_name, attribute)] \
+                = (module_name, is_cython)
+        if is_cython:
+            with open(join(src_path, source_file), "r") as cython_file:
+                lines = cython_file.read().splitlines()
+            for attribute, (first, last) in _index_cython_code(lines).items():
+                cython_line_index[(package_name, attribute)] = (first, last)
     
-    return attribute_index, file_index
+    return attribute_index, cython_line_index
 
 
-def _is_package(path):
-    content = listdir(path)
-    return "__init__.py" in content
-
-
-_attribute_index, _file_index = _index_attributes(
-    "biotite",
-    # Directory to src/biotite
-    join(dirname(dirname(__file__)), "src", "biotite")
-)
-
-
-
-
-def find_actual_module(app, modname, attribute):
-    top_attribute = attribute.split(".")[0]
-    return _attribute_index[(modname, top_attribute)]
-
-
-def index_source(app, modname):
-    source_file = _file_index[modname]
-    
-    if source_file.endswith(".pyx"):
-        with open(source_file) as file:
-            code = file.read()
-        code_lines = code.split("\n")
-        tags = _analyze_cython_code(code_lines)
-        return code, tags
-        
-    else:
-        # For normal Python files return None to tell Sphinx viewcode
-        # to do the default handling for these files 
-        return None
-
-
-def _analyze_cython_code(code_lines):
+def _index_cython_code(code_lines):
     """
-    Find the position of classes and functions in *Cython* files.
+    Find the line position of classes and functions in *Cython* files.
 
     This analyzer works in a very simple way:
     It looks for the `def` and `class` keywords at zero-indentation
@@ -123,16 +99,14 @@ def _analyze_cython_code(code_lines):
     ----------
     code_lines : list of str
         The *Cython* source code splitted into lines.
-    indent : int
-        Attributes are The indentation level.
     
     Returns
     -------
-    tags : dict
-        The tag dictionary, as expected by the *Sphinx*
-        ``viewcode-find-source`` event.
+    line_index : dict (str -> tuple(int, int))
+        Maps an attribute name to its first and last line in a Cython
+        module.
     """
-    tags = {}
+    line_index = {}
 
     for i in range(len(code_lines)):
         line = code_lines[i]
@@ -184,12 +158,70 @@ def _analyze_cython_code(code_lines):
                 # Exclusive stop -> +1
                 attr_line_stop = j + 1
         
-        tags[attr_name] = (
-            attr_type,
+        line_index[attr_name] = (
             # 'One' based indexing
             attr_line_start + 1,
             # 'One' based indexing and inclusive stop
             attr_line_stop
         )
         
-    return tags
+    return line_index
+
+
+def _is_package(path):
+    content = listdir(path)
+    return "__init__.py" in content
+
+
+_attribute_index, _cython_line_index = _index_attributes(
+    "biotite",
+    # Directory to src/biotite
+    join(dirname(dirname(__file__)), "src", "biotite")
+)
+
+
+
+
+def linkcode_resolve(domain, info):
+    if domain != "py":
+        return None
+    
+    package_name = info["module"]
+    attr_name = info["fullname"]
+    try:
+        module_name, is_cython = _attribute_index[(package_name, attr_name)]
+    except KeyError:
+        # The attribute is not defined within Biotite
+        # It may be e.g. in inherited method from an external source
+        return None
+
+    if is_cython:
+        if (package_name, attr_name) in _cython_line_index:
+            first, last = _cython_line_index[(package_name, attr_name)]
+            return f"https://github.com/biotite-dev/biotite/blob/master/src/" \
+                   f"{module_name.replace('.', '/')}.pyx#L{first}-L{last}"
+        else:
+            # In case the attribute is not found
+            # by the Cython code analyzer
+            return f"https://github.com/biotite-dev/biotite/blob/master/src/" \
+                   f"{module_name.replace('.', '/')}.pyx"
+    
+    else:
+        module = import_module(module_name)
+        
+        # Get the object defined by the attribute name,
+        # by traversing the 'attribute tree' to the leaf
+        obj = module
+        for attr_name_part in attr_name.split("."):
+            obj = getattr(obj, attr_name_part)
+        
+        # Temporarily change the '__module__' attribute, which is set
+        # to the subpackage in Biotite, back to the actual module in
+        # order to fool Python's inspect module
+        obj.__module__ = module_name
+
+        source_lines, first = inspect.getsourcelines(obj)
+        last = first + len(source_lines) - 1
+
+        return f"https://github.com/biotite-dev/biotite/blob/master/src/" \
+               f"{module_name.replace('.', '/')}.py#L{first}-L{last}"

--- a/src/biotite/sequence/align/kmeralphabet.pyx
+++ b/src/biotite/sequence/align/kmeralphabet.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 __all__ = ["KmerAlphabet"]
 

--- a/src/biotite/sequence/align/kmersimilarity.pyx
+++ b/src/biotite/sequence/align/kmersimilarity.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 __all__ = ["SimilarityRule", "ScoreThresholdRule"]
 

--- a/src/biotite/sequence/align/kmertable.pyx
+++ b/src/biotite/sequence/align/kmertable.pyx
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.align"
 __author__ = "Patrick Kunzmann"
 __all__ = ["KmerTable"]
 

--- a/src/biotite/sequence/graphics/plasmid.py
+++ b/src/biotite/sequence/graphics/plasmid.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.graphics"
 __author__ = "Patrick Kunzmann"
 __all__ = ["plot_plasmid_map"]
 

--- a/src/biotite/sequence/io/fastq/convert.py
+++ b/src/biotite/sequence/io/fastq/convert.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+__name__ = "biotite.sequence.io.fastq"
 __author__ = "Patrick Kunzmann"
 
 from collections import OrderedDict

--- a/src/biotite/sequence/io/general.py
+++ b/src/biotite/sequence/io/general.py
@@ -7,6 +7,7 @@ This module contains a convenience function for loading sequences from
 general sequence files.
 """
 
+__name__ = "biotite.sequence.io"
 __author__ = "Patrick Kunzmann"
 __all__ = ["load_sequence", "save_sequence",
            "load_sequences", "save_sequences"]

--- a/src/biotite/structure/charges.pyx
+++ b/src/biotite/structure/charges.pyx
@@ -8,7 +8,7 @@ charges of the individual atoms of a given AtomArray according to the
 PEOE algorithm of Gasteiger-Marsili.
 """
 
-__name__ = "biotite.charges"
+__name__ = "biotite.structure"
 __author__ = "Jacob Marcel Anter, Patrick Kunzmann"
 __all__ = ["partial_charges"]
 

--- a/tests/test_modname.py
+++ b/tests/test_modname.py
@@ -1,0 +1,49 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+import pkgutil
+from os.path import dirname, join, isdir, splitext
+import importlib
+import pytest
+
+
+def find_all_modules(package_name, src_dir):
+    """
+    Recursively look for Python modules in the given source directory.
+    (Sub-)Packages are not considered as modules.
+    """
+    module_names = []
+    for _, module_name, is_package in pkgutil.iter_modules([src_dir]):
+        full_module_name = f"{package_name}.{module_name}"
+        if is_package:
+            module_names.extend(find_all_modules(
+                full_module_name,
+                join(src_dir, module_name)
+            ))
+        else:
+            module_names.append(full_module_name)
+    return module_names
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    find_all_modules(
+        "biotite",
+        join(dirname(dirname(__file__)), "src", "biotite")
+    )
+)
+def test_module_name(module_name):
+    """
+    Test whether the '__name__' attribute of each module in Biotite is
+    set to the name of the subpackage.
+    This needs to be tested, since by default the '__name__' attribute
+    is equal to the name of the module.
+    For example, we expect 'biotite.structure' instead of
+    'biotite.structure.atoms'.
+    """
+    # Remove the part after the last '.' of the module name
+    # to obtain the package name
+    package_name = ".".join(module_name.split(".")[:-1])
+    module = importlib.import_module(module_name)
+    assert module.__name__ == package_name


### PR DESCRIPTION
Up to now the source code for a class or function in the API reference points to a page in the *Biotite* documentation using *Sphinx* `viewcode`. This PR changes this, so that the code points to the corresponding GitHub page with highlighted lines using `linkcode`.