### PR TITLE
feat: propagate default_bond_type to molfile set_structure

### DIFF
--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -97,7 +97,7 @@ def read_structure_from_ctab(ctab_lines):
     return atoms
 
 
-def write_structure_to_ctab(atoms, default_bond_type=8):
+def write_structure_to_ctab(atoms, default_bond_type=BondType.ANY):
     """
     Convert an :class:`AtomArray` into a
     *MDL* connection table (Ctab). :footcite:`Dalby1992`
@@ -113,9 +113,10 @@ def write_structure_to_ctab(atoms, default_bond_type=8):
         The lines containing the *ctab*.
         The lines begin with the *counts* line and end with the `M END`
         .line
-    default_bond_type : int
+    default_bond_type : BondType
         Bond type fallback in the *Bond block* if a bond has no bond_type
-        defined in *atoms* array.
+        defined in *atoms* array. By default, each bond is treated as
+        :attr:`BondType.ANY`.
 
     References
     ----------
@@ -144,9 +145,11 @@ def write_structure_to_ctab(atoms, default_bond_type=8):
         for i in range(atoms.array_length())
     ]
 
+    default_bond_value = BOND_TYPE_MAPPING_REV[default_bond_type]
+
     bond_lines = [
         f"{i+1:>3d}{j+1:>3d}"
-        f"{BOND_TYPE_MAPPING_REV.get(bond_type, default_bond_type):>3d}"
+        f"{BOND_TYPE_MAPPING_REV.get(bond_type, default_bond_value):>3d}"
         + f"{0:>3d}" * 4
         for i, j, bond_type in atoms.bonds.as_array()
     ]

--- a/src/biotite/structure/io/mol/convert.py
+++ b/src/biotite/structure/io/mol/convert.py
@@ -48,4 +48,4 @@ def set_structure(mol_file, atoms, default_bond_type=BondType.ANY):
         Must have an associated :class:`BondList`.
 
     """
-    mol_file.set_structure(atoms, default_bond_type=default_bond_type)
+    mol_file.set_structure(atoms, default_bond_type)

--- a/src/biotite/structure/io/mol/convert.py
+++ b/src/biotite/structure/io/mol/convert.py
@@ -6,6 +6,7 @@ __name__ = "biotite.structure.io.mol"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_structure", "set_structure"]
 
+from ...bonds import BondType
 
 
 def get_structure(mol_file):
@@ -19,7 +20,7 @@ def get_structure(mol_file):
     ----------
     mol_file : MOLFile
         The MOL file.
-    
+
     Returns
     -------
     array : AtomArray
@@ -29,15 +30,15 @@ def get_structure(mol_file):
         empty.
     """
     return mol_file.get_structure()
-    
 
-def set_structure(mol_file, atoms):
+
+def set_structure(mol_file, atoms, default_bond_type=BondType.ANY):
     """
     Set the :class:`AtomArray` for the MOL file.
 
     Ths function is a thin wrapper around
     :meth:`MOLFile.set_structure()`.
-    
+
     Parameters
     ----------
     mol_file : MOLFile
@@ -45,5 +46,6 @@ def set_structure(mol_file, atoms):
     array : AtomArray
         The array to be saved into this file.
         Must have an associated :class:`BondList`.
+
     """
-    mol_file.set_structure(atoms)
+    mol_file.set_structure(atoms, default_bond_type=default_bond_type)

--- a/src/biotite/structure/io/mol/file.py
+++ b/src/biotite/structure/io/mol/file.py
@@ -195,7 +195,7 @@ class MOLFile(TextFile):
         """
         self.lines = self.lines[:N_HEADER] + write_structure_to_ctab(
             atoms,
-            default_bond_type=default_bond_type
+            default_bond_type
         )
 
 

--- a/src/biotite/structure/io/mol/file.py
+++ b/src/biotite/structure/io/mol/file.py
@@ -13,6 +13,7 @@ from ...atoms import AtomArray
 from ....file import TextFile, InvalidFileError
 from ...error import BadStructureError
 from ..ctab import read_structure_from_ctab, write_structure_to_ctab
+from ...bonds import BondType
 
 
 # Number of header lines
@@ -33,12 +34,12 @@ class MOLFile(TextFile):
 
     This class can also be used to parse the first structure from an SDF
     file, as the SDF format extends the MOL format.
-    
+
     References
     ----------
-    
+
     .. footbibliography::
-    
+
     Examples
     --------
 
@@ -71,16 +72,16 @@ class MOLFile(TextFile):
                 0             H        -0.123   -0.399   -5.059
                 0             H        -1.333   -0.030    4.784
     """
-    
+
     def __init__(self):
         super().__init__()
         # empty header lines
         self.lines = [""] * N_HEADER
-    
+
     def get_header(self):
         """
         Get the header from the MOL file.
-        
+
         Returns
         -------
         mol_name : str
