### PR TITLE
Add support for Muscle 5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,3 +85,32 @@ jobs:
         run: pip install .//dist//*.whl
       - name: Testing code
         run: pytest --ignore=tests//application//test_blast.py --ignore=tests//application//test_sra.py --ignore=tests//database//test_entrez.py
+  
+
+  test-muscle5:
+    name: Testing Biotite's interface for MUSCLE 5
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: biotite-dev
+          auto-update-conda: true
+          python-version: 3.9
+          mamba-version: "*"
+          channels: conda-forge,defaults
+      - name: Installing dependencies
+        run: conda install -c conda-forge "cython>=0.29" "numpy=1.19" "requests>=2.12" "msgpack-python>=0.5.6" "networkx>=2.0" "pytest>=3.2" 
+        env:
+          NUMPY_VERSION: ${{ matrix.numpy }}
+      - name: Building distribution
+        run: python setup.py bdist_wheel
+      - name: Installing distribution
+        run: pip install .//dist//*.whl
+      - name: Testing code
+        run: pytest tests//application//test_msa.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
   
 
   test-muscle5:
-    name: Testing Biotite's interface for MUSCLE 5
+    name: Testing Biotite's interface for Muscle 5
 
     runs-on: ubuntu-latest
     defaults:
@@ -105,7 +105,7 @@ jobs:
           mamba-version: "*"
           channels: conda-forge,defaults
       - name: Installing dependencies
-        run: conda install -c conda-forge "cython>=0.29" "numpy=1.19" "requests>=2.12" "msgpack-python>=0.5.6" "networkx>=2.0" "pytest>=3.2" 
+        run: conda install -c conda-forge -c bioconda "muscle=5" "cython>=0.29" "numpy=1.19" "requests>=2.12" "msgpack-python>=0.5.6" "networkx>=2.0" "pytest>=3.2"
         env:
           NUMPY_VERSION: ${{ matrix.numpy }}
       - name: Building distribution

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - dssp
   - clustalo
   - mafft
-  - muscle
+  - muscle =3
   - sra-tools
   - autodock-vina
   - viennarna

--- a/src/biotite/application/application.py
+++ b/src/biotite/application/application.py
@@ -4,8 +4,8 @@
 
 __name__ = "biotite.application"
 __author__ = "Patrick Kunzmann"
-__all__ = ["Application", "AppStateError", "TimeoutError", "AppState",
-           "requires_state"]
+__all__ = ["Application", "AppStateError", "TimeoutError", "VersionError",
+           "AppState", "requires_state"]
 
 import abc
 import time
@@ -249,5 +249,12 @@ class AppStateError(Exception):
 class TimeoutError(Exception):
     """
     Indicate that the application's timeout expired.
+    """
+    pass
+
+
+class VersionError(Exception):
+    """
+    Indicate that the application's version is invalid.
     """
     pass

--- a/src/biotite/application/muscle/__init__.py
+++ b/src/biotite/application/muscle/__init__.py
@@ -9,4 +9,5 @@ A subpackage for multiple sequence alignments using MUSCLE.
 __name__ = "biotite.application.muscle"
 __author__ = "Patrick Kunzmann"
 
-from .app import *
+from .app3 import *
+from .app5 import *

