### PR TITLE
Ensure align_vectors inputs are correct

### DIFF
--- a/src/biotite/structure/transform.py
+++ b/src/biotite/structure/transform.py
@@ -428,13 +428,23 @@ def align_vectors(atoms, origin_direction, target_direction,
         A       2  LEU HD22   H        -6.255    7.544   -2.657
         A       2  LEU HD23   H        -5.592    8.445   -1.281
     """
-    origin_direction = np.asarray(origin_direction, dtype=np.float32)
-    target_direction = np.asarray(target_direction, dtype=np.float32)
+    origin_direction = np.asarray(
+        origin_direction, dtype=np.float32
+    ).squeeze()
+    target_direction = np.asarray(
+        target_direction, dtype=np.float32
+    ).squeeze()
     # check that original and target direction are vectors of shape (3,)
     if origin_direction.shape != (3,):
-        raise ValueError("Expexted orgin vector to have shape (3,).")
+        raise ValueError(
+            f"Expexted orgin vector to have shape (3,) "
+            f"got {origin_direction.shape}."
+        )
     if target_direction.shape != (3,):
-        raise ValueError("Expexted target vector to have shape (3,).")
+        raise ValueError(
+            f"Expexted target vector to have shape (3,) "
+            f"got {target_direction.shape}."
+        )
     if np.linalg.norm(origin_direction) == 0:
         raise ValueError("Length of the origin vector is 0")
     if np.linalg.norm(target_direction) == 0:

--- a/src/biotite/structure/transform.py
+++ b/src/biotite/structure/transform.py
@@ -430,6 +430,11 @@ def align_vectors(atoms, origin_direction, target_direction,
     """
     origin_direction = np.asarray(origin_direction, dtype=np.float32)
     target_direction = np.asarray(target_direction, dtype=np.float32)
+    # check that original and target direction are vectors of shape (3,)
+    if origin_direction.shape != (3,):
+        raise ValueError("Expexted orgin vector to have shape (3,).")
+    if target_direction.shape != (3,):
+        raise ValueError("Expexted target vector to have shape (3,).")
     if np.linalg.norm(origin_direction) == 0:
         raise ValueError("Length of the origin vector is 0")
     if np.linalg.norm(target_direction) == 0:
@@ -452,11 +457,11 @@ def align_vectors(atoms, origin_direction, target_direction,
     norm_vector(target_direction)
     # Formula is taken from
     # https://math.stackexchange.com/questions/180418/calculate-rotation-matrix-to-align-vector-a-to-vector-b-in-3d/476311#476311
-    v = np.cross(origin_direction, target_direction)
+    vx, vy, vz = np.cross(origin_direction, target_direction)
     v_c = np.array([
-        [         0, -v[..., 2],  v[..., 1]],
-        [ v[..., 2],          0, -v[..., 0]],
-        [-v[..., 1],  v[..., 0],          0]
+        [  0, -vz,  vy],
+        [ vz,   0, -vx],
+        [-vy,  vx,   0]
     ], dtype=float)
     cos_a = vector_dot(origin_direction, target_direction)
     if np.all(cos_a == -1):
@@ -464,7 +469,7 @@ def align_vectors(atoms, origin_direction, target_direction,
             "Direction vectors are point into opposite directions, "
             "cannot calculate rotation matrix"
         )
-    rot_matrix = np.identity(3) + v_c + (v_c @ v_c) / (1+cos_a)
+    rot_matrix = np.identity(3) + v_c + (v_c @ v_c) / (1 + cos_a)
     
     positions = matrix_rotate(positions, rot_matrix)
     

--- a/src/biotite/structure/transform.py
+++ b/src/biotite/structure/transform.py
@@ -437,8 +437,8 @@ def align_vectors(atoms, origin_direction, target_direction,
     # check that original and target direction are vectors of shape (3,)
     if origin_direction.shape != (3,):
         raise ValueError(
-            f"Expexted orgin vector to have shape (3,) "
-            f"got {origin_direction.shape}."
+            f"Expected origin vector to have shape (3,), "
+            f"got {origin_direction.shape}"
         )
     if target_direction.shape != (3,):
         raise ValueError(

--- a/src/biotite/structure/transform.py
+++ b/src/biotite/structure/transform.py
@@ -442,8 +442,8 @@ def align_vectors(atoms, origin_direction, target_direction,
         )
     if target_direction.shape != (3,):
         raise ValueError(
-            f"Expexted target vector to have shape (3,) "
-            f"got {target_direction.shape}."
+            f"Expected target vector to have shape (3,), "
+            f"got {target_direction.shape}"
         )
     if np.linalg.norm(origin_direction) == 0:
         raise ValueError("Length of the origin vector is 0")

--- a/tests/structure/test_transform.py
+++ b/tests/structure/test_transform.py
@@ -330,14 +330,6 @@ def test_align_vectors_non_vector_inputs(input_atoms):
     """
     Enure input vectors to ``struct.align_vectors`` are the correct shape.
     """
-    source_direction = np.random.rand(1, 3)
-    target_direction = np.random.rand(1, 3)
-    with pytest.raises(ValueError):
-        struc.align_vectors(
-            input_atoms,
-            source_direction,
-            target_direction,
-        )
     source_direction = np.random.rand(2, 3)
     target_direction = np.random.rand(2, 3)
     with pytest.raises(ValueError):

--- a/tests/structure/test_transform.py
+++ b/tests/structure/test_transform.py
@@ -328,7 +328,7 @@ def test_align_vectors(input_atoms, as_list, use_support, random_seed):
 
 def test_align_vectors_non_vector_inputs(input_atoms):
     """
-    Enure input vectors to ``struct.align_vectors`` are the correct shape.
+    Ensure input vectors to ``struct.align_vectors`` have the correct shape.
     """
     source_direction = np.random.rand(2, 3)
     target_direction = np.random.rand(2, 3)

--- a/tests/structure/test_transform.py
+++ b/tests/structure/test_transform.py
@@ -324,3 +324,33 @@ def test_align_vectors(input_atoms, as_list, use_support, random_seed):
     assert np.allclose(
         struc.coord(restored), struc.coord(input_atoms), atol=1e-5
     )
+
+
+def test_align_vectors_non_vector_inputs(input_atoms):
+    """
+    Enure input vectors to ``struct.align_vectors`` are the correct shape.
+    """
+    source_direction = np.random.rand(1, 3)
+    target_direction = np.random.rand(1, 3)
+    with pytest.raises(ValueError):
+        struc.align_vectors(
+            input_atoms,
+            source_direction,
+            target_direction,
+        )
+    source_direction = np.random.rand(2, 3)
+    target_direction = np.random.rand(2, 3)
+    with pytest.raises(ValueError):
+        struc.align_vectors(
+            input_atoms,
+            source_direction,
+            target_direction,
+        )
+    source_direction = np.random.rand(4)
+    target_direction = np.random.rand(4)
+    with pytest.raises(ValueError):
+        struc.align_vectors(
+            input_atoms,
+            source_direction,
+            target_direction,
+        )


### PR DESCRIPTION
If origin_direction or target_direction are shape (1, 3), it is
possible to raise a DeprecationWaring when declaring v_c.
I addressed this by adding a check of the shape of these inputs.
End users could call np.squeeze to ensure the vectors have the
correct shape.

If origin_direction or target_direction have some other shape, the
rest of the code won't work anyway.