@@ -121,7 +122,7 @@ class MOLFile(TextFile):
                    registry_number="", comments=""):
         """
         Set the header for the MOL file.
-        
+
         Parameters
         ----------
         mol_name : str
@@ -163,7 +164,7 @@ class MOLFile(TextFile):
     def get_structure(self):
         """
         Get an :class:`AtomArray` from the MOL file.
-        
+
         Returns
         -------
         array : AtomArray
@@ -174,21 +175,28 @@ class MOLFile(TextFile):
         """
         ctab_lines = _get_ctab_lines(self.lines)
         if len(ctab_lines) == 0:
-            raise InvalidFileError("File does not contain structure data") 
+            raise InvalidFileError("File does not contain structure data")
         return read_structure_from_ctab(ctab_lines)
-    
 
-    def set_structure(self, atoms):
+
+    def set_structure(self, atoms, default_bond_type=BondType.ANY):
         """
         Set the :class:`AtomArray` for the file.
-        
+
         Parameters
         ----------
         array : AtomArray
             The array to be saved into this file.
             Must have an associated :class:`BondList`.
+        default_bond_type : BondType
+            Bond type fallback in the *Bond block* if a bond has no bond_type
+            defined in *atoms* array. By default, each bond is treated as
+            :attr:`BondType.ANY`.
         """
-        self.lines = self.lines[:N_HEADER] + write_structure_to_ctab(atoms)
+        self.lines = self.lines[:N_HEADER] + write_structure_to_ctab(
+            atoms,
+            default_bond_type=default_bond_type
+        )
 
 
 def _get_ctab_lines(lines):

--- a/tests/structure/test_mol.py
+++ b/tests/structure/test_mol.py
@@ -2,15 +2,17 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
-import itertools
 import datetime
-from tempfile import TemporaryFile
 import glob
+import itertools
 from os.path import join, split, splitext
-import pytest
+from tempfile import TemporaryFile
 import numpy as np
+import pytest
 import biotite.structure.info as info
 import biotite.structure.io.mol as mol
+from biotite.structure.bonds import BondType
+from biotite.structure.io.ctab import BOND_TYPE_MAPPING_REV
 from ..util import data_dir
 
 
@@ -70,10 +72,38 @@ def test_structure_conversion(path, omit_charge):
     test_atoms = mol.get_structure(mol_file)
     if omit_charge:
         assert np.all(test_atoms.charge == 0)
-        test_atoms.del_annotation("charge") 
+        test_atoms.del_annotation("charge")
     temp.close()
 
     assert test_atoms == ref_atoms
+
+    # Check bond type fallback in MolFile.set_structure
+    # Update last bond type in ref_atoms with a quadruple bond type
+    ref_atoms.bonds.add_bond(0, 1, BondType.QUADRUPLE)
+    updated_bond = ref_atoms.bonds.as_array()[
+        np.all(ref_atoms.bonds.as_array()[:,[0,1]] == [0,1], axis=1)
+    ]
+    assert updated_bond.tolist()[0][2] == BondType.QUADRUPLE
+    test_mol_file = mol.MOLFile()
+    mol.set_structure(test_mol_file, ref_atoms)
+    # test bond type fallback to BondType.ANY value (8) in
+    # MolFile.set_structure to format mol_file.lines
+    updated_line = [
+        mol_line
+        for mol_line in test_mol_file.lines if mol_line.startswith('  1  2  ')
+    ].pop()
+    assert int(updated_line[8]) == \
+        BOND_TYPE_MAPPING_REV[BondType.ANY]
+    # test bond type fallback to BondType.SINGLE value (1) in
+    # MolFile.set_structure to format mol_file.lines
+    mol.set_structure(test_mol_file, ref_atoms,
+                      default_bond_type=BondType.SINGLE)
+    updated_line = [
+        mol_line
+        for mol_line in test_mol_file.lines if mol_line.startswith('  1  2  ')
+    ].pop()
+    assert int(updated_line[8]) == \
+        BOND_TYPE_MAPPING_REV[BondType.SINGLE]
 
 
 @pytest.mark.parametrize(

--- a/tests/structure/test_mol.py
+++ b/tests/structure/test_mol.py
@@ -77,35 +77,6 @@ def test_structure_conversion(path, omit_charge):
 
     assert test_atoms == ref_atoms
 
-    # Check bond type fallback in MolFile.set_structure
-    # Update last bond type in ref_atoms with a quadruple bond type,
-    # which is not supported by MOL files
-    # and thus translates to the default bond type
-    ref_atoms.bonds.add_bond(0, 1, BondType.QUADRUPLE)
-    updated_bond = ref_atoms.bonds.as_array()[
-        np.all(ref_atoms.bonds.as_array()[:,[0,1]] == [0,1], axis=1)
-    ]
-    assert updated_bond.tolist()[0][2] == BondType.QUADRUPLE
-    test_mol_file = mol.MOLFile()
-    mol.set_structure(test_mol_file, ref_atoms)
-    # test bond type fallback to BondType.ANY value (8) in
-    # MolFile.set_structure to format mol_file.lines
-    updated_line = [
-        mol_line
-        for mol_line in test_mol_file.lines if mol_line.startswith('  1  2  ')
-    ].pop()
-    assert int(updated_line[8]) == \
-        BOND_TYPE_MAPPING_REV[BondType.ANY]
-    # test bond type fallback to BondType.SINGLE value (1) in
-    # MolFile.set_structure to format mol_file.lines
-    mol.set_structure(test_mol_file, ref_atoms,
-                      default_bond_type=BondType.SINGLE)
-    updated_line = [
-        mol_line
-        for mol_line in test_mol_file.lines if mol_line.startswith('  1  2  ')
-    ].pop()
-    assert int(updated_line[8]) == \
-        BOND_TYPE_MAPPING_REV[BondType.SINGLE]
 
 
 @pytest.mark.parametrize(
@@ -136,3 +107,43 @@ def test_pdbx_consistency(path):
     assert test_atoms.charge.tolist() == ref_atoms.charge.tolist()
     assert set(tuple(bond) for bond in test_atoms.bonds.as_array()) \
         == set(tuple(bond) for bond in  ref_atoms.bonds.as_array())
+
+@pytest.mark.parametrize(
+    "path", glob.glob(join(data_dir("structure"), "molecules", "*.sdf")),
+)
+def test_structure_bond_type_fallback(path):
+    """
+    Check if a bond with a type not supported by MOL files will be translated
+    thanks to the bond type fallback in `MolFile.set_structure`
+    """
+    # Extract original list of bonds from an SDF file
+    mol_file = mol.MOLFile.read(path)
+    ref_atoms = mol.get_structure(mol_file)
+    # Update one bond in `ref_atoms` with with a quadruple bond type,
+    # which is not supported by MOL files and thus translates to
+    # the default bond type
+    ref_atoms.bonds.add_bond(0, 1, BondType.QUADRUPLE)
+    updated_bond = ref_atoms.bonds.as_array()[
+        np.all(ref_atoms.bonds.as_array()[:,[0,1]] == [0,1], axis=1)
+    ]
+    assert updated_bond.tolist()[0][2] == BondType.QUADRUPLE
+    test_mol_file = mol.MOLFile()
+    mol.set_structure(test_mol_file, ref_atoms)
+    # Test bond type fallback to BondType.ANY value (8) in
+    # MolFile.set_structure during mol_file.lines formatting
+    updated_line = [
+        mol_line
+        for mol_line in test_mol_file.lines if mol_line.startswith('  1  2  ')
+    ].pop()
+    assert int(updated_line[8]) == \
+        BOND_TYPE_MAPPING_REV[BondType.ANY]
+    # Test bond type fallback to BondType.SINGLE value (1) in
+    # MolFile.set_structure during mol_file.lines formatting
+    mol.set_structure(test_mol_file, ref_atoms,
+                      default_bond_type=BondType.SINGLE)
+    updated_line = [
+        mol_line
+        for mol_line in test_mol_file.lines if mol_line.startswith('  1  2  ')
+    ].pop()
+    assert int(updated_line[8]) == \
+        BOND_TYPE_MAPPING_REV[BondType.SINGLE]

--- a/tests/structure/test_mol.py
+++ b/tests/structure/test_mol.py
@@ -78,7 +78,9 @@ def test_structure_conversion(path, omit_charge):
     assert test_atoms == ref_atoms
 
     # Check bond type fallback in MolFile.set_structure
-    # Update last bond type in ref_atoms with a quadruple bond type
+    # Update last bond type in ref_atoms with a quadruple bond type,
+    # which is not supported by MOL files
+    # and thus translates to the default bond type
     ref_atoms.bonds.add_bond(0, 1, BondType.QUADRUPLE)
     updated_bond = ref_atoms.bonds.as_array()[
         np.all(ref_atoms.bonds.as_array()[:,[0,1]] == [0,1], axis=1)


### PR DESCRIPTION
Hi

Related to modifications added in the [PR #381](https://github.com/biotite-dev/biotite/pull/381), I forgot to propagate `default_bond_type` to `MolFile.set_structure`. This PR aims to correct this

* `structure/io/ctab.py`: change type of  `default_bond_type` parameter to `BondType`  enum
* `src/biotite/structure/io/mol/convert.py`:  add `default_bond_type` parameter to generic `set_structure`
* `src/biotite/structure/io/mol/file.py`: add `default_bond_type` parameter to `MOLFile.set_structure`
*  `tests/structure/test_mol.py`: check `default_bond_type` fallback in `test_structure_conversion`

I hope it doesn't affect too much the initial design