--- a/src/biotite/application/muscle/app5.py
+++ b/src/biotite/application/muscle/app5.py
@@ -1,0 +1,171 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+__name__ = "biotite.application.muscle"
+__author__ = "Patrick Kunzmann"
+__all__ = ["Muscle5App"]
+
+import numbers
+import warnings
+from tempfile import NamedTemporaryFile
+from ..localapp import cleanup_tempfile
+from ..msaapp import MSAApp
+from ..application import AppState, VersionError, requires_state
+from ...sequence.sequence import Sequence
+from ...sequence.seqtypes import NucleotideSequence, ProteinSequence
+from ...sequence.align.matrix import SubstitutionMatrix
+from ...sequence.align.alignment import Alignment
+from ...sequence.phylo.tree import Tree
+from .app3 import get_version
+
+
+class Muscle5App(MSAApp):
+    """
+    Perform a multiple sequence alignment using MUSCLE version 5.
+    
+    Parameters
+    ----------
+    sequences : list of Sequence
+        The sequences to be aligned.
+    bin_path : str, optional
+        Path of the MUSCLE binary.
+    
+    See also
+    ---------
+    MuscleApp
+
+    Notes
+    -----
+    Alignment ensemble generation is not supported, yet.
+    
+    Examples
+    --------
+
+    >>> seq1 = ProteinSequence("BIQTITE")
+    >>> seq2 = ProteinSequence("TITANITE")
+    >>> seq3 = ProteinSequence("BISMITE")
+    >>> seq4 = ProteinSequence("IQLITE")
+    >>> app = Muscle5App([seq1, seq2, seq3, seq4])
+    >>> app.start()
+    >>> app.join()
+    >>> alignment = app.get_alignment()
+    >>> print(alignment)
+    BI-QTITE
+    TITANITE
+    BI-SMITE
+    -I-QLITE
+    """
+    
+    def __init__(self, sequences, bin_path="muscle"):
+        major_version = get_version(bin_path)[0]
+        if major_version < 5:
+            raise VersionError(
+                f"At least Muscle 5 is required, got version {major_version}"
+            )
+        
+        super().__init__(sequences, bin_path)
+        self._mode = "align"
+        self._consiters = None
+        self._refineiters = None
+        self._n_threads = None
+
+    @requires_state(AppState.CREATED)
+    def set_iterations(self, consistency=None, refinement=None):
+        """
+        Set the number of iterations for the alignment algorithm.
+
+        Parameters
+        ----------
+        consistency : int, optional
+            The number of consistency iterations.
+        refinement : int, optional
+            The number of refinement iterations.
+        """
+        if consistency is not None:
+            self._consiters = consistency
+        if refinement is not None:
+            self._refineiters = refinement
+    
+    @requires_state(AppState.CREATED)
+    def set_thread_number(self, number):
+        """
+        Set the number of threads for the alignment run.
+
+        Parameters
+        ----------
+        number : int, optional
+            The number of threads.
+        """
+        self._n_threads = number
+
+    @requires_state(AppState.CREATED)
+    def use_super5(self):
+        """
+        Use the *Super5* algorithm for the alignment run.
+        """
+        self._mode = "super5"
+
+    def run(self):
+        args = [
+            f"-{self._mode}",
+            self.get_input_file_path(),
+            "-output", self.get_output_file_path(),
+        ]
+        if self.get_seqtype() == "protein":
+            args += ["-amino"]
+        else:
+            args += ["-nt"]
+        if self._n_threads is not None:
+             args += ["-threads", str(self._n_threads)]
+        if self._consiters is not None:
+             args += ["-consiters", str(self._consiters)]
+        if self._refineiters is not None:
+             args += ["-refineiters", str(self._refineiters)]
+        self.set_arguments(args)
+        super().run()
+    
+    def clean_up(self):
+        super().clean_up()
+    
+    @staticmethod
+    def supports_nucleotide():
+        return True
+    
+    @staticmethod
+    def supports_protein():
+        return True
+    
+    @staticmethod
+    def supports_custom_nucleotide_matrix():
+        return False
+    
+    @staticmethod
+    def supports_custom_protein_matrix():
+        return False
+    
+    @classmethod
+    def align(cls, sequences, bin_path=None):
+        """
+        Perform a multiple sequence alignment.
+        
+        This is a convenience function, that wraps the :class:`Muscle5App`
+        execution.
+        
+        Parameters
+        ----------
+        sequences : iterable object of Sequence
+            The sequences to be aligned
+        bin_path : str, optional
+            Path of the MSA software binary. By default, the default path
+            will be used.
+        
+        Returns
+        -------
+        alignment : Alignment
+            The global multiple sequence alignment.
+        """
+        app = cls(sequences, bin_path)
+        app.start()
+        app.join()
+        return app.get_alignment()

--- a/tests/application/test_msa.py
+++ b/tests/application/test_msa.py
@@ -16,6 +16,14 @@ import shutil
 from ..util import is_not_installed
 
 
+BIN_PATH = {
+    MuscleApp : "muscle",
+    Muscle5App : "muscle",
+    MafftApp : "mafft",
+    ClustalOmegaApp: "clustalo"
+}
+
+
 @pytest.fixture
 def sequences():
     return [seq.ProteinSequence(string) for string in [
@@ -26,42 +34,39 @@ def sequences():
 ]]
 
 
