### PR TITLE
Structure module patches

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -1,6 +1,7 @@
 CONTRIBUTORS
 ============
 
+- Fabrice Allain <https://github.com/f-allain>
 - Jacob Marcel Anter <https://github.com/jacob-no-cop>
 - Daniel Bauer <https://github.com/danijoo>
 - Patrick Kunzmann <https://github.com/padix-key>

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1374,7 +1374,7 @@ def connect_via_distances(atoms, dict distance_range=None, atom_mask=None,
     Create a :class:`BondList` for a given atom array, based on
     pairwise atom distances.
 
-    A :attr:`BondType.Any`, bond is created for two atoms within the
+    A :attr:`BondType.ANY`, bond is created for two atoms within the
     same residue, if the distance between them is within the expected 
     bond distance range.
     Bonds between two adjacent residues are created for the atoms

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1372,12 +1372,13 @@ def connect_via_distances(atoms, dict distance_range=None,
     Create a :class:`BondList` for a given atom array, based on
     pairwise atom distances.
 
-    A :attr:`BondType.ANY`, bond is created for two atoms within the
+    A :attr:`BondType.SINGLE`, bond is created for two atoms within the
     same residue, if the distance between them is within the expected 
     bond distance range.
     Bonds between two adjacent residues are created for the atoms
     expected to connect these residues, i.e. ``'C'`` and ``'N'`` for
-    peptides and ``"O3'"`` and ``'P'`` for nucleotides.
+    peptides and ``"O3'"`` and ``'P'`` for nucleotides. Those are 
+    approptiately typed.
     
     Parameters
     ----------
@@ -1491,7 +1492,7 @@ def connect_via_distances(atoms, dict distance_range=None,
                     bonds.append((
                         curr_start_i + atom_index1,
                         curr_start_i + atom_index2,
-                        BondType.ANY
+                        BondType.SINGLE
                     ))
 
     bond_list = BondList(atoms.array_length(), np.array(bonds))

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -15,13 +15,15 @@ __all__ = ["BondList", "BondType",
 
 cimport cython
 cimport numpy as np
-from libc.stdlib cimport realloc, malloc, free
+from libc.stdlib cimport free, malloc, realloc
 
-import numbers
 import itertools
+import numbers
 from enum import IntEnum
-import numpy as np
+
 import networkx as nx
+import numpy as np
+
 from ..copyable import Copyable
 
 ctypedef np.uint64_t ptr
@@ -1364,8 +1366,8 @@ _DEFAULT_DISTANCE_RANGE = {
     ("SI", "SE") : (2.359 - 2*0.012,  2.359 + 2*0.012),
 }
 
-def connect_via_distances(atoms, dict distance_range=None,
-                          atom_mask=None, bint inter_residue=True):
+def connect_via_distances(atoms, dict distance_range=None, atom_mask=None, 
+                          bint inter_residue=True, default_bond_type=BondType.Any):
     """
     connect_via_distances(atoms, distance_range=None, atom_mask=None, inter_residue=True)
 
@@ -1401,7 +1403,9 @@ def connect_via_distances(atoms, dict distance_range=None,
     inter_residue : bool, optional
         If true, connections between consecutive amino acids and
         nucleotides are also added.
-    
+    default_bond_type : BondType or int, optional
+        The default type of the bond. Default is :attr:`BondType.ANY`.
+
     Returns
     -------
     BondList
@@ -1424,9 +1428,9 @@ def connect_via_distances(atoms, dict distance_range=None,
     
     .. footbibliography::
     """
-    from .residues import get_residue_starts
-    from .geometry import distance
     from .atoms import AtomArray
+    from .geometry import distance
+    from .residues import get_residue_starts
 
     cdef list bonds = []
     cdef uint8[:] mask = _prepare_mask(atom_mask, atoms.array_length())
@@ -1492,7 +1496,7 @@ def connect_via_distances(atoms, dict distance_range=None,
                     bonds.append((
                         curr_start_i + atom_index1,
                         curr_start_i + atom_index2,
-                        BondType.SINGLE
+                        default_bond_type
                     ))
 
     bond_list = BondList(atoms.array_length(), np.array(bonds))
@@ -1552,8 +1556,8 @@ def connect_via_residue_names(atoms, atom_mask=None, bint inter_residue=True):
     Although this includes most molecules one encounters, this will fail
     for exotic molecules, e.g. specialized inhibitors.
     """
-    from .residues import get_residue_starts
     from .info.bonds import bond_dataset
+    from .residues import get_residue_starts
 
     cdef list bonds = []
     cdef uint8[:] mask = _prepare_mask(atom_mask, atoms.array_length())

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -20,7 +20,6 @@ from libc.stdlib cimport free, malloc, realloc
 import itertools
 import numbers
 from enum import IntEnum
-
 import networkx as nx
 import numpy as np
 

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1502,7 +1502,7 @@ def connect_via_distances(atoms, dict distance_range=None, atom_mask=None,
     
     if inter_residue:
         inter_bonds = _connect_inter_residue(atoms, residue_starts)
-        if default_bond_type == BondType.Any:
+        if default_bond_type == BondType.ANY:
             # As all bonds should be of type ANY, convert also
             # inter-residue bonds to ANY
             inter_bonds.remove_bond_order()

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1374,13 +1374,12 @@ def connect_via_distances(atoms, dict distance_range=None, atom_mask=None,
     Create a :class:`BondList` for a given atom array, based on
     pairwise atom distances.
 
-    A :attr:`BondType.SINGLE`, bond is created for two atoms within the
+    A :attr:`BondType.Any`, bond is created for two atoms within the
     same residue, if the distance between them is within the expected 
     bond distance range.
     Bonds between two adjacent residues are created for the atoms
     expected to connect these residues, i.e. ``'C'`` and ``'N'`` for
-    peptides and ``"O3'"`` and ``'P'`` for nucleotides. Those are 
-    approptiately typed.
+    peptides and ``"O3'"`` and ``'P'`` for nucleotides.
     
     Parameters
     ----------
@@ -1503,9 +1502,10 @@ def connect_via_distances(atoms, dict distance_range=None, atom_mask=None,
     
     if inter_residue:
         inter_bonds = _connect_inter_residue(atoms, residue_starts)
-        # As all bonds should be of type ANY, convert also
-        # inter-residue bonds to ANY
-        inter_bonds.remove_bond_order()
+        if default_bond_type == BondType.Any:
+            # As all bonds should be of type ANY, convert also
+            # inter-residue bonds to ANY
+            inter_bonds.remove_bond_order()
         return bond_list.merge(inter_bonds)
     else:
         return bond_list

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1403,7 +1403,8 @@ def connect_via_distances(atoms, dict distance_range=None, atom_mask=None,
         If true, connections between consecutive amino acids and
         nucleotides are also added.
     default_bond_type : BondType or int, optional
-        The default type of the bond. Default is :attr:`BondType.ANY`.
+        By default, all created bonds have :attr:`BondType.ANY`.
+        An alternative :class:`BondType` can be given in this parameter.
 
     Returns
     -------

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -22,7 +22,6 @@ import numbers
 from enum import IntEnum
 import networkx as nx
 import numpy as np
-
 from ..copyable import Copyable
 
 ctypedef np.uint64_t ptr

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1367,7 +1367,7 @@ _DEFAULT_DISTANCE_RANGE = {
 }
 
 def connect_via_distances(atoms, dict distance_range=None, atom_mask=None, 
-                          bint inter_residue=True, default_bond_type=BondType.Any):
+                          bint inter_residue=True, default_bond_type=BondType.ANY):
     """
     connect_via_distances(atoms, distance_range=None, atom_mask=None, inter_residue=True)
 

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -153,7 +153,7 @@ def write_structure_to_ctab(atoms):
     ]
 
     bond_lines = [
-        f"{i+1:>3d}{j+1:>3d}{BOND_TYPE_MAPPING_REV.get(bond_type, 8):>3d}" +
+        f"{i+1:>3d}{j+1:>3d}{BOND_TYPE_MAPPING_REV.get(bond_type, 1):>3d}" +
         f"{0:>3d}" * 4
         for i, j, bond_type in atoms.bonds.as_array()
     ]

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -152,8 +152,8 @@ def write_structure_to_ctab(atoms, default_bond_type=8):
     ]
 
     counts_line = (
-        f"{len(atom_lines):>3d}{len(bond_lines):>3d}   "
-        + f"  0  0  0  0  0  1 V2000"
+        f"{len(atom_lines):>3d}{len(bond_lines):>3d}     0  0  0  0  0  1 "
+        "V2000"
     )
 
     return [counts_line] + atom_lines + bond_lines + ["M  END"]

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -12,154 +12,146 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["read_structure_from_ctab", "write_structure_to_ctab"]
 
 import warnings
+
 import numpy as np
 
 from biotite.structure.error import BadStructureError
+
 from ..atoms import AtomArray, AtomArrayStack
 from ..bonds import BondList, BondType
 
-
 BOND_TYPE_MAPPING = {
-    1 : BondType.SINGLE,
-    2 : BondType.DOUBLE,
-    3 : BondType.TRIPLE,
-    6 : BondType.SINGLE,
-    7 : BondType.DOUBLE,
-    8 : BondType.ANY,
+    1: BondType.SINGLE,
+    2: BondType.DOUBLE,
+    3: BondType.TRIPLE,
+    6: BondType.SINGLE,
+    7: BondType.DOUBLE,
+    8: BondType.ANY,
 }
 BOND_TYPE_MAPPING_REV = {
-    BondType.SINGLE          : 1,
-    BondType.DOUBLE          : 2,
-    BondType.TRIPLE          : 3,
-    BondType.AROMATIC_SINGLE : 1,
-    BondType.AROMATIC_DOUBLE : 2,
-    BondType.ANY             : 8,
+    BondType.SINGLE: 1,
+    BondType.DOUBLE: 2,
+    BondType.TRIPLE: 3,
+    BondType.AROMATIC_SINGLE: 1,
+    BondType.AROMATIC_DOUBLE: 2,
+    BondType.ANY: 8,
 }
 
-CHARGE_MAPPING = {
-    0:  0,
-    1:  3,
-    2:  2,
-    3:  1,
-    5: -1,
-    6: -2,
-    7: -3
-}
-CHARGE_MAPPING_REV    = {val: key for key, val in    CHARGE_MAPPING.items()}
+CHARGE_MAPPING = {0: 0, 1: 3, 2: 2, 3: 1, 5: -1, 6: -2, 7: -3}
+CHARGE_MAPPING_REV = {val: key for key, val in CHARGE_MAPPING.items()}
 
 
 def read_structure_from_ctab(ctab_lines):
     """
     Parse a *MDL* connection table (Ctab) to obtain an
-    :class:`AtomArray`. :footcite:`Dalby1992` 
+    :class:`AtomArray`. :footcite:`Dalby1992`
 
     Parameters
     ----------
     ctab_lines : lines of str
         The lines containing the *ctab*.
         Must begin with the *counts* line and end with the `M END` line
-    
+
     Returns
     -------
     atoms : AtomArray
         This :class:`AtomArray` contains the optional ``charge``
         annotation and has an associated :class:`BondList`.
-    
+
     References
     ----------
-    
+
     .. footbibliography::
     """
     n_atoms, n_bonds = _get_counts(ctab_lines[0])
     atom_lines = ctab_lines[1 : 1 + n_atoms]
     bond_lines = ctab_lines[1 + n_atoms : 1 + n_atoms + n_bonds]
-    
+
     atoms = AtomArray(n_atoms)
     atoms.add_annotation("charge", int)
     for i, line in enumerate(atom_lines):
-        atoms.coord[i, 0] = float(line[ 0 : 10])
-        atoms.coord[i, 1] = float(line[10 : 20])
-        atoms.coord[i, 2] = float(line[20 : 30])
-        atoms.element[i]  =       line[31 : 34].strip().upper()
-        charge = CHARGE_MAPPING.get(int(line[36 : 39]))
+        atoms.coord[i, 0] = float(line[0:10])
+        atoms.coord[i, 1] = float(line[10:20])
+        atoms.coord[i, 2] = float(line[20:30])
+        atoms.element[i] = line[31:34].strip().upper()
+        charge = CHARGE_MAPPING.get(int(line[36:39]))
         if charge is None:
             warnings.warn(
                 f"Cannot handle MDL charge type {int(line[36 : 39])}, "
                 f"0 is used instead"
             )
             charge = 0
-        atoms.charge[i]   = charge
-    
+        atoms.charge[i] = charge
+
     bond_array = np.zeros((n_bonds, 3), dtype=np.uint32)
     for i, line in enumerate(bond_lines):
-        bond_type = BOND_TYPE_MAPPING.get(int(line[6 : 9]))
+        bond_type = BOND_TYPE_MAPPING.get(int(line[6:9]))
         if bond_type is None:
             warnings.warn(
                 f"Cannot handle MDL bond type {int(line[6 : 9])}, "
                 f"BondType.ANY is used instead"
             )
             bond_type = BondType.ANY
-        bond_array[i, 0] = int(line[0 : 3]) - 1
-        bond_array[i, 1] = int(line[3 : 6]) - 1
+        bond_array[i, 0] = int(line[0:3]) - 1
+        bond_array[i, 1] = int(line[3:6]) - 1
         bond_array[i, 2] = bond_type
     atoms.bonds = BondList(n_atoms, bond_array)
-    
+
     return atoms
 
 
-def write_structure_to_ctab(atoms):
+def write_structure_to_ctab(atoms, default_bond_type: int = 8):
     """
     Convert an :class:`AtomArray` into a
-    *MDL* connection table (Ctab). :footcite:`Dalby1992` 
+    *MDL* connection table (Ctab). :footcite:`Dalby1992`
 
     Parameters
     ----------
     atoms : AtomArray
         The array must have an associated :class:`BondList`.
-    
+
     Returns
     -------
     ctab_lines : lines of str
         The lines containing the *ctab*.
         The lines begin with the *counts* line and end with the `M END`
         .line
-    
+
     References
     ----------
-    
+
     .. footbibliography::
     """
     if isinstance(atoms, AtomArrayStack):
         raise TypeError(
-            "An 'AtomArrayStack' was given, "
-            "but only a single model can be written"
+            "An 'AtomArrayStack' was given, " "but only a single model can be written"
         )
     if atoms.bonds is None:
         raise BadStructureError("Input AtomArray has no associated BondList")
-    
+
     try:
         charge = atoms.charge
     except AttributeError:
         charge = np.zeros(atoms.array_length(), dtype=int)
-    
+
     atom_lines = [
         f"{atoms.coord[i,0]:>10.5f}"
         f"{atoms.coord[i,1]:>10.5f}"
         f"{atoms.coord[i,2]:>10.5f}"
         f" {atoms.element[i]:>3}"
-        f"  {CHARGE_MAPPING_REV.get(charge[i], 0):>3d}" +
-        f"{0:>3d}" * 10
+        f"  {CHARGE_MAPPING_REV.get(charge[i], 0):>3d}" + f"{0:>3d}" * 10
         for i in range(atoms.array_length())
     ]
 
     bond_lines = [
-        f"{i+1:>3d}{j+1:>3d}{BOND_TYPE_MAPPING_REV.get(bond_type, 1):>3d}" +
-        f"{0:>3d}" * 4
+        f"{i+1:>3d}{j+1:>3d}{BOND_TYPE_MAPPING_REV.get(bond_type, default_bond_type):>3d}"
+        + f"{0:>3d}" * 4
         for i, j, bond_type in atoms.bonds.as_array()
     ]
 
-    counts_line = f"{len(atom_lines):>3d}{len(bond_lines):>3d}   " + \
-                  f"  0  0  0  0  0  1 V2000"
+    counts_line = (
+        f"{len(atom_lines):>3d}{len(bond_lines):>3d}   " + f"  0  0  0  0  0  1 V2000"
+    )
 
     return [counts_line] + atom_lines + bond_lines + ["M  END"]
 

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -113,6 +113,9 @@ def write_structure_to_ctab(atoms, default_bond_type=8):
         The lines containing the *ctab*.
         The lines begin with the *counts* line and end with the `M END`
         .line
+    default_bond_type : int
+        Bond type fallback in the *Bond block* if a bond has no bond_type
+        defined in *atoms* array.
 
     References
     ----------
@@ -142,7 +145,8 @@ def write_structure_to_ctab(atoms, default_bond_type=8):
     ]
 
     bond_lines = [
-        f"{i+1:>3d}{j+1:>3d}{BOND_TYPE_MAPPING_REV.get(bond_type, default_bond_type):>3d}"
+        f"{i+1:>3d}{j+1:>3d}"
+        f"{BOND_TYPE_MAPPING_REV.get(bond_type, default_bond_type):>3d}"
         + f"{0:>3d}" * 4
         for i, j, bond_type in atoms.bonds.as_array()
     ]

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -97,7 +97,7 @@ def read_structure_from_ctab(ctab_lines):
     return atoms
 
 
-def write_structure_to_ctab(atoms, default_bond_type: int = 8):
+def write_structure_to_ctab(atoms, default_bond_type=8):
     """
     Convert an :class:`AtomArray` into a
     *MDL* connection table (Ctab). :footcite:`Dalby1992`

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -12,11 +12,8 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["read_structure_from_ctab", "write_structure_to_ctab"]
 
 import warnings
-
 import numpy as np
-
 from biotite.structure.error import BadStructureError
-
 from ..atoms import AtomArray, AtomArrayStack
 from ..bonds import BondList, BondType
 

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -124,7 +124,8 @@ def write_structure_to_ctab(atoms, default_bond_type: int = 8):
     """
     if isinstance(atoms, AtomArrayStack):
         raise TypeError(
-            "An 'AtomArrayStack' was given, " "but only a single model can be written"
+            "An 'AtomArrayStack' was given, "
+            "but only a single model can be written"
         )
     if atoms.bonds is None:
         raise BadStructureError("Input AtomArray has no associated BondList")
@@ -150,7 +151,8 @@ def write_structure_to_ctab(atoms, default_bond_type: int = 8):
     ]
 
     counts_line = (
-        f"{len(atom_lines):>3d}{len(bond_lines):>3d}   " + f"  0  0  0  0  0  1 V2000"
+        f"{len(atom_lines):>3d}{len(bond_lines):>3d}   "
+        + f"  0  0  0  0  0  1 V2000"
     )
 
     return [counts_line] + atom_lines + bond_lines + ["M  END"]

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -238,30 +238,82 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
 
 def _fill_annotations(array, model_dict, extra_fields, use_author_fields):
     prefix = "auth" if use_author_fields else "label"
-    array.set_annotation(
-        "chain_id", model_dict[f"{prefix}_asym_id"].astype("U4")
-    )
-    array.set_annotation(
-        "res_id", np.array(
-            [-1 if e in [".","?"] else int(e)
-             for e in model_dict[f"{prefix}_seq_id"]]
+    if f"{prefix}_asym_id" in model_dict.keys:
+        array.set_annotation(
+            "chain_id", model_dict[f"{prefix}_asym_id"].astype("U4")
         )
-    )
+    else:
+        if use_author_fields:
+            array.set_annotation(
+                "chain_id", model_dict["label_asym_id"].astype("U4")
+            )
+        else:
+            array.set_annotation(
+                "chain_id", model_dict["auth_asym_id"].astype("U4")
+            )
+
+    if f"{prefix}_seq_id" in model_dict.keys:
+        array.set_annotation(
+            "res_id", np.array(
+                [-1 if e in [".","?"] else int(e)
+                for e in model_dict["label_seq_id"]]
+            )
+        )
+    else:
+        if use_author_fields:
+            array.set_annotation(
+                "res_id", np.array(
+                    [-1 if e in [".","?"] else int(e)
+                    for e in model_dict["label_seq_id"]]
+                )
+            )
+        else:
+            array.set_annotation(
+                "res_id", np.array(
+                    [-1 if e in [".","?"] else int(e)
+                    for e in model_dict["auth_seq_id"]]
+                )
+            )
+
     array.set_annotation(
         "ins_code", np.array(
             ["" if e in [".","?"] else e
              for e in model_dict["pdbx_PDB_ins_code"].astype("U1")]
         )
     )
-    array.set_annotation(
-        "res_name", model_dict[f"{prefix}_comp_id"].astype("U3")
-    )
+
+    if f"{prefix}_comp_id" in model_dict.keys:
+        array.set_annotation(
+            "res_name", model_dict[f"{prefix}_comp_id"].astype("U3")
+        )
+    else:
+        if use_author_fields:
+            array.set_annotation(
+                "res_name", model_dict["label_comp_id"].astype("U3")
+            )
+        else:
+            array.set_annotation(
+                "res_name", model_dict["auth_comp_id"].astype("U3")
+            )
+
     array.set_annotation(
         "hetero", (model_dict["group_PDB"] == "HETATM")
     )
-    array.set_annotation(
-        "atom_name", model_dict[f"{prefix}_atom_id"].astype("U6")
-    )
+
+    if f"{prefix}_atom_id" in model_dict.keys:
+        array.set_annotation(
+            "atom_name", model_dict[f"{prefix}_atom_id"].astype("U6")
+        )
+    else:
+        if use_author_fields:
+            array.set_annotation(
+                "atom_name", model_dict["label_atom_id"].astype("U6")
+            )
+        else:
+            array.set_annotation(
+                "atom_name", model_dict["auth_atom_id"].astype("U6")
+            )
+
     array.set_annotation("element", model_dict["type_symbol"].astype("U2"))
     
     for field in extra_fields:

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -15,10 +15,8 @@ __all__ = [
 
 import itertools
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
-import numpy.typing as npt
 
 from ....file import InvalidFileError
 from ....sequence.seqtypes import NucleotideSequence, ProteinSequence
@@ -26,7 +24,6 @@ from ...atoms import AtomArray, AtomArrayStack, repeat
 from ...box import unitcell_from_vectors, vectors_from_unitcell
 from ...filter import filter_first_altloc, filter_highest_occupancy_altloc
 from ...util import matrix_rotate
-from .file import PDBxFile
 
 _proteinseq_type_list = ["polypeptide(D)", "polypeptide(L)"]
 _nucleotideseq_type_list = [
@@ -104,13 +101,13 @@ def get_model_count(file, data_block=None):
 
 
 def get_structure(
-    pdbx_file: PDBxFile,
-    model: Optional[int] = None,
-    data_block: Optional[str] = None,
-    altloc: Literal["first", "occupancy", "all"] = "first",
-    extra_fields: Optional[List[str]] = None,
-    use_author_fields: bool = True,
-) -> Union[AtomArray, AtomArrayStack]:
+    pdbx_file,
+    model=None,
+    data_block=None,
+    altloc="first",
+    extra_fields=None,
+    use_author_fields=True,
+):
     """
     Create an :class:`AtomArray` or :class:`AtomArrayStack` from the
     ``atom_site`` category in a :class:`PDBxFile`.
@@ -261,11 +258,11 @@ def get_structure(
 
 
 def _fill_annotations(
-    array: Union[AtomArrayStack, AtomArray],
-    model_dict: Dict[str, npt.NDArray[Any]],
-    extra_fields: List[str],
-    use_author_fields: bool,
-) -> None:
+    array,
+    model_dict,
+    extra_fields,
+    use_author_fields,
+):
     """Fill atom_site annotations in atom array or atom array stack.
 
     Parameters
@@ -281,30 +278,21 @@ def _fill_annotations(
         prefix
     """
 
-    def get_or_fallback_from_dict(
-        input_dict: Dict[str, Any], key: str, fallback_key: str
-    ) -> Any:
+    def get_or_fallback_from_dict(input_dict, key, fallback_key):
         """
         Return value related to key in input dict if it exists otherwise try to get the
         value related to fallback key."""
         return input_dict[key if key in input_dict else fallback_key]
 
     def get_annotation_from_model(
-        model_dict: Dict[str, npt.NDArray[Any]],
-        annotation_name: str,
-        annotation_fallback: Optional[str] = None,
-        as_type: Optional[
-            Union[
-                Literal["U1", "U2", "U3", "U4", "U6"],
-                Type[str],
-                Type[int],
-                Type[float],
-            ]
-        ] = None,
-        formatter: Optional[Callable[[npt.NDArray[Any]], npt.NDArray[Any]]] = None,
-    ) -> npt.NDArray[Any]:
+        model_dict,
+        annotation_name,
+        annotation_fallback=None,
+        as_type=None,
+        formatter=None,
+    ):
         """Get and format annotation array from model dictionary."""
-        array: npt.NDArray[Any] = (
+        array = (
             get_or_fallback_from_dict(model_dict, annotation_name, annotation_fallback)
             if annotation_fallback is not None
             else model_dict[annotation_name]
@@ -315,22 +303,7 @@ def _fill_annotations(
 
     prefix, alt_prefix = ("auth", "label") if use_author_fields else ("label", "auth")
 
-    annotation_data: Dict[
-        str,
-        Tuple[
-            str,
-            Optional[str],
-            Optional[
-                Union[
-                    Literal["U1", "U2", "U3", "U4", "U6"],
-                    Type[str],
-                    Type[int],
-                    Type[float],
-                ]
-            ],
-            Optional[Callable[[npt.NDArray[Any]], npt.NDArray[Any]]],
-        ],
-    ] = {
+    annotation_data = {
         "chain_id": (f"{prefix}_asym_id", f"{alt_prefix}_asym_id", "U4", None),
         "res_id": (
             f"{prefix}_seq_id",
@@ -364,7 +337,7 @@ def _fill_annotations(
         ),
     }
 
-    mandatory_annotations: List[str] = [
+    mandatory_annotations = [
         "chain_id",
         "res_id",
         "ins_code",
@@ -382,6 +355,7 @@ def _fill_annotations(
             if annotation_name in annotation_data
             else get_annotation_from_model(model_dict, annotation_name, as_type=str),
         )
+
 
 def _filter_altloc(array, model_dict, altloc):
     altloc_ids = model_dict.get("label_alt_id")

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -202,7 +202,9 @@ def get_structure(
                 "instead"
             )
 
-        stack.coord = np.zeros((model_count, model_length, 3), dtype=np.float32)
+        stack.coord = np.zeros(
+            (model_count, model_length, 3), dtype=np.float32
+        )
         stack.coord[:, :, 0] = atom_site_dict["Cartn_x"].reshape(
             (model_count, model_length)
         )
@@ -241,14 +243,22 @@ def get_structure(
         _fill_annotations(array, model_dict, extra_fields, use_author_fields)
 
         # Append exclusive stop
-        model_starts = np.append(model_starts, [len(atom_site_dict["group_PDB"])])
+        model_starts = np.append(
+            model_starts, [len(atom_site_dict["group_PDB"])]
+        )
         # Indexing starts at 0, but model number starts at 1
         model_index = model - 1
         start, stop = model_starts[model_index], model_starts[model_index + 1]
         array.coord = np.zeros((model_length, 3), dtype=np.float32)
-        array.coord[:, 0] = atom_site_dict["Cartn_x"][start:stop].astype(np.float32)
-        array.coord[:, 1] = atom_site_dict["Cartn_y"][start:stop].astype(np.float32)
-        array.coord[:, 2] = atom_site_dict["Cartn_z"][start:stop].astype(np.float32)
+        array.coord[:, 0] = atom_site_dict["Cartn_x"][start:stop].astype(
+            np.float32
+        )
+        array.coord[:, 1] = atom_site_dict["Cartn_y"][start:stop].astype(
+            np.float32
+        )
+        array.coord[:, 2] = atom_site_dict["Cartn_z"][start:stop].astype(
+            np.float32
+        )
 
         array = _filter_altloc(array, model_dict, altloc)
 
@@ -293,7 +303,9 @@ def _fill_annotations(
     ):
         """Get and format annotation array from model dictionary."""
         array = (
-            get_or_fallback_from_dict(model_dict, annotation_name, annotation_fallback)
+            get_or_fallback_from_dict(
+                model_dict, annotation_name, annotation_fallback
+            )
             if annotation_fallback is not None
             else model_dict[annotation_name]
         )
@@ -301,7 +313,9 @@ def _fill_annotations(
             array = array.astype(as_type)
         return formatter(array) if formatter is not None else array
 
-    prefix, alt_prefix = ("auth", "label") if use_author_fields else ("label", "auth")
+    prefix, alt_prefix = (
+        ("auth", "label") if use_author_fields else ("label", "auth")
+    )
 
     annotation_data = {
         "chain_id": (f"{prefix}_asym_id", f"{alt_prefix}_asym_id", "U4", None),
@@ -317,11 +331,18 @@ def _fill_annotations(
             "pdbx_PDB_ins_code",
             None,
             "U1",
-            lambda annot: np.array(["" if elt in [".", "?"] else elt for elt in annot]),
+            lambda annot: np.array(
+                ["" if elt in [".", "?"] else elt for elt in annot]
+            ),
         ),
         "res_name": (f"{prefix}_comp_id", f"{alt_prefix}_comp_id", "U3", None),
         "hetero": ("group_PDB", None, None, lambda annot: annot == "HETATM"),
-        "atom_name": (f"{prefix}_atom_id", f"{alt_prefix}_atom_id", "U6", None),
+        "atom_name": (
+            f"{prefix}_atom_id",
+            f"{alt_prefix}_atom_id",
+            "U6",
+            None,
+        ),
         "element": ("type_symbol", None, "U2", None),
         "atom_id": ("id", None, int, None),
         "b_factor": ("B_iso_or_equiv", None, float, None),
@@ -331,7 +352,10 @@ def _fill_annotations(
             None,
             None,
             lambda annot: np.array(
-                [0 if charge in ["?", "."] else int(charge) for charge in annot],
+                [
+                    0 if charge in ["?", "."] else int(charge)
+                    for charge in annot
+                ],
                 dtype=int,
             ),
         ),
@@ -351,9 +375,13 @@ def _fill_annotations(
     for annotation_name in mandatory_annotations + extra_fields:
         array.set_annotation(
             annotation_name,
-            get_annotation_from_model(model_dict, *annotation_data[annotation_name])
+            get_annotation_from_model(
+                model_dict, *annotation_data[annotation_name]
+            )
             if annotation_name in annotation_data
-            else get_annotation_from_model(model_dict, annotation_name, as_type=str),
+            else get_annotation_from_model(
+                model_dict, annotation_name, as_type=str
+            ),
         )
 
 
@@ -367,7 +395,9 @@ def _filter_altloc(array, model_dict, altloc):
     elif altloc == "occupancy" and occupancy is not None:
         return array[
             ...,
-            filter_highest_occupancy_altloc(array, altloc_ids, occupancy.astype(float)),
+            filter_highest_occupancy_altloc(
+                array, altloc_ids, occupancy.astype(float)
+            ),
         ]
     # 'first' is also fallback if file has no occupancy information
     elif altloc == "first":
@@ -395,7 +425,9 @@ def _get_model_dict(atom_site_dict, model_starts, model):
     model.
     """
     # Append exclusive stop
-    model_starts = np.append(model_starts, [len(atom_site_dict["pdbx_PDB_model_num"])])
+    model_starts = np.append(
+        model_starts, [len(atom_site_dict["pdbx_PDB_model_num"])]
+    )
     model_dict = {}
     # Indexing starts at 0, but model number starts at 1
     model_index = model - 1
@@ -415,7 +447,8 @@ def _get_box(pdbx_file, data_block):
         return None
     try:
         len_a, len_b, len_c = [
-            float(cell_dict[length]) for length in ["length_a", "length_b", "length_c"]
+            float(cell_dict[length])
+            for length in ["length_a", "length_b", "length_c"]
         ]
     except ValueError:
         # 'cell_dict' has no proper unit cell values, e.g. '?'
@@ -515,13 +548,17 @@ def set_structure(pdbx_file, array, data_block=None):
         atom_site_dict["Cartn_z"] = np.array(
             [f"{c:.3f}" for c in np.ravel(array.coord[..., 2])]
         )
-        atom_site_dict["pdbx_PDB_model_num"] = np.full(array.array_length(), "1")
+        atom_site_dict["pdbx_PDB_model_num"] = np.full(
+            array.array_length(), "1"
+        )
     # In case of multiple models repeat annotations
     # and use model specific coordinates
     elif type(array) == AtomArrayStack:
         for key, value in atom_site_dict.items():
             atom_site_dict[key] = np.tile(value, reps=array.stack_depth())
-        coord = np.reshape(array.coord, (array.stack_depth() * array.array_length(), 3))
+        coord = np.reshape(
+            array.coord, (array.stack_depth() * array.array_length(), 3)
+        )
         atom_site_dict["Cartn_x"] = np.array([f"{c:.3f}" for c in coord[:, 0]])
         atom_site_dict["Cartn_y"] = np.array([f"{c:.3f}" for c in coord[:, 1]])
         atom_site_dict["Cartn_z"] = np.array([f"{c:.3f}" for c in coord[:, 2]])
@@ -613,7 +650,9 @@ def list_assemblies(pdbx_file, data_block=None):
         raise InvalidFileError("File has no 'pdbx_struct_assembly' category")
     return {
         id: details
-        for id, details in zip(assembly_category["id"], assembly_category["details"])
+        for id, details in zip(
+            assembly_category["id"], assembly_category["details"]
+        )
     }
 
 
@@ -694,7 +733,9 @@ def get_assembly(
         "pdbx_struct_assembly_gen", data_block, expect_looped=True
     )
     if assembly_gen_category is None:
-        raise InvalidFileError("File has no 'pdbx_struct_assembly_gen' category")
+        raise InvalidFileError(
+            "File has no 'pdbx_struct_assembly_gen' category"
+        )
 
     struct_oper_category = pdbx_file.get_category(
         "pdbx_struct_oper_list", data_block, expect_looped=True
@@ -731,7 +772,12 @@ def get_assembly(
     else:
         extra_fields_and_asym = extra_fields + ["label_asym_id"]
     structure = get_structure(
-        pdbx_file, model, data_block, altloc, extra_fields_and_asym, use_author_fields
+        pdbx_file,
+        model,
+        data_block,
+        altloc,
+        extra_fields_and_asym,
+        use_author_fields,
     )
     # Filter asym IDs
     structure = structure[..., np.isin(structure.label_asym_id, asym_ids)]
@@ -744,11 +790,18 @@ def get_assembly(
     if model is None:
         # Coordinates for AtomArrayStack
         assembly_coord = np.zeros(
-            (len(operations), structure.stack_depth(), structure.array_length(), 3)
+            (
+                len(operations),
+                structure.stack_depth(),
+                structure.array_length(),
+                3,
+            )
         )
     else:
         # Coordinates for AtomArray
-        assembly_coord = np.zeros((len(operations), structure.array_length(), 3))
+        assembly_coord = np.zeros(
+            (len(operations), structure.array_length(), 3)
+        )
 
     ### Apply corresponding transformation for each copy in the assembly
     for i, operation in enumerate(operations):
@@ -771,7 +824,10 @@ def _get_transformations(struct_oper):
     for index, id in enumerate(struct_oper["id"]):
         rotation_matrix = np.array(
             [
-                [float(struct_oper[f"matrix[{i}][{j}]"][index]) for j in (1, 2, 3)]
+                [
+                    float(struct_oper[f"matrix[{i}][{j}]"][index])
+                    for j in (1, 2, 3)
+                ]
                 for i in (1, 2, 3)
             ]
         )
@@ -796,7 +852,9 @@ def _parse_operation_expression(expression):
         if "-" in expr:
             # Range of operation IDs, they must be integers
             first, last = expr.split("-")
-            operations.append([str(id) for id in range(int(first), int(last) + 1)])
+            operations.append(
+                [str(id) for id in range(int(first), int(last) + 1)]
+            )
         elif "," in expr:
             # List of operation IDs
             operations.append(expr.split(","))
@@ -820,4 +878,6 @@ def _convert_string_to_sequence(string, stype):
     elif stype in _other_type_list:
         return None
     else:
-        raise InvalidFileError("mmCIF _entity_poly.type unsupported" " type: " + stype)
+        raise InvalidFileError(
+            "mmCIF _entity_poly.type unsupported" " type: " + stype
+        )

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -15,9 +15,7 @@ __all__ = [
 
 import itertools
 from collections import OrderedDict
-
 import numpy as np
-
 from ....file import InvalidFileError
 from ....sequence.seqtypes import NucleotideSequence, ProteinSequence
 from ...atoms import AtomArray, AtomArrayStack, repeat
@@ -284,14 +282,14 @@ def _fill_annotations(
     extra_fields : List[str]
         Entry names, that are additionally added as annotation arrays.
     use_author_fields : bool
-        Define if alternate fields prefixed with auth should be used instead of label
-        prefix
+        Define if alternate fields prefixed with auth should be used instead
+        of label prefix
     """
 
     def get_or_fallback_from_dict(input_dict, key, fallback_key):
         """
-        Return value related to key in input dict if it exists otherwise try to get the
-        value related to fallback key."""
+        Return value related to key in input dict if it exists otherwise try
+        to get the value related to fallback key."""
         return input_dict[key if key in input_dict else fallback_key]
 
     def get_annotation_from_model(

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -98,14 +98,8 @@ def get_model_count(file, data_block=None):
     return len(_get_model_starts(atom_site_dict["pdbx_PDB_model_num"]))
 
 
-def get_structure(
-    pdbx_file,
-    model=None,
-    data_block=None,
-    altloc="first",
-    extra_fields=None,
-    use_author_fields=True,
-):
+def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
+                  extra_fields=None, use_author_fields=True):
     """
     Create an :class:`AtomArray` or :class:`AtomArrayStack` from the
     ``atom_site`` category in a :class:`PDBxFile`.

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -565,7 +565,7 @@ def set_structure(pdbx_file, array, data_block=None):
         data_blocks = pdbx_file.get_block_names()
         if len(data_blocks) == 0:
             raise TypeError(
-                "No data block is existent in PDBx file, " "must be specified"
+                "No data block is existent in PDBx file, must be specified"
             )
         else:
             data_block = data_blocks[0]

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -643,15 +643,8 @@ def list_assemblies(pdbx_file, data_block=None):
     }
 
 
-def get_assembly(
-    pdbx_file,
-    assembly_id=None,
-    model=None,
-    data_block=None,
-    altloc="first",
-    extra_fields=None,
-    use_author_fields=True,
-):
+def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
+                 altloc="first", extra_fields=None, use_author_fields=True):
     """
     Build the given biological assembly.
 

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -3,7 +3,7 @@
 # information.
 
 __name__ = "biotite.structure.io.pdbx"
-__author__ = "Patrick Kunzmann"
+__author__ = "Fabrice Allain, Patrick Kunzmann"
 __all__ = [
     "get_sequence",
     "get_model_count",

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -264,15 +264,15 @@ def _fill_annotations(array, model_dict, extra_fields, use_author_fields):
 
     Parameters
     ----------
-    array : Union[AtomArrayStack, AtomArray]
-        Atom stack which will be annotated
-    model_dict : Dict[str, npt.NDArray[Any]]
+    array : AtomArray or AtomArrayStack
+        Atom array or stack which will be annotated.
+    model_dict : dict(str, ndarray)
         ``atom_site`` dictionary with values for one model.
-    extra_fields : List[str]
+    extra_fields : list of str
         Entry names, that are additionally added as annotation arrays.
     use_author_fields : bool
-        Define if alternate fields prefixed with auth should be used instead
-        of label prefix
+        Define if alternate fields prefixed with ``auth_`` should be used
+        instead of ``label_``.
     """
 
     def get_or_fallback_from_dict(input_dict, key, fallback_key):

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -259,12 +259,7 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
         return array
 
 
-def _fill_annotations(
-    array,
-    model_dict,
-    extra_fields,
-    use_author_fields,
-):
+def _fill_annotations(array, model_dict, extra_fields, use_author_fields):
     """Fill atom_site annotations in atom array or atom array stack.
 
     Parameters

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -291,8 +291,8 @@ def _fill_annotations(array, model_dict, extra_fields, use_author_fields):
                 return input_dict[fallback_key]
             except KeyError as key_exc:
                 raise InvalidFileError(
-                    f"Fallback key {fallback_key} not found in {dict_name}"
-                    "entry."
+                    f"Fallback attribute '{fallback_key}' not found in "
+                    "'{dict_name}' category"
                 ) from key_exc
         return input_dict[key]
 

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -283,8 +283,8 @@ def _fill_annotations(array, model_dict, extra_fields, use_author_fields):
         otherwise try to get the value related to fallback key."""
         if key not in input_dict:
             warnings.warn(
-                f"Key {key} not found within {dict_name} dictionnary. The "
-                f"fallback key {fallback_key} will be used instead",
+                f"Attribute '{key}' not found within '{dict_name}' category. "
+                f"The fallback attribute '{fallback_key}' will be used instead",
                 UserWarning
             )
             try:

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -306,7 +306,8 @@ def _fill_annotations(array, model_dict, extra_fields, use_author_fields):
         """Get and format annotation array from model dictionary."""
         array = (
             get_or_fallback_from_dict(
-                model_dict, annotation_name, annotation_fallback, dict_name="atom_site"
+                model_dict, annotation_name, annotation_fallback,
+                dict_name="atom_site"
             )
             if annotation_fallback is not None
             else model_dict[annotation_name]

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -4,26 +4,44 @@
 
 __name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
-__all__ = ["get_sequence", "get_model_count", "get_structure", "set_structure",
-           "list_assemblies", "get_assembly"]
+__all__ = [
+    "get_sequence",
+    "get_model_count",
+    "get_structure",
+    "set_structure",
+    "list_assemblies",
+    "get_assembly",
+]
 
 import itertools
-import numpy as np
-from ...error import BadStructureError
-from ....file import InvalidFileError
-from ...atoms import Atom, AtomArray, AtomArrayStack, repeat
-from ...filter import filter_first_altloc, filter_highest_occupancy_altloc
-from ...box import unitcell_from_vectors, vectors_from_unitcell
-from ...util import matrix_rotate
-from ....sequence.seqtypes import ProteinSequence, NucleotideSequence
 from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import numpy as np
+import numpy.typing as npt
+
+from ....file import InvalidFileError
+from ....sequence.seqtypes import NucleotideSequence, ProteinSequence
+from ...atoms import AtomArray, AtomArrayStack, repeat
+from ...box import unitcell_from_vectors, vectors_from_unitcell
+from ...filter import filter_first_altloc, filter_highest_occupancy_altloc
+from ...util import matrix_rotate
+from .file import PDBxFile
 
 _proteinseq_type_list = ["polypeptide(D)", "polypeptide(L)"]
-_nucleotideseq_type_list = ["polydeoxyribonucleotide", "polyribonucleotide",
-                        "polydeoxyribonucleotide/polyribonucleotide hybrid"
-                        ]
-_other_type_list = ["cyclic-pseudo-peptide", "other", "peptide nucleic acid",
-                        "polysaccharide(D)", "polysaccharide(L)"]
+_nucleotideseq_type_list = [
+    "polydeoxyribonucleotide",
+    "polyribonucleotide",
+    "polydeoxyribonucleotide/polyribonucleotide hybrid",
+]
+_other_type_list = [
+    "cyclic-pseudo-peptide",
+    "other",
+    "peptide nucleic acid",
+    "polysaccharide(D)",
+    "polysaccharide(L)",
+]
+
 
 def get_sequence(pdbx_file, data_block=None):
     """
@@ -35,7 +53,7 @@ def get_sequence(pdbx_file, data_block=None):
     ``'polydeoxyribonucleotide'``, ``'polyribonucleotide'`` and
     ``'polydeoxyribonucleotide/polyribonucleotide hybrid'``.
     Uracil is converted to Thymine.
-    
+
     Parameters
     ----------
     pdbx_file : PDBxFile
@@ -43,7 +61,7 @@ def get_sequence(pdbx_file, data_block=None):
     data_block : string, optional
         The name of the data block. Default is the first
         (and most times only) data block of the file.
-        
+
     Returns
     -------
     sequences : list of Sequence
@@ -58,7 +76,7 @@ def get_sequence(pdbx_file, data_block=None):
         for string, stype in zip(seq_string, seq_type):
             sequence = _convert_string_to_sequence(string, stype)
             if sequence is not None:
-                sequences.append(sequence) 
+                sequences.append(sequence)
     else:
         sequences.append(_convert_string_to_sequence(seq_string, seq_type))
     return sequences
@@ -85,12 +103,18 @@ def get_model_count(file, data_block=None):
     return len(_get_model_starts(atom_site_dict["pdbx_PDB_model_num"]))
 
 
-def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
-                  extra_fields=None, use_author_fields=True):
+def get_structure(
+    pdbx_file: PDBxFile,
+    model: Optional[int] = None,
+    data_block: Optional[str] = None,
+    altloc: Literal["first", "occupancy", "all"] = "first",
+    extra_fields: Optional[List[str]] = None,
+    use_author_fields: bool = True,
+) -> Union[AtomArray, AtomArrayStack]:
     """
     Create an :class:`AtomArray` or :class:`AtomArrayStack` from the
     ``atom_site`` category in a :class:`PDBxFile`.
-    
+
     Parameters
     ----------
     pdbx_file : PDBxFile
@@ -138,12 +162,12 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
         If `use_author_fields` is true, the annotation arrays will be
         read from the ``auth_xxx`` fields (if applicable),
         otherwise from the the ``label_xxx`` fields.
-        
+
     Returns
     -------
     array : AtomArray or AtomArrayStack
         The return type depends on the `model` parameter.
-        
+
     Examples
     --------
 
@@ -152,50 +176,55 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
     >>> arr = get_structure(file, model=1)
     >>> print(len(arr))
     304
-    
+
     """
     altloc = [] if altloc is None else altloc
     extra_fields = [] if extra_fields is None else extra_fields
-    
+
     atom_site_dict = pdbx_file.get_category("atom_site", data_block)
     models = atom_site_dict["pdbx_PDB_model_num"]
     model_starts = _get_model_starts(models)
     model_count = len(model_starts)
     atom_count = len(models)
-    
+
     if model is None:
         # For a stack, the annotations are derived from the first model
         model_dict = _get_model_dict(atom_site_dict, model_starts, 1)
         # Any field of the category would work here to get the length
         model_length = len(model_dict["group_PDB"])
         stack = AtomArrayStack(model_count, model_length)
-        
+
         _fill_annotations(stack, model_dict, extra_fields, use_author_fields)
-        
+
         # Check if each model has the same amount of atoms
         # If not, raise exception
         if model_length * model_count != atom_count:
-            raise InvalidFileError("The models in the file have unequal "
-                                   "amount of atoms, give an explicit model "
-                                   "instead")
-        
-        stack.coord = np.zeros((model_count,model_length,3), dtype=np.float32)
-        stack.coord[:,:,0] = atom_site_dict["Cartn_x"].reshape((model_count,
-                                                                model_length))
-        stack.coord[:,:,1] = atom_site_dict["Cartn_y"].reshape((model_count,
-                                                                model_length))
-        stack.coord[:,:,2] = atom_site_dict["Cartn_z"].reshape((model_count,
-                                                                model_length))
-        
+            raise InvalidFileError(
+                "The models in the file have unequal "
+                "amount of atoms, give an explicit model "
+                "instead"
+            )
+
+        stack.coord = np.zeros((model_count, model_length, 3), dtype=np.float32)
+        stack.coord[:, :, 0] = atom_site_dict["Cartn_x"].reshape(
+            (model_count, model_length)
+        )
+        stack.coord[:, :, 1] = atom_site_dict["Cartn_y"].reshape(
+            (model_count, model_length)
+        )
+        stack.coord[:, :, 2] = atom_site_dict["Cartn_z"].reshape(
+            (model_count, model_length)
+        )
+
         stack = _filter_altloc(stack, model_dict, altloc)
-        
+
         box = _get_box(pdbx_file, data_block)
         if box is not None:
             # Duplicate same box for each model
             stack.box = np.repeat(box[np.newaxis, ...], model_count, axis=0)
-        
+
         return stack
-    
+
     else:
         if model == 0:
             raise ValueError("The model index must not be 0")
@@ -211,149 +240,160 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
         # Any field of the category would work here to get the length
         model_length = len(model_dict["group_PDB"])
         array = AtomArray(model_length)
-        
+
         _fill_annotations(array, model_dict, extra_fields, use_author_fields)
-        
+
         # Append exclusive stop
-        model_starts = np.append(
-            model_starts, [len(atom_site_dict["group_PDB"])]
-        )
+        model_starts = np.append(model_starts, [len(atom_site_dict["group_PDB"])])
         # Indexing starts at 0, but model number starts at 1
         model_index = model - 1
-        start, stop = model_starts[model_index], model_starts[model_index+1]
+        start, stop = model_starts[model_index], model_starts[model_index + 1]
         array.coord = np.zeros((model_length, 3), dtype=np.float32)
-        array.coord[:,0] = atom_site_dict["Cartn_x"][start : stop] \
-                           .astype(np.float32)
-        array.coord[:,1] = atom_site_dict["Cartn_y"][start : stop] \
-                           .astype(np.float32)
-        array.coord[:,2] = atom_site_dict["Cartn_z"][start : stop] \
-                           .astype(np.float32)
-        
+        array.coord[:, 0] = atom_site_dict["Cartn_x"][start:stop].astype(np.float32)
+        array.coord[:, 1] = atom_site_dict["Cartn_y"][start:stop].astype(np.float32)
+        array.coord[:, 2] = atom_site_dict["Cartn_z"][start:stop].astype(np.float32)
+
         array = _filter_altloc(array, model_dict, altloc)
-        
+
         array.box = _get_box(pdbx_file, data_block)
-        
+
         return array
-        
 
-def _fill_annotations(array, model_dict, extra_fields, use_author_fields):
-    prefix = "auth" if use_author_fields else "label"
-    if f"{prefix}_asym_id" in model_dict.keys:
+
+def _fill_annotations(
+    array: Union[AtomArrayStack, AtomArray],
+    model_dict: Dict[str, npt.NDArray[Any]],
+    extra_fields: List[str],
+    use_author_fields: bool,
+) -> None:
+    """Fill atom_site annotations in atom array or atom array stack.
+
+    Parameters
+    ----------
+    array : Union[AtomArrayStack, AtomArray]
+        Atom stack which will be annotated
+    model_dict : Dict[str, npt.NDArray[Any]]
+        ``atom_site`` dictionary with values for one model.
+    extra_fields : List[str]
+        Entry names, that are additionally added as annotation arrays.
+    use_author_fields : bool
+        Define if alternate fields prefixed with auth should be used instead of label
+        prefix
+    """
+
+    def get_or_fallback_from_dict(
+        input_dict: Dict[str, Any], key: str, fallback_key: str
+    ) -> Any:
+        """
+        Return value related to key in input dict if it exists otherwise try to get the
+        value related to fallback key."""
+        return input_dict[key if key in input_dict else fallback_key]
+
+    def get_annotation_from_model(
+        model_dict: Dict[str, npt.NDArray[Any]],
+        annotation_name: str,
+        annotation_fallback: Optional[str] = None,
+        as_type: Optional[
+            Union[
+                Literal["U1", "U2", "U3", "U4", "U6"],
+                Type[str],
+                Type[int],
+                Type[float],
+            ]
+        ] = None,
+        formatter: Optional[Callable[[npt.NDArray[Any]], npt.NDArray[Any]]] = None,
+    ) -> npt.NDArray[Any]:
+        """Get and format annotation array from model dictionary."""
+        array: npt.NDArray[Any] = (
+            get_or_fallback_from_dict(model_dict, annotation_name, annotation_fallback)
+            if annotation_fallback is not None
+            else model_dict[annotation_name]
+        )
+        if as_type is not None:
+            array = array.astype(as_type)
+        return formatter(array) if formatter is not None else array
+
+    prefix, alt_prefix = ("auth", "label") if use_author_fields else ("label", "auth")
+
+    annotation_data: Dict[
+        str,
+        Tuple[
+            str,
+            Optional[str],
+            Optional[
+                Union[
+                    Literal["U1", "U2", "U3", "U4", "U6"],
+                    Type[str],
+                    Type[int],
+                    Type[float],
+                ]
+            ],
+            Optional[Callable[[npt.NDArray[Any]], npt.NDArray[Any]]],
+        ],
+    ] = {
+        "chain_id": (f"{prefix}_asym_id", f"{alt_prefix}_asym_id", "U4", None),
+        "res_id": (
+            f"{prefix}_seq_id",
+            f"{alt_prefix}_seq_id",
+            None,
+            lambda annot: np.array(
+                [-1 if elt in [".", "?"] else int(elt) for elt in annot]
+            ),
+        ),
+        "ins_code": (
+            "pdbx_PDB_ins_code",
+            None,
+            "U1",
+            lambda annot: np.array(["" if elt in [".", "?"] else elt for elt in annot]),
+        ),
+        "res_name": (f"{prefix}_comp_id", f"{alt_prefix}_comp_id", "U3", None),
+        "hetero": ("group_PDB", None, None, lambda annot: annot == "HETATM"),
+        "atom_name": (f"{prefix}_atom_id", f"{alt_prefix}_atom_id", "U6", None),
+        "element": ("type_symbol", None, "U2", None),
+        "atom_id": ("id", None, int, None),
+        "b_factor": ("B_iso_or_equiv", None, float, None),
+        "occupancy": ("occupancy", None, float, None),
+        "charge": (
+            "pdbx_formal_charge",
+            None,
+            None,
+            lambda annot: np.array(
+                [0 if charge in ["?", "."] else int(charge) for charge in annot],
+                dtype=int,
+            ),
+        ),
+    }
+
+    mandatory_annotations: List[str] = [
+        "chain_id",
+        "res_id",
+        "ins_code",
+        "res_name",
+        "hetero",
+        "atom_name",
+        "element",
+    ]
+
+    # Iterate over mandatory annotations and given extra_fields
+    for annotation_name in mandatory_annotations + extra_fields:
         array.set_annotation(
-            "chain_id", model_dict[f"{prefix}_asym_id"].astype("U4")
+            annotation_name,
+            get_annotation_from_model(model_dict, *annotation_data[annotation_name])
+            if annotation_name in annotation_data
+            else get_annotation_from_model(model_dict, annotation_name, as_type=str),
         )
-    else:
-        if use_author_fields:
-            array.set_annotation(
-                "chain_id", model_dict["label_asym_id"].astype("U4")
-            )
-        else:
-            array.set_annotation(
-                "chain_id", model_dict["auth_asym_id"].astype("U4")
-            )
-
-    if f"{prefix}_seq_id" in model_dict.keys:
-        array.set_annotation(
-            "res_id", np.array(
-                [-1 if e in [".","?"] else int(e)
-                for e in model_dict["label_seq_id"]]
-            )
-        )
-    else:
-        if use_author_fields:
-            array.set_annotation(
-                "res_id", np.array(
-                    [-1 if e in [".","?"] else int(e)
-                    for e in model_dict["label_seq_id"]]
-                )
-            )
-        else:
-            array.set_annotation(
-                "res_id", np.array(
-                    [-1 if e in [".","?"] else int(e)
-                    for e in model_dict["auth_seq_id"]]
-                )
-            )
-
-    array.set_annotation(
-        "ins_code", np.array(
-            ["" if e in [".","?"] else e
-             for e in model_dict["pdbx_PDB_ins_code"].astype("U1")]
-        )
-    )
-
-    if f"{prefix}_comp_id" in model_dict.keys:
-        array.set_annotation(
-            "res_name", model_dict[f"{prefix}_comp_id"].astype("U3")
-        )
-    else:
-        if use_author_fields:
-            array.set_annotation(
-                "res_name", model_dict["label_comp_id"].astype("U3")
-            )
-        else:
-            array.set_annotation(
-                "res_name", model_dict["auth_comp_id"].astype("U3")
-            )
-
-    array.set_annotation(
-        "hetero", (model_dict["group_PDB"] == "HETATM")
-    )
-
-    if f"{prefix}_atom_id" in model_dict.keys:
-        array.set_annotation(
-            "atom_name", model_dict[f"{prefix}_atom_id"].astype("U6")
-        )
-    else:
-        if use_author_fields:
-            array.set_annotation(
-                "atom_name", model_dict["label_atom_id"].astype("U6")
-            )
-        else:
-            array.set_annotation(
-                "atom_name", model_dict["auth_atom_id"].astype("U6")
-            )
-
-    array.set_annotation("element", model_dict["type_symbol"].astype("U2"))
-    
-    for field in extra_fields:
-        if field == "atom_id":
-            array.set_annotation(
-                "atom_id", model_dict["id"].astype(int)
-            )
-        elif field == "b_factor":
-            array.set_annotation(
-                "b_factor", model_dict["B_iso_or_equiv"].astype(float)
-            )
-        elif field == "occupancy":
-            array.set_annotation(
-                "occupancy", model_dict["occupancy"].astype(float)
-            )
-        elif field == "charge":
-            array.set_annotation(
-                "charge", np.array(
-                    [0 if charge in ["?","."] else int(charge)
-                     for charge in model_dict["pdbx_formal_charge"]],
-                    dtype=int
-                )
-            )
-        else:
-            array.set_annotation(field, model_dict[field].astype(str))
-
 
 def _filter_altloc(array, model_dict, altloc):
     altloc_ids = model_dict.get("label_alt_id")
-    occupancy =  model_dict.get("occupancy")
-    
+    occupancy = model_dict.get("occupancy")
+
     # Filter altloc IDs and return
     if altloc_ids is None:
         return array
     elif altloc == "occupancy" and occupancy is not None:
         return array[
             ...,
-            filter_highest_occupancy_altloc(
-                array, altloc_ids, occupancy.astype(float)
-            )
+            filter_highest_occupancy_altloc(array, altloc_ids, occupancy.astype(float)),
         ]
     # 'first' is also fallback if file has no occupancy information
     elif altloc == "first":
@@ -381,15 +421,13 @@ def _get_model_dict(atom_site_dict, model_starts, model):
     model.
     """
     # Append exclusive stop
-    model_starts = np.append(
-        model_starts, [len(atom_site_dict["pdbx_PDB_model_num"])]
-    )
+    model_starts = np.append(model_starts, [len(atom_site_dict["pdbx_PDB_model_num"])])
     model_dict = {}
     # Indexing starts at 0, but model number starts at 1
     model_index = model - 1
     for key in atom_site_dict.keys():
         model_dict[key] = atom_site_dict[key][
-            model_starts[model_index] : model_starts[model_index+1]
+            model_starts[model_index] : model_starts[model_index + 1]
         ]
     return model_dict
 
@@ -402,29 +440,31 @@ def _get_box(pdbx_file, data_block):
     if cell_dict is None:
         return None
     try:
-        len_a, len_b, len_c = [float(cell_dict[length]) for length
-                               in ["length_a", "length_b", "length_c"]]
+        len_a, len_b, len_c = [
+            float(cell_dict[length]) for length in ["length_a", "length_b", "length_c"]
+        ]
     except ValueError:
         # 'cell_dict' has no proper unit cell values, e.g. '?'
         return None
-    alpha, beta, gamma =  [np.deg2rad(float(cell_dict[angle])) for angle
-                           in ["angle_alpha", "angle_beta", "angle_gamma"]]
+    alpha, beta, gamma = [
+        np.deg2rad(float(cell_dict[angle]))
+        for angle in ["angle_alpha", "angle_beta", "angle_gamma"]
+    ]
     return vectors_from_unitcell(len_a, len_b, len_c, alpha, beta, gamma)
-
 
 
 def set_structure(pdbx_file, array, data_block=None):
     """
     Set the `atom_site` category with an
     :class:`AtomArray` or :class:`AtomArrayStack`.
-    
+
     This will save the coordinates, the mandatory annotation categories
     and the optional annotation categories
     ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and ``'charge'``.
     If the atom array (stack) contains the annotation ``'atom_id'``,
     these values will be used for atom numbering instead of continuous
     numbering.
-    
+
     Parameters
     ----------
     pdbx_file : PDBxFile
@@ -435,7 +475,7 @@ def set_structure(pdbx_file, array, data_block=None):
     data_block : str, optional
         The name of the data block. Default is the first
         (and most times only) data block of the file.
-    
+
     Examples
     --------
 
@@ -443,17 +483,18 @@ def set_structure(pdbx_file, array, data_block=None):
     >>> file = PDBxFile()
     >>> set_structure(file, atom_array, data_block="structure")
     >>> file.write(os.path.join(path_to_directory, "structure.cif"))
-    
+
     """
     # Fill PDBx columns from information
     # in structures' attribute arrays as good as possible
     # Use OrderedDict in order to ensure the usually used column order.
     atom_site_dict = OrderedDict()
     # Save list of annotation categories for checks,
-    # if an optional category exists 
+    # if an optional category exists
     annot_categories = array.get_annotation_categories()
-    atom_site_dict["group_PDB"] = np.array(["ATOM" if e == False else "HETATM"
-                                            for e in array.hetero])
+    atom_site_dict["group_PDB"] = np.array(
+        ["ATOM" if e == False else "HETATM" for e in array.hetero]
+    )
     atom_site_dict["type_symbol"] = np.copy(array.element)
     atom_site_dict["label_atom_id"] = np.copy(array.atom_name)
     atom_site_dict["label_alt_id"] = np.full(array.array_length(), ".")
@@ -466,7 +507,7 @@ def set_structure(pdbx_file, array, data_block=None):
     atom_site_dict["auth_comp_id"] = atom_site_dict["label_comp_id"]
     atom_site_dict["auth_asym_id"] = atom_site_dict["label_asym_id"]
     atom_site_dict["auth_atom_id"] = atom_site_dict["label_atom_id"]
-    
+
     if "atom_id" in annot_categories:
         atom_site_dict["id"] = np.array([str(e) for e in array.atom_id])
     else:
@@ -483,61 +524,55 @@ def set_structure(pdbx_file, array, data_block=None):
         atom_site_dict["pdbx_formal_charge"] = np.array(
             [f"{c:+d}" if c != 0 else "?" for c in array.charge]
         )
-    
+
     # In case of a single model handle each coordinate
     # simply like a flattened array
-    if (  type(array) == AtomArray or
-         (type(array) == AtomArrayStack and array.stack_depth() == 1)  ):
+    if type(array) == AtomArray or (
+        type(array) == AtomArrayStack and array.stack_depth() == 1
+    ):
         # 'ravel' flattens coord without copy
         # in case of stack with stack_depth = 1
         atom_site_dict["Cartn_x"] = np.array(
-            [f"{c:.3f}" for c in np.ravel(array.coord[...,0])]
+            [f"{c:.3f}" for c in np.ravel(array.coord[..., 0])]
         )
         atom_site_dict["Cartn_y"] = np.array(
-            [f"{c:.3f}" for c in np.ravel(array.coord[...,1])]
+            [f"{c:.3f}" for c in np.ravel(array.coord[..., 1])]
         )
         atom_site_dict["Cartn_z"] = np.array(
-            [f"{c:.3f}" for c in np.ravel(array.coord[...,2])]
+            [f"{c:.3f}" for c in np.ravel(array.coord[..., 2])]
         )
-        atom_site_dict["pdbx_PDB_model_num"] = np.full(
-            array.array_length(), "1"
-        )
+        atom_site_dict["pdbx_PDB_model_num"] = np.full(array.array_length(), "1")
     # In case of multiple models repeat annotations
     # and use model specific coordinates
     elif type(array) == AtomArrayStack:
         for key, value in atom_site_dict.items():
             atom_site_dict[key] = np.tile(value, reps=array.stack_depth())
-        coord = np.reshape(array.coord,
-                           (array.stack_depth()*array.array_length(), 3))
-        atom_site_dict["Cartn_x"] = np.array(
-            [f"{c:.3f}" for c in coord[:,0]]
-        )
-        atom_site_dict["Cartn_y"] = np.array(
-            [f"{c:.3f}" for c in coord[:,1]]
-        )
-        atom_site_dict["Cartn_z"] = np.array(
-            [f"{c:.3f}" for c in coord[:,2]]
-        )
+        coord = np.reshape(array.coord, (array.stack_depth() * array.array_length(), 3))
+        atom_site_dict["Cartn_x"] = np.array([f"{c:.3f}" for c in coord[:, 0]])
+        atom_site_dict["Cartn_y"] = np.array([f"{c:.3f}" for c in coord[:, 1]])
+        atom_site_dict["Cartn_z"] = np.array([f"{c:.3f}" for c in coord[:, 2]])
         models = np.repeat(
-            np.arange(1, array.stack_depth()+1).astype(str),
-            repeats=array.array_length()
+            np.arange(1, array.stack_depth() + 1).astype(str),
+            repeats=array.array_length(),
         )
         atom_site_dict["pdbx_PDB_model_num"] = models
     else:
         raise ValueError("Structure must be AtomArray or AtomArrayStack")
     if not "atom_id" in annot_categories:
         # Count from 1
-        atom_site_dict["id"] = (np.arange(1,len(atom_site_dict["group_PDB"])+1)
-                               .astype("U6"))
+        atom_site_dict["id"] = np.arange(
+            1, len(atom_site_dict["group_PDB"]) + 1
+        ).astype("U6")
     if data_block is None:
         data_blocks = pdbx_file.get_block_names()
         if len(data_blocks) == 0:
-            raise TypeError("No data block is existent in PDBx file, "
-                            "must be specified")
+            raise TypeError(
+                "No data block is existent in PDBx file, " "must be specified"
+            )
         else:
             data_block = data_blocks[0]
     pdbx_file.set_category("atom_site", atom_site_dict, data_block)
-    
+
     # Write box into file
     if array.box is not None:
         # PDBx files can only store one box for all models
@@ -552,7 +587,7 @@ def set_structure(pdbx_file, array, data_block=None):
         cell_dict["length_b"] = "{:6.3f}".format(len_b)
         cell_dict["length_c"] = "{:6.3f}".format(len_c)
         cell_dict["angle_alpha"] = "{:5.3f}".format(np.rad2deg(alpha))
-        cell_dict["angle_beta"]  = "{:5.3f}".format(np.rad2deg(beta ))
+        cell_dict["angle_beta"] = "{:5.3f}".format(np.rad2deg(beta))
         cell_dict["angle_gamma"] = "{:5.3f}".format(np.rad2deg(gamma))
         pdbx_file.set_category("cell", cell_dict, data_block)
 
@@ -573,7 +608,6 @@ def _determine_entity_id(chain_id):
     return entity_id.astype(str)
 
 
-
 def list_assemblies(pdbx_file, data_block=None):
     """
     List the biological assemblies that are available for the structure
@@ -591,7 +625,7 @@ def list_assemblies(pdbx_file, data_block=None):
         The name of the data block.
         Defaults to the first (and most times only) data block of the
         file.
-    
+
     Returns
     -------
     assemblies : dict of str -> str
@@ -603,12 +637,21 @@ def list_assemblies(pdbx_file, data_block=None):
     )
     if assembly_category is None:
         raise InvalidFileError("File has no 'pdbx_struct_assembly' category")
-    return {id: details for id, details in
-            zip(assembly_category["id"], assembly_category["details"])}
+    return {
+        id: details
+        for id, details in zip(assembly_category["id"], assembly_category["details"])
+    }
 
 
-def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
-                 altloc="first", extra_fields=None, use_author_fields=True):
+def get_assembly(
+    pdbx_file,
+    assembly_id=None,
+    model=None,
+    data_block=None,
+    altloc="first",
+    extra_fields=None,
+    use_author_fields=True,
+):
     """
     Build the given biological assembly.
 
@@ -667,7 +710,7 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
         If `use_author_fields` is true, the annotation arrays will be
         read from the ``auth_xxx`` fields (if applicable),
         otherwise from the the ``label_xxx`` fields.
-    
+
     Returns
     -------
     assembly : AtomArray or AtomArrayStack
@@ -677,9 +720,7 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
         "pdbx_struct_assembly_gen", data_block, expect_looped=True
     )
     if assembly_gen_category is None:
-        raise InvalidFileError(
-            "File has no 'pdbx_struct_assembly_gen' category"
-        )
+        raise InvalidFileError("File has no 'pdbx_struct_assembly_gen' category")
 
     struct_oper_category = pdbx_file.get_category(
         "pdbx_struct_oper_list", data_block, expect_looped=True
@@ -694,21 +735,19 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
 
     transformations = _get_transformations(struct_oper_category)
 
-
     ### Get transformations to apply and the affected asym IDs
     # Find the operation expression for given assembly ID
     # We already asserted that the ID is actually present
     for id, op_expr, asym_id_expr in zip(
         assembly_gen_category["assembly_id"],
         assembly_gen_category["oper_expression"],
-        assembly_gen_category["asym_id_list"]
+        assembly_gen_category["asym_id_list"],
     ):
         if id == assembly_id:
             operations = _parse_operation_expression(op_expr)
             asym_ids = asym_id_expr.split(",")
             break
-    
-    
+
     ### Get structure containing the affected asym IDs
     # Include 'label_asym_id' as annotation array
     # for correct asym ID filtering
@@ -718,8 +757,7 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
     else:
         extra_fields_and_asym = extra_fields + ["label_asym_id"]
     structure = get_structure(
-        pdbx_file, model, data_block,
-        altloc, extra_fields_and_asym, use_author_fields
+        pdbx_file, model, data_block, altloc, extra_fields_and_asym, use_author_fields
     )
     # Filter asym IDs
     structure = structure[..., np.isin(structure.label_asym_id, asym_ids)]
@@ -728,20 +766,15 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
     if "label_asym_id" not in extra_fields:
         structure.del_annotation("label_asym_id")
 
-
     ### Prepare coordinates
     if model is None:
         # Coordinates for AtomArrayStack
         assembly_coord = np.zeros(
-            (len(operations), structure.stack_depth(),
-             structure.array_length(), 3)
+            (len(operations), structure.stack_depth(), structure.array_length(), 3)
         )
     else:
         # Coordinates for AtomArray
-        assembly_coord = np.zeros(
-            (len(operations), structure.array_length(), 3)
-        )
-    
+        assembly_coord = np.zeros((len(operations), structure.array_length(), 3))
 
     ### Apply corresponding transformation for each copy in the assembly
     for i, operation in enumerate(operations):
@@ -755,20 +788,22 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
             # Translate
             coord += translation_vector
         assembly_coord[i] = coord
-    
-    return repeat(structure, assembly_coord)     
+
+    return repeat(structure, assembly_coord)
 
 
 def _get_transformations(struct_oper):
     transformation_dict = {}
     for index, id in enumerate(struct_oper["id"]):
-        rotation_matrix = np.array([
-            [float(struct_oper[f"matrix[{i}][{j}]"][index]) for j in (1,2,3)]
-            for i in (1,2,3)
-        ])
-        translation_vector = np.array([
-            float(struct_oper[f"vector[{i}]"][index]) for i in (1,2,3)
-        ])
+        rotation_matrix = np.array(
+            [
+                [float(struct_oper[f"matrix[{i}][{j}]"][index]) for j in (1, 2, 3)]
+                for i in (1, 2, 3)
+            ]
+        )
+        translation_vector = np.array(
+            [float(struct_oper[f"vector[{i}]"][index]) for i in (1, 2, 3)]
+        )
         transformation_dict[id] = (rotation_matrix, translation_vector)
     return transformation_dict
 
@@ -776,8 +811,8 @@ def _get_transformations(struct_oper):
 def _parse_operation_expression(expression):
     # Split groups by parentheses:
     # use the opening parenthesis as delimiter
-    # and just remove the closing parenthesis 
-    expressions_per_step = expression.replace(")","").split("(")
+    # and just remove the closing parenthesis
+    expressions_per_step = expression.replace(")", "").split("(")
     expressions_per_step = [e for e in expressions_per_step if len(e) > 0]
     # Important: Operations are applied from right to left
     expressions_per_step.reverse()
@@ -787,9 +822,7 @@ def _parse_operation_expression(expression):
         if "-" in expr:
             # Range of operation IDs, they must be integers
             first, last = expr.split("-")
-            operations.append(
-                [str(id) for id in range(int(first), int(last)+1)]
-            )
+            operations.append([str(id) for id in range(int(first), int(last) + 1)])
         elif "," in expr:
             # List of operation IDs
             operations.append(expr.split(","))
@@ -813,5 +846,4 @@ def _convert_string_to_sequence(string, stype):
     elif stype in _other_type_list:
         return None
     else:
-        raise InvalidFileError("mmCIF _entity_poly.type unsupported"
-                               " type: " + stype)
+        raise InvalidFileError("mmCIF _entity_poly.type unsupported" " type: " + stype)

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -338,8 +338,10 @@ class PDBxFile(TextFile, MutableMapping):
         # Enclose values with quotes if required
         for key, value in category_dict.items():
             if is_looped:
-                for i in range(len(value)):
-                    value[i] = _quote(value[i])
+                list_value = value.tolist()
+                for i in range(len(list_value)):
+                    list_value[i] = _quote(list_value[i])
+                category_dict[key] = np.asarray(list_value)
             else:
                 category_dict[key] = _quote(value)
         

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -148,7 +148,9 @@ class PDBxFile(TextFile, MutableMapping):
                     if is_loop_in_line:
                         # In case of lines with "loop_" the category is in the
                         # next line
-                        category_in_line = _get_category_name(file.lines[i + 1])
+                        category_in_line = _get_category_name(
+                            file.lines[i + 1]
+                        )
                     is_loop = is_loop_in_line
                     current_category = category_in_line
                     start = i
@@ -163,7 +165,12 @@ class PDBxFile(TextFile, MutableMapping):
         # this needs to be handled separately
         stop = len(file.lines)
         file._add_category(
-            data_block, current_category, start, stop, is_loop, has_multiline_values
+            data_block,
+            current_category,
+            start,
+            stop,
+            is_loop,
+            has_multiline_values,
         )
         return file
 
@@ -274,7 +281,8 @@ class PDBxFile(TextFile, MutableMapping):
 
         if expect_looped and not is_loop:
             category_dict = {
-                key: np.array([val], dtype=object) for key, val in category_dict.items()
+                key: np.array([val], dtype=object)
+                for key, val in category_dict.items()
             }
 
         return category_dict
@@ -342,7 +350,9 @@ class PDBxFile(TextFile, MutableMapping):
         # Hence make a copy to avoid unwanted side effects
         # due to modification of input values
         if is_looped:
-            category_dict = {key: val.copy() for key, val in category_dict.items()}
+            category_dict = {
+                key: val.copy() for key, val in category_dict.items()
+            }
 
         # Enclose values with quotes if required
         for key, value in category_dict.items():
@@ -357,7 +367,8 @@ class PDBxFile(TextFile, MutableMapping):
 
         if is_looped:
             keylines = [
-                "_" + category + "." + key + " " for key in category_dict.keys()
+                "_" + category + "." + key + " "
+                for key in category_dict.keys()
             ]
             value_arr = list(category_dict.values())
             # Array containing the number of characters + whitespace
@@ -512,9 +523,13 @@ class PDBxFile(TextFile, MutableMapping):
         elif isinstance(index, str):
             return self.get_block_names()[0], index
         else:
-            raise TypeError(f"'{type(index).__name__}' is an invalid index type")
+            raise TypeError(
+                f"'{type(index).__name__}' is an invalid index type"
+            )
 
-    def _add_category(self, block, category_name, start, stop, is_loop, is_multilined):
+    def _add_category(
+        self, block, category_name, start, stop, is_loop, is_multilined
+    ):
         # Before the first category starts,
         # the current_category is None
         # This is checked before adding an entry

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -355,8 +355,8 @@ class PDBxFile(TextFile, MutableMapping):
         # Enclose values with quotes if required
         for key, value in category_dict.items():
             if is_looped:
-                # Since value is a numpy string array with fixed size, we need to
-                # convert it as a list before using _quote
+                # Since value is a numpy string array with fixed size,
+                # we need to convert it as a list before using _quote
                 category_dict[key] = np.asarray(
                     [_quote(item) for item in value.tolist()]
                 )

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -9,7 +9,6 @@ __all__ = ["PDBxFile"]
 import copy
 import shlex
 from collections.abc import MutableMapping
-
 import numpy as np
 
 from ....file import TextFile

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -10,7 +10,6 @@ import copy
 import shlex
 from collections.abc import MutableMapping
 import numpy as np
-
 from ....file import TextFile
 
 

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -6,17 +6,19 @@ __name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
 __all__ = ["PDBxFile"]
 
-import shlex
 import copy
+import shlex
 from collections.abc import MutableMapping
+
 import numpy as np
+
 from ....file import TextFile
 
 
 class PDBxFile(TextFile, MutableMapping):
     """
     This class represents a PDBx/mmCIF file.
-    
+
     The categories of the file can be accessed using the
     :meth:`get_category()`/:meth:`set_category()` methods.
     The content of each category is represented by a dictionary.
@@ -25,29 +27,29 @@ class PDBxFile(TextFile, MutableMapping):
     The corresponding values are either strings in *non-looped*
     categories, or 1-D numpy arrays of string objects in case of
     *looped* categories.
-    
+
     A category can be changed or added using :meth:`set_category()`:
     If a string-valued dictionary is provided, a *non-looped* category
     will be created; if an array-valued dictionary is given, a
     *looped* category will be created. In case of arrays, it is
     important that all arrays have the same size.
-    
+
     Alternatively, The content of this file can also be read/write
     accessed using dictionary-like indexing:
     You can either provide a data block and a category or only a
     category, in which case the first data block is taken.
-    
+
     Notes
     -----
     This class is also able to detect and parse multiline entries in the
     file. However, when writing a category no multiline values are used.
     This could lead to long lines.
-    
+
     This class uses a lazy category dictionary creation: When reading
     the file only the line positions of all categories are checked. The
     time consuming task of dictionary creation is done when
     :meth:`get_category()` is called.
-    
+
     Examples
     --------
     Read the file and get author names:
@@ -57,47 +59,46 @@ class PDBxFile(TextFile, MutableMapping):
     >>> author_dict = file.get_category("citation_author", block="1L2Y")
     >>> print(author_dict["name"])
     ['Neidigh, J.W.' 'Fesinmeyer, R.M.' 'Andersen, N.H.']
-    
+
     Dictionary style indexing, no specification of data block:
-    
+
     >>> print(file["citation_author"]["name"])
     ['Neidigh, J.W.' 'Fesinmeyer, R.M.' 'Andersen, N.H.']
-    
+
     Get the structure from the file:
-    
+
     >>> arr = get_structure(file)
     >>> print(type(arr).__name__)
     AtomArrayStack
     >>> arr = get_structure(file, model=1)
     >>> print(type(arr).__name__)
     AtomArray
-    
+
     Modify atom array and write it back into the file:
-    
+
     >>> arr_mod = rotate(arr, [1,2,3])
     >>> set_structure(file, arr_mod)
     >>> file.write(os.path.join(path_to_directory, "1l2y_mod.cif"))
     """
-    
+
     def __init__(self):
         super().__init__()
         # This dictionary saves the PDBx category names,
         # together with its line position in the file
         # and the data_block it is in
         self._categories = {}
-    
-    
+
     @classmethod
     def read(cls, file):
         """
         Read a PDBx/mmCIF file.
-        
+
         Parameters
         ----------
         file : file-like object or str
             The file to be read.
             Alternatively a file path can be supplied.
-        
+
         Returns
         -------
         file_object : PDBxFile
@@ -107,8 +108,7 @@ class PDBxFile(TextFile, MutableMapping):
         # Remove emptyline at then end of file, if present
         if file.lines[-1] == "":
             del file.lines[-1]
-        
-        current_data_block = ""
+
         current_category = None
         start = -1
         stop = -1
@@ -126,26 +126,34 @@ class PDBxFile(TextFile, MutableMapping):
                     stop = -1
                     is_loop = False
                     has_multiline_values = False
-                
+
                 is_loop_in_line = _is_loop_start(line)
                 category_in_line = _get_category_name(line)
-                if is_loop_in_line or (category_in_line != current_category
-                                       and category_in_line is not None):
+                if is_loop_in_line or (
+                    category_in_line != current_category
+                    and category_in_line is not None
+                ):
                     # Start of a new category
                     # Add an entry into the dictionary with the old category
                     stop = i
-                    file._add_category(data_block, current_category, start,
-                                       stop, is_loop, has_multiline_values)
+                    file._add_category(
+                        data_block,
+                        current_category,
+                        start,
+                        stop,
+                        is_loop,
+                        has_multiline_values,
+                    )
                     # Track the new category
                     if is_loop_in_line:
                         # In case of lines with "loop_" the category is in the
                         # next line
-                        category_in_line = _get_category_name(file.lines[i+1])
+                        category_in_line = _get_category_name(file.lines[i + 1])
                     is_loop = is_loop_in_line
                     current_category = category_in_line
                     start = i
                     has_multiline_values = False
-                
+
                 multiline = _is_multi(line, is_loop)
                 if multiline:
                     has_multiline_values = True
@@ -154,15 +162,15 @@ class PDBxFile(TextFile, MutableMapping):
         # is not determined by the start of a new one,
         # this needs to be handled separately
         stop = len(file.lines)
-        file._add_category(data_block, current_category, start,
-                           stop, is_loop, has_multiline_values)
+        file._add_category(
+            data_block, current_category, start, stop, is_loop, has_multiline_values
+        )
         return file
-    
-    
+
     def get_block_names(self):
         """
         Get the names of all data blocks in the file.
-        
+
         Returns
         -------
         blocks : list
@@ -173,12 +181,11 @@ class PDBxFile(TextFile, MutableMapping):
             block, _ = category_tuple
             blocks.add(block)
         return sorted(blocks)
-    
-    
+
     def get_category(self, category, block=None, expect_looped=False):
         """
         Get the dictionary for a given category.
-        
+
         Parameters
         ----------
         category : string
@@ -191,7 +198,7 @@ class PDBxFile(TextFile, MutableMapping):
             arrays (only if the category exists):
             If the category is *non-looped*, each array will contain
             only one element.
-            
+
         Returns
         -------
         category_dict : dict of (str or ndarray, dtype=str) or None
@@ -210,11 +217,14 @@ class PDBxFile(TextFile, MutableMapping):
         stop = category_info["stop"]
         is_loop = category_info["loop"]
         is_multilined = category_info["multiline"]
-        
+
         if is_multilined:
             # Convert multiline values into singleline values
-            prelines = [line.strip() for line in self.lines[start:stop]
-                         if not _is_empty(line) and not _is_loop_start(line)]
+            prelines = [
+                line.strip()
+                for line in self.lines[start:stop]
+                if not _is_empty(line) and not _is_loop_start(line)
+            ]
             lines = (len(prelines)) * [None]
             # lines index
             k = 0
@@ -224,28 +234,31 @@ class PDBxFile(TextFile, MutableMapping):
                 if prelines[i][0] == ";":
                     # multiline values
                     multi_line_str = prelines[i][1:]
-                    j = i+1
+                    j = i + 1
                     while prelines[j] != ";":
                         multi_line_str += prelines[j]
                         j += 1
-                    lines[k-1] += " " + shlex.quote(multi_line_str)
-                    i = j+1
-                elif not is_loop and prelines[i][0] in ["'",'"']:
+                    lines[k - 1] += " " + shlex.quote(multi_line_str)
+                    i = j + 1
+                elif not is_loop and prelines[i][0] in ["'", '"']:
                     # Singleline values where value is in the line
                     # after the corresponding key
-                    lines[k-1] += " " + prelines[i]
+                    lines[k - 1] += " " + prelines[i]
                     i += 1
-                else:    
+                else:
                     # Normal singleline value in the same row as the key
                     lines[k] = prelines[i]
                     i += 1
                     k += 1
             lines = [line for line in lines if line is not None]
-            
+
         else:
-            lines = [line.strip() for line in self.lines[start:stop]
-                     if not _is_empty(line) and not _is_loop_start(line)]
-        
+            lines = [
+                line.strip()
+                for line in self.lines[start:stop]
+                if not _is_empty(line) and not _is_loop_start(line)
+            ]
+
         if is_loop:
             # Special optimization for "atom_site":
             # Even if the values are quote protected,
@@ -258,22 +271,22 @@ class PDBxFile(TextFile, MutableMapping):
             category_dict = _process_looped(lines, whitespace_values)
         else:
             category_dict = _process_singlevalued(lines)
-        
+
         if expect_looped and not is_loop:
-            category_dict = {key: np.array([val], dtype=object)
-                             for key, val in category_dict.items()}
+            category_dict = {
+                key: np.array([val], dtype=object) for key, val in category_dict.items()
+            }
 
         return category_dict
-            
-    
+
     def set_category(self, category, category_dict, block=None):
         """
         Set the content of a category.
-        
+
         If the category is already exisiting, all lines corresponding
         to the category are replaced. Otherwise a new category is
         created and the lines are appended at the end of the data block.
-        
+
         Parameters
         ----------
         category : string
@@ -290,13 +303,12 @@ class PDBxFile(TextFile, MutableMapping):
         """
         if block is None:
             block = self.get_block_names()[0]
-        
-        
+
         # Determine whether the category is a looped category
         sample_category_value = list(category_dict.values())[0]
         if isinstance(sample_category_value, (np.ndarray, list)):
             is_looped = True
-             # Check whether all arrays have the same length
+            # Check whether all arrays have the same length
             arr_len = len(list(category_dict.values())[0])
             for subcat, array in category_dict.items():
                 if len(array) != arr_len:
@@ -306,7 +318,6 @@ class PDBxFile(TextFile, MutableMapping):
                     )
         else:
             is_looped = False
-        
 
         # Sanitize dictionary
         # -> convert to string
@@ -327,45 +338,45 @@ class PDBxFile(TextFile, MutableMapping):
                 value = value if value != "" else "."
                 category_dict[subcat] = str(value)
 
-        
         # Value arrays (looped categories) can be modified (e.g. quoted)
         # Hence make a copy to avoid unwanted side effects
         # due to modification of input values
         if is_looped:
-            category_dict = {key : val.copy() for key, val
-                             in category_dict.items()}
+            category_dict = {key: val.copy() for key, val in category_dict.items()}
 
         # Enclose values with quotes if required
         for key, value in category_dict.items():
             if is_looped:
-                list_value = value.tolist()
-                for i in range(len(list_value)):
-                    list_value[i] = _quote(list_value[i])
-                category_dict[key] = np.asarray(list_value)
+                # Since value is a numpy string array with fixed size, we need to
+                # convert it as a list before using _quote
+                category_dict[key] = np.asarray(
+                    [_quote(item) for item in value.tolist()]
+                )
             else:
                 category_dict[key] = _quote(value)
-        
+
         if is_looped:
-            keylines = ["_" + category + "." + key + " "
-                         for key in category_dict.keys()]
+            keylines = [
+                "_" + category + "." + key + " " for key in category_dict.keys()
+            ]
             value_arr = list(category_dict.values())
             # Array containing the number of characters + whitespace
-            # of each column 
+            # of each column
             col_lens = np.zeros(len(value_arr), dtype=int)
             for i, column in enumerate(value_arr):
                 col_len = 0
                 for value in column:
                     if len(value) > col_len:
                         col_len = len(value)
-                # Length of column is max value length 
-                # +1 whitespace character as separator 
-                col_lens[i] = col_len+1
+                # Length of column is max value length
+                # +1 whitespace character as separator
+                col_lens[i] = col_len + 1
             valuelines = [""] * arr_len
             for i in range(arr_len):
                 for j, arr in enumerate(value_arr):
-                    valuelines[i] += arr[i] + " "*(col_lens[j] - len(arr[i]))
+                    valuelines[i] += arr[i] + " " * (col_lens[j] - len(arr[i]))
             newlines = ["loop_"] + keylines + valuelines
-            
+
         else:
             # For better readability, not only one space is inserted
             # after each key, but as much spaces that every value starts
@@ -376,24 +387,25 @@ class PDBxFile(TextFile, MutableMapping):
                     max_len = len(key)
             # "+3" Because of three whitespace chars after longest key
             req_len = max_len + 3
-            newlines = ["_" + category + "." + key
-                         + " " * (req_len-len(key)) + value
-                         for key, value in category_dict.items()]
-            
+            newlines = [
+                "_" + category + "." + key + " " * (req_len - len(key)) + value
+                for key, value in category_dict.items()
+            ]
+
         # A comment line is set after every category
         newlines += ["#"]
-        
-        if (block,category) in self._categories:
+
+        if (block, category) in self._categories:
             # Category already exists in data block
             category_info = self._categories[(block, category)]
             # Insertion point of new lines
             old_category_start = category_info["start"]
             old_category_stop = category_info["stop"]
-            category_start = old_category_start 
+            category_start = old_category_start
             # Difference between number of lines of the old and new category
-            len_diff = len(newlines) - (old_category_stop-old_category_start)
+            len_diff = len(newlines) - (old_category_stop - old_category_start)
             # Remove old category content
-            del self.lines[old_category_start : old_category_stop]
+            del self.lines[old_category_start:old_category_stop]
             # Insert new lines at category start
             self.lines[category_start:category_start] = newlines
             # Update category info
@@ -415,12 +427,18 @@ class PDBxFile(TextFile, MutableMapping):
             category_stop = category_start + len(newlines)
             len_diff = len(newlines)
             self.lines[category_start:category_start] = newlines
-            self._add_category(block, category, category_start, category_stop,
-                               is_looped, is_multilined=False)
+            self._add_category(
+                block,
+                category,
+                category_start,
+                category_stop,
+                is_looped,
+                is_multilined=False,
+            )
         else:
             # The data block does not exist
             # Put the begin of data block in front of newlines
-            newlines = ["data_"+block, "#"] + newlines
+            newlines = ["data_" + block, "#"] + newlines
             # Find last category in the file
             # and set start of new data_block with new category
             # to stop of last category
@@ -430,32 +448,34 @@ class PDBxFile(TextFile, MutableMapping):
                     last_stop = category_info["stop"]
             category_start = last_stop + 2
             category_stop = last_stop + len(newlines)
-            len_diff = len(newlines)-2
+            len_diff = len(newlines) - 2
             self.lines[last_stop:last_stop] = newlines
-            self._add_category(block, category, category_start, category_stop,
-                               is_looped, is_multilined=False)
+            self._add_category(
+                block,
+                category,
+                category_start,
+                category_stop,
+                is_looped,
+                is_multilined=False,
+            )
         # Update start and stop of all categories appearing after the
         # changed/added category
         for category_info in self._categories.values():
             if category_info["start"] > category_start:
                 category_info["start"] += len_diff
                 category_info["stop"] += len_diff
-    
-    
+
     def __copy_fill__(self, clone):
         super().__copy_fill__(clone)
         clone._categories = copy.deepcopy(self._categories)
-        
-        
+
     def __setitem__(self, index, item):
         block, category_name = self._full_index(index)
         self.set_category(category_name, item, block=block)
-    
-    
+
     def __getitem__(self, index):
         block, category_name = self._full_index(index)
         return self.get_category(category_name, block=block)
-    
 
     def __delitem__(self, index):
         block, category_name = self._full_index(index)
@@ -463,7 +483,7 @@ class PDBxFile(TextFile, MutableMapping):
         # Insertion point of new lines
         category_start = category_info["start"]
         category_stop = category_info["stop"]
-        del self.lines[category_start : category_stop]
+        del self.lines[category_start:category_stop]
         # Update start and stop of all categories appearing after the
         # deleted category
         len_diff = category_stop - category_start
@@ -471,21 +491,17 @@ class PDBxFile(TextFile, MutableMapping):
             if category_info["start"] > category_start:
                 category_info["start"] -= len_diff
                 category_info["stop"] -= len_diff
-    
 
     def __contains__(self, index):
         block, category_name = self._full_index(index)
         return (block, category_name) in self._categories
-    
 
     def __iter__(self):
         return self._categories.__iter__()
-    
 
     def __len__(self):
         return len(self._categories)
-    
-    
+
     def _full_index(self, index):
         """
         Converts a an integer or tuple index into a block and a category
@@ -496,24 +512,21 @@ class PDBxFile(TextFile, MutableMapping):
         elif isinstance(index, str):
             return self.get_block_names()[0], index
         else:
-            raise TypeError(
-                f"'{type(index).__name__}' is an invalid index type"
-            )
+            raise TypeError(f"'{type(index).__name__}' is an invalid index type")
 
-
-    def _add_category(self, block, category_name,
-                      start, stop, is_loop, is_multilined):
+    def _add_category(self, block, category_name, start, stop, is_loop, is_multilined):
         # Before the first category starts,
         # the current_category is None
         # This is checked before adding an entry
         if category_name is not None:
-            self._categories[
-                (block, category_name)] = {"start"     : start,
-                                           "stop"      : stop,
-                                           "loop"      : is_loop,
-                                           "multiline" : is_multilined}
-    
-    
+            self._categories[(block, category_name)] = {
+                "start": start,
+                "stop": stop,
+                "loop": is_loop,
+                "multiline": is_multilined,
+            }
+
+
 def _process_singlevalued(lines):
     category_dict = {}
     i = 0
@@ -553,16 +566,17 @@ def _process_looped(lines, whitepace_values):
             # use standard shlex split
             # Otherwise use much more faster whitespace split
             # and quote removal if applicable,
-            # bypassing the slow shlex module 
+            # bypassing the slow shlex module
             if whitepace_values:
                 values = shlex.split(line)
             else:
                 values = line.split()
                 for k in range(len(values)):
                     # Remove quotes
-                    if ((values[k][0] == '"' and values[k][-1] == '"') or
-                        (values[k][0] == "'" and values[k][-1] == "'")):
-                            values[k] = values[k][1:-1]
+                    if (values[k][0] == '"' and values[k][-1] == '"') or (
+                        values[k][0] == "'" and values[k][-1] == "'"
+                    ):
+                        values[k] = values[k][1:-1]
             for value in values:
                 category_dict[keys[j]][i] = value
                 j += 1
@@ -575,7 +589,7 @@ def _process_looped(lines, whitepace_values):
         # Trim to correct size
         category_dict[key] = category_dict[key][:i]
     return category_dict
-    
+
 
 def _is_empty(line):
     return len(line) == 0 or line[0] == "#"
@@ -596,22 +610,22 @@ def _is_multi(line, is_loop):
     if is_loop:
         return line[0] == ";"
     else:
-        return line[0] in [";","'",'"']
+        return line[0] in [";", "'", '"']
 
 
 def _get_category_name(line):
     if line[0] != "_":
         return None
     else:
-        return line[1:line.find(".")]
+        return line[1 : line.find(".")]
 
 
 def _quote(value):
     if "'" in value:
-        return('"' + value + '"')
+        return '"' + value + '"'
     elif '"' in value:
-        return("'" + value + "'")
+        return "'" + value + "'"
     elif " " in value:
-        return("'" + value + "'")
+        return "'" + value + "'"
     else:
         return value

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -5,16 +5,13 @@
 import glob
 import itertools
 from os.path import join
-
 import numpy as np
 import pytest
 from pytest import approx
-
 import biotite
 import biotite.sequence as seq
 import biotite.structure as struc
 import biotite.structure.io.pdbx as pdbx
-
 from ..util import data_dir
 
 
@@ -53,7 +50,8 @@ def test_parsing(category, key, exp_value):
 
 
 @pytest.mark.parametrize(
-    "string, use_array", itertools.product(["", " ", "\n", "\t"], [False, True])
+    "string, use_array",
+    itertools.product(["", " ", "\n", "\t"], [False, True]),
 )
 def test_empty_values(string, use_array):
     """
@@ -64,7 +62,9 @@ def test_empty_values(string, use_array):
     ref_value = np.full(LENGTH, string, dtype="U1") if use_array else ""
     pdbx_file = pdbx.PDBxFile()
     pdbx_file.set_category(
-        category="test_category", block="test", category_dict={"test_field": ref_value}
+        category="test_category",
+        block="test",
+        category_dict={"test_field": ref_value},
     )
 
     test_value = pdbx_file["test_category"]["test_field"]
@@ -77,7 +77,9 @@ def test_empty_values(string, use_array):
 
 @pytest.mark.parametrize(
     "path, model",
-    itertools.product(glob.glob(join(data_dir("structure"), "*.cif")), [None, 1, -1]),
+    itertools.product(
+        glob.glob(join(data_dir("structure"), "*.cif")), [None, 1, -1]
+    ),
 )
 def test_conversion(path, model):
     pdbx_file = pdbx.PDBxFile.read(path)
@@ -96,7 +98,8 @@ def test_conversion(path, model):
     pdbx_file = pdbx.PDBxFile()
     pdbx.set_structure(pdbx_file, array1, data_block="test")
 
-    # Remove one optional auth section in label to test fallback to label fields
+    # Remove one optional auth section in label to test fallback to label
+    # fields
     atom_cat = pdbx_file.get_category("atom_site", "test")
     atom_cat.pop("auth_atom_id")
     pdbx_file.set_category("atom_site", atom_cat, "test")
@@ -152,11 +155,16 @@ def test_extra_fields():
 def test_unequal_lengths():
     valid_category_dict = {"foo1": ["1", "2", "3"], "foo2": ["1", "2", "3"]}
     # Arrays have unequal lengths -> invalid
-    invalid_category_dict = {"foo1": ["1", "2", "3"], "foo2": ["1", "2", "3", "4"]}
+    invalid_category_dict = {
+        "foo1": ["1", "2", "3"],
+        "foo2": ["1", "2", "3", "4"],
+    }
     pdbx_file = pdbx.PDBxFile()
     pdbx_file.set_category("test", valid_category_dict, block="test_block")
     with pytest.raises(ValueError):
-        pdbx_file.set_category("test", invalid_category_dict, block="test_block")
+        pdbx_file.set_category(
+            "test", invalid_category_dict, block="test_block"
+        )
 
 
 def test_list_assemblies():
@@ -200,7 +208,9 @@ def test_get_assembly(model):
     ):
         print("Assembly ID:", id)
         try:
-            assembly = pdbx.get_assembly(pdbx_file, assembly_id=id, model=model)
+            assembly = pdbx.get_assembly(
+                pdbx_file, assembly_id=id, model=model
+            )
         except biotite.InvalidFileError:
             if model is None:
                 # The file cannot be parsed into an AtomArrayStack,

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -2,16 +2,19 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
-import itertools
 import glob
+import itertools
 from os.path import join
+
 import numpy as np
 import pytest
 from pytest import approx
+
 import biotite
+import biotite.sequence as seq
 import biotite.structure as struc
 import biotite.structure.io.pdbx as pdbx
-import biotite.sequence as seq
+
 from ..util import data_dir
 
 
@@ -23,21 +26,21 @@ def test_get_model_count():
 
 
 @pytest.mark.parametrize(
-    "category, key, exp_value", 
+    "category, key, exp_value",
     [
         (
-            "audit_author", "name",
-            ["Neidigh, J.W.", "Fesinmeyer, R.M.", "Andersen, N.H."]
+            "audit_author",
+            "name",
+            ["Neidigh, J.W.", "Fesinmeyer, R.M.", "Andersen, N.H."],
         ),
+        ("struct_ref_seq", "pdbx_PDB_id_code", "1L2Y"),
         (
-            "struct_ref_seq", "pdbx_PDB_id_code", "1L2Y"
-        ),
-        (
-            "pdbx_nmr_ensemble", "conformer_selection_criteria",
+            "pdbx_nmr_ensemble",
+            "conformer_selection_criteria",
             "structures with acceptable covalent geometry, "
-            "structures with the least restraint violations"
-        )
-    ]
+            "structures with the least restraint violations",
+        ),
+    ],
 )
 def test_parsing(category, key, exp_value):
     pdbx_file = pdbx.PDBxFile.read(join(data_dir("structure"), "1l2y.cif"))
@@ -50,30 +53,22 @@ def test_parsing(category, key, exp_value):
 
 
 @pytest.mark.parametrize(
-    "string, use_array",
-    itertools.product(
-        ["", " ", "\n", "\t"],
-        [False, True]
-    )
+    "string, use_array", itertools.product(["", " ", "\n", "\t"], [False, True])
 )
 def test_empty_values(string, use_array):
     """
     Test whether empty strings for field values are properly replaced
-    by ``'.'``. 
+    by ``'.'``.
     """
     LENGTH = 10
-    ref_value = np.full(LENGTH, string, dtype="U1") if use_array else "" 
+    ref_value = np.full(LENGTH, string, dtype="U1") if use_array else ""
     pdbx_file = pdbx.PDBxFile()
     pdbx_file.set_category(
-        category="test_category",
-        block="test",
-        category_dict={
-            "test_field": ref_value
-        }
+        category="test_category", block="test", category_dict={"test_field": ref_value}
     )
-    
+
     test_value = pdbx_file["test_category"]["test_field"]
-    
+
     if use_array:
         assert test_value.tolist() == ["."] * LENGTH
     else:
@@ -82,14 +77,11 @@ def test_empty_values(string, use_array):
 
 @pytest.mark.parametrize(
     "path, model",
-    itertools.product(
-        glob.glob(join(data_dir("structure"), "*.cif")),
-        [None, 1, -1]
-    )
+    itertools.product(glob.glob(join(data_dir("structure"), "*.cif")), [None, 1, -1]),
 )
 def test_conversion(path, model):
     pdbx_file = pdbx.PDBxFile.read(path)
-    
+
     try:
         array1 = pdbx.get_structure(pdbx_file, model=model)
     except biotite.InvalidFileError:
@@ -100,53 +92,55 @@ def test_conversion(path, model):
             return
         else:
             raise
-    
+
     pdbx_file = pdbx.PDBxFile()
     pdbx.set_structure(pdbx_file, array1, data_block="test")
-    
+
+    # Remove one optional auth section in label to test fallback to label fields
+    atom_cat = pdbx_file.get_category("atom_site", "test")
+    atom_cat.pop("auth_atom_id")
+    pdbx_file.set_category("atom_site", atom_cat, "test")
+
     array2 = pdbx.get_structure(pdbx_file, model=model)
-    
+
     assert array1.array_length() > 0
     if array1.box is not None:
         assert np.allclose(array1.box, array2.box)
     assert array1.bonds == array2.bonds
     for category in array1.get_annotation_categories():
-        assert array1.get_annotation(category).tolist() == \
-               array2.get_annotation(category).tolist()
+        assert (
+            array1.get_annotation(category).tolist()
+            == array2.get_annotation(category).tolist()
+        )
     assert array1.coord.tolist() == array2.coord.tolist()
 
 
 def test_extra_fields():
     path = join(data_dir("structure"), "1l2y.cif")
     pdbx_file = pdbx.PDBxFile.read(path)
-    stack1 = pdbx.get_structure(pdbx_file, extra_fields=["atom_id","b_factor",
-                                "occupancy","charge"])
+    stack1 = pdbx.get_structure(
+        pdbx_file, extra_fields=["atom_id", "b_factor", "occupancy", "charge"]
+    )
     pdbx_file = pdbx.PDBxFile()
     pdbx.set_structure(pdbx_file, stack1, data_block="test")
-    stack2 = pdbx.get_structure(pdbx_file, extra_fields=["atom_id","b_factor",
-                                "occupancy","charge"])
+    stack2 = pdbx.get_structure(
+        pdbx_file, extra_fields=["atom_id", "b_factor", "occupancy", "charge"]
+    )
     assert stack1 == stack2
-
 
     path = join(data_dir("structure"), "1l2y.cif")
     pdbx_file = pdbx.PDBxFile.read(path)
     stack1 = pdbx.get_structure(
-        pdbx_file,
-        extra_fields=[
-            "atom_id", "b_factor", "occupancy", "charge"
-        ]
+        pdbx_file, extra_fields=["atom_id", "b_factor", "occupancy", "charge"]
     )
 
     pdbx_file = pdbx.PDBxFile()
     pdbx.set_structure(pdbx_file, stack1, data_block="test")
-    
+
     stack2 = pdbx.get_structure(
-        pdbx_file,
-        extra_fields=[
-            "atom_id", "b_factor", "occupancy", "charge"
-        ]
+        pdbx_file, extra_fields=["atom_id", "b_factor", "occupancy", "charge"]
     )
-    
+
     assert stack1.ins_code.tolist() == stack2.ins_code.tolist()
     assert stack1.atom_id.tolist() == stack2.atom_id.tolist()
     assert stack1.b_factor.tolist() == approx(stack2.b_factor.tolist())
@@ -156,23 +150,15 @@ def test_extra_fields():
 
 
 def test_unequal_lengths():
-    valid_category_dict = {
-        "foo1" : ["1", "2", "3"],
-        "foo2" : ["1", "2", "3"]
-    }
+    valid_category_dict = {"foo1": ["1", "2", "3"], "foo2": ["1", "2", "3"]}
     # Arrays have unequal lengths -> invalid
-    invalid_category_dict = {
-        "foo1" : ["1", "2", "3"],
-        "foo2" : ["1", "2", "3", "4"]
-    }
+    invalid_category_dict = {"foo1": ["1", "2", "3"], "foo2": ["1", "2", "3", "4"]}
     pdbx_file = pdbx.PDBxFile()
-    pdbx_file.set_category("test", valid_category_dict,  block="test_block")
+    pdbx_file.set_category("test", valid_category_dict, block="test_block")
     with pytest.raises(ValueError):
-        pdbx_file.set_category(
-            "test", invalid_category_dict, block="test_block"
-        )
-            
-        
+        pdbx_file.set_category("test", invalid_category_dict, block="test_block")
+
+
 def test_list_assemblies():
     """
     Test the :func:`list_assemblies()` function based on a known
@@ -188,7 +174,7 @@ def test_list_assemblies():
         "3": "icosahedral pentamer",
         "4": "icosahedral 23 hexamer",
         "5": "icosahedral asymmetric unit, std point frame",
-        "6": "crystal asymmetric unit, crystal frame"
+        "6": "crystal asymmetric unit, crystal frame",
     }
 
 
@@ -210,14 +196,11 @@ def test_get_assembly(model):
     )
     # Test each available assembly
     for id, ref_oligomer_count in zip(
-        assembly_category["id"],
-        assembly_category["oligomeric_count"]
-    ):    
+        assembly_category["id"], assembly_category["oligomeric_count"]
+    ):
         print("Assembly ID:", id)
         try:
-            assembly = pdbx.get_assembly(
-                pdbx_file, assembly_id=id, model=model
-            )
+            assembly = pdbx.get_assembly(pdbx_file, assembly_id=id, model=model)
         except biotite.InvalidFileError:
             if model is None:
                 # The file cannot be parsed into an AtomArrayStack,
@@ -246,25 +229,26 @@ def test_get_sequence():
     sequences = pdbx.get_sequence(file)
     file = pdbx.PDBxFile.read(join(data_dir("structure"), "4gxy.cif"))
     sequences += pdbx.get_sequence(file)
-    assert (str(sequences[0]) == "CCGACGGCGCATCAGC")
-    assert (type(sequences[0]) is seq.NucleotideSequence)
-    assert (str(sequences[1]) == "GCTGATGCGCC")
-    assert (type(sequences[1]) is seq.NucleotideSequence)
-    assert (str(sequences[2]) == "GTCGG")
-    assert (type(sequences[2]) is seq.NucleotideSequence)
-    assert (str(sequences[3]) == "MSKRKAPQETLNGGITDMLTELANFEKNVSQAIHKYN"
-                "AYRKAASVIAKYPHKIKSGAEAKKLPGVGTKIAEKIDEFLATGKLRKLEKIRQD"
-                "DTSSSINFLTRVSGIGPSAARKFVDEGIKTLEDLRKNEDKLNHHQRIGLKYFGD"
-                "FEKRIPREEMLQMQDIVLNEVKKVDSEYIATVCGSFRRGAESSGDMDVLLTHPS"
-                "FTSESTKQPKLLHQVVEQLQKVHFITDTLSKGETKFMGVCQLPSKNDEKEYPHR"
-                "RIDIRLIPKDQYYCGVLYFTGSDIFNKNMRAHALEKGFTINEYTIRPLGVTGVA"
-                "GEPLPVDSEKDIFDYIQWKYREPKDRSE"
+    assert str(sequences[0]) == "CCGACGGCGCATCAGC"
+    assert type(sequences[0]) is seq.NucleotideSequence
+    assert str(sequences[1]) == "GCTGATGCGCC"
+    assert type(sequences[1]) is seq.NucleotideSequence
+    assert str(sequences[2]) == "GTCGG"
+    assert type(sequences[2]) is seq.NucleotideSequence
+    assert (
+        str(sequences[3]) == "MSKRKAPQETLNGGITDMLTELANFEKNVSQAIHKYN"
+        "AYRKAASVIAKYPHKIKSGAEAKKLPGVGTKIAEKIDEFLATGKLRKLEKIRQD"
+        "DTSSSINFLTRVSGIGPSAARKFVDEGIKTLEDLRKNEDKLNHHQRIGLKYFGD"
+        "FEKRIPREEMLQMQDIVLNEVKKVDSEYIATVCGSFRRGAESSGDMDVLLTHPS"
+        "FTSESTKQPKLLHQVVEQLQKVHFITDTLSKGETKFMGVCQLPSKNDEKEYPHR"
+        "RIDIRLIPKDQYYCGVLYFTGSDIFNKNMRAHALEKGFTINEYTIRPLGVTGVA"
+        "GEPLPVDSEKDIFDYIQWKYREPKDRSE"
     )
-    assert (type(sequences[3]) is seq.ProteinSequence)
-    assert (str(sequences[4]) == "GGCGGCAGGTGCTCCCGACCCTGCGGTCGGGAGTTAA"
-                "AAGGGAAGCCGGTGCAAGTCCGGCACGGTCCCGCCACTGTGACGGGGAGTCGCC"
-                "CCTCGGGATGTGCCACTGGCCCGAAGGCCGGGAAGGCGGAGGGGCGGCGAGGAT"
-                "CCGGAGTCAGGAAACCTGCCTGCCGTC"
+    assert type(sequences[3]) is seq.ProteinSequence
+    assert (
+        str(sequences[4]) == "GGCGGCAGGTGCTCCCGACCCTGCGGTCGGGAGTTAA"
+        "AAGGGAAGCCGGTGCAAGTCCGGCACGGTCCCGCCACTGTGACGGGGAGTCGCC"
+        "CCTCGGGATGTGCCACTGGCCCGAAGGCCGGGAAGGCGGAGGGGCGGCGAGGAT"
+        "CCGGAGTCAGGAAACCTGCCTGCCGTC"
     )
-    assert (type(sequences[4]) is seq.NucleotideSequence)
-        
+    assert type(sequences[4]) is seq.NucleotideSequence


### PR DESCRIPTION
Hi

We are actually using in our project a patched version of biotite `v0.29.0`. Can those minor patches be included in the main codebase if it suits the contributing guidelines ?

* `biotite.structure.bonds.connect_via_distances`
  * Allow the user to change the default `BondType` in the generated `BondList`.
* `biotite.structure.io.ctab.write_structure_to_ctab`
  * Format file using black formatter (`black -l 79 ...`) 
  * Add `default_bond_type` as a keyword parameter
* `biotite.structure.io.pdbx.file.PDBxFile.set_category`
  * Format file using black formatter
  * Ensure `_quote` calls on looped categories will not be truncated by numpy array dtype (eg: `<U4` array becoming `<U6` array)
* `biotite.structure.io.pdbx.convert._fill_annotations`
  * ~~Add `typing` information to `_fill_annotations`~~
  * Format file using black formatter  (`black -l 79 ...`) 
  * Add a fallback prefix to `label` or `auth` if `prefix`  is missing and not an mmcif mandatory field like `atom_id` or `comp_id` (https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v40.dic/Categories/atom_site.html). Throw a `UserWarning` for every attempt to use the fallback key if the default prefix is missing. An `InvalidFileError` will be raised if both prefix are missing.
* `tests.structure.test_pdbx.test_conversion`
  * Format file using black formatter  (`black -l 79 ...`) 
  * Test prefix fallback if `_atom_site.auth_*` annotation is missing.