-@pytest.mark.parametrize("app_cls, bin_path, exp_ali, exp_order",
+@pytest.mark.parametrize("app_cls, exp_ali, exp_order",
     [(MuscleApp,
-      "muscle",
       "BIQT-ITE\n"
       "TITANITE\n"
       "BISM-ITE\n"
       "-IQL-ITE",
       [1, 2, 0, 3]),
      (Muscle5App,
-      "muscle",
       "BI-QTITE\n"
       "TITANITE\n"
       "BI-SMITE\n"
       "-I-QLITE",
       [0, 3, 1, 2]),
      (MafftApp,
-      "mafft",
       "-BIQTITE\n"
       "TITANITE\n"
       "-BISMITE\n"
       "--IQLITE",
       [0, 3, 2, 1]),
      (ClustalOmegaApp,
-      "clustalo",
       "-BIQTITE\n"
       "TITANITE\n"
       "-BISMITE\n"
       "--IQLITE",
      [1, 2, 0, 3])]
 )
-def test_msa(sequences, app_cls, bin_path, exp_ali, exp_order):
+def test_msa(sequences, app_cls, exp_ali, exp_order):
+    bin_path = BIN_PATH[app_cls]
     if is_not_installed(bin_path):
         pytest.skip(f"'{bin_path}' is not installed")
 
     try:
-        app = app_cls(sequences, bin_path)
+        app = app_cls(sequences)
     except VersionError:
         pytest.skip(f"Invalid software version")
     app.start()
@@ -74,6 +79,10 @@ def test_msa(sequences, app_cls, bin_path, exp_ali, exp_order):
 
 
 def test_additional_options(sequences):
+    bin_path = BIN_PATH[ClustalOmegaApp]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+
     app1 = ClustalOmegaApp(sequences)
     app1.start()
     
@@ -90,6 +99,10 @@ def test_additional_options(sequences):
 
 @pytest.mark.parametrize("app_cls", [MuscleApp, MafftApp])
 def test_custom_substitution_matrix(sequences, app_cls):
+    bin_path = BIN_PATH[app_cls]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     alph = seq.ProteinSequence.alphabet
     # Strong identity matrix
     score_matrix = np.identity(len(alph)) * 1000
@@ -114,6 +127,10 @@ def test_custom_substitution_matrix(sequences, app_cls):
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("app_cls", [MuscleApp, MafftApp])
 def test_custom_sequence_type(app_cls):
+    bin_path = BIN_PATH[app_cls]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     alph = seq.Alphabet(("foo", "bar", 42))
     sequences = [seq.GeneralSequence(alph, sequence) for sequence in [
         ["foo", "bar", 42, "foo",        "foo", 42, 42],
@@ -151,6 +168,10 @@ def test_invalid_sequence_type_no_matrix(app_cls):
     A custom substitution matrix is required for normally unsupported
     sequence types.
     """
+    bin_path = BIN_PATH[app_cls]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     alph = seq.Alphabet(("foo", "bar", 42))
     sequences = [seq.GeneralSequence(alph, sequence) for sequence in [
         ["foo", "bar", 42, "foo",        "foo", 42, 42],
@@ -169,6 +190,10 @@ def test_invalid_sequence_type_unsuitable_alphabet(app_cls):
     The alphabet of the custom sequence type cannot be longer than the
     amino acid alphabet.
     """
+    bin_path = BIN_PATH[app_cls]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     alph = seq.Alphabet(range(50))
     sequences = [seq.GeneralSequence(alph, sequence) for sequence in [
         [1,2,3],
@@ -186,6 +211,10 @@ def test_invalid_muscle_version(sequences):
     One of `MuscleApp` and `Muscle5App` should raise an error, since one
     is incompatible with the installed version
     """
+    bin_path = BIN_PATH[MuscleApp]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     if is_not_installed("muscle"):
         pytest.skip(f"'muscle' is not installed")
 
@@ -195,6 +224,10 @@ def test_invalid_muscle_version(sequences):
 
 
 def test_clustalo_matrix(sequences):
+    bin_path = BIN_PATH[ClustalOmegaApp]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     ref_matrix = [
         [0, 1, 2, 3],
         [1, 0, 1, 2],
@@ -211,6 +244,10 @@ def test_clustalo_matrix(sequences):
 
 
 def test_clustalo_tree(sequences):
+    bin_path = BIN_PATH[ClustalOmegaApp]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     leaves = [phylo.TreeNode(index=i) for i in range(len(sequences))]
     inter1 = phylo.TreeNode([leaves[0], leaves[1]], [1.0, 1.0])
     inter2 = phylo.TreeNode([leaves[2], leaves[3]], [2.5, 2.5])
@@ -230,6 +267,10 @@ def test_clustalo_tree(sequences):
 
 
 def test_mafft_tree(sequences):
+    bin_path = BIN_PATH[MafftApp]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     app = MafftApp(sequences)
     app.start()
     app.join()
@@ -238,6 +279,10 @@ def test_mafft_tree(sequences):
 
 
 def test_muscle_tree(sequences):
+    bin_path = BIN_PATH[MuscleApp]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
     try:
         app = MuscleApp(sequences)
     except VersionError:
@@ -251,7 +296,14 @@ def test_muscle_tree(sequences):
 
 
 def test_muscle5_options(sequences):
-    app = Muscle5App(sequences)
+    bin_path = BIN_PATH[Muscle5App]
+    if is_not_installed(bin_path):
+        pytest.skip(f"'{bin_path}' is not installed")
+    
+    try:
+        app = Muscle5App(sequences)
+    except VersionError:
+        pytest.skip(f"Invalid software version")
     app.use_super5()
     app.set_iterations(2, 100)
     app.set_thread_number(2)

--- a/tests/sequence/align/test_pairwise.py
+++ b/tests/sequence/align/test_pairwise.py
@@ -8,6 +8,7 @@ import pytest
 import biotite.sequence as seq
 import biotite.sequence.align as align
 import biotite.application.muscle as muscle
+from biotite.application import VersionError
 from ...util import is_not_installed
 from .util import sequences
 
@@ -94,9 +95,14 @@ def test_align_optimal_complex(sequences, gap_penalty, seq_indices):
         seq1, seq2, matrix,
         gap_penalty=gap_penalty, terminal_penalty=True, max_number=1
     )[0]
-    ref_alignment = muscle.MuscleApp.align(
-        [seq1, seq2], matrix=matrix, gap_penalty=gap_penalty
-    )
+
+    try:
+        ref_alignment = muscle.MuscleApp.align(
+            [seq1, seq2], matrix=matrix, gap_penalty=gap_penalty
+        )
+    except VersionError:
+        pytest.skip(f"Invalid Muscle software version")
+
     # Check whether the score of the optimal alignments is the same
     # or higher as the MUSCLE alignment
     # Direct alignment comparison is not feasible,

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -143,12 +143,13 @@ UNIPROT_URL = "https://www.uniprot.org/"
         "biotite.application.blast",
         [],
     ),
-    pytest.param(
-        "biotite.application.muscle",
-        ["biotite.sequence"],
-        marks = pytest.mark.skipif(
-            is_not_installed("muscle"), reason="Software is not installed")
-        ),
+    # Do not test Muscle due to version clash
+    #pytest.param(
+    #    "biotite.application.muscle",
+    #    ["biotite.sequence"],
+    #    marks = pytest.mark.skipif(
+    #        is_not_installed("muscle"), reason="Software is not installed")
+    #    ),
     pytest.param(
         "biotite.application.clustalo",
         ["biotite.sequence"],
@@ -205,7 +206,6 @@ def test_doctest(package_name, context_package_names):
     # Collect all attributes of this package and its subpackages
     # as globals for the doctests
     globs = {}
-    mod_names = []
     #The package itself is also used as context
     for name in context_package_names + [package_name]:
         context_package = import_module(name)


### PR DESCRIPTION
This PR adds support for *Muscle* version 5. Since *Muscle* 5 is a major rewrite of Muscle 3 with other CLI options, the interface is separated into two `Application` classes: `MuscleApp` for the original *Muscle* 3 and `Muscle5App` for the new *Muscle* 5.