### PR TITLE
Add more chain-level utitlities and change chain start condition

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -181,7 +181,8 @@
             "BondType",
             "connect_via_residue_names",
             "connect_via_distances",
-            "find_connected"
+            "find_connected",
+            "find_rotatable_bonds"
         ],
         "Geometry" : [
             "displacement",
@@ -203,6 +204,7 @@
             "rotate_centered",
             "rotate_about_axis",
             "align_vectors",
+            "orient_principal_components",
             "superimpose",
             "superimpose_apply"
         ],
@@ -236,6 +238,12 @@
         ],
         "Chain level utility" : [
             "get_chain_starts",
+            "apply_chain_wise",
+            "spread_chain_wise",
+            "get_chain_masks",
+            "get_chain_starts_for",
+            "get_chain_positions",
+            "chain_iter",
             "get_chains",
             "get_chain_count",
             "chain_iter"

--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -127,4 +127,4 @@ from .sse import *
 from .superimpose import *
 from .transform import *
 from .basepairs import *
-# util is used internally
+# util and resutil are used internally

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -20,10 +20,8 @@ def get_chain_starts(array, add_exclusive_stop=False):
     Get the indices in an atom array, which indicates the beginning of
     a new chain.
     
-    A new chain starts, when the chain ID changes.
-
-    This method is internally used by all other chain-related
-    functions.
+    A new chain starts, when the chain ID changes or when the residue ID
+    decreases.
     
     Parameters
     ----------
@@ -39,17 +37,24 @@ def get_chain_starts(array, add_exclusive_stop=False):
     starts : ndarray, dtype=int
         The start indices of new chains in `array`.
     
+    Notes
+    -----
+    This method is internally used by all other chain-related
+    functions.
+    
     See also
     --------
     get_residue_starts
     """
+    diff = np.diff(array.res_id)
+    res_id_decrement = diff < 0
     # This mask is 'true' at indices where the value changes
     chain_id_changes = (array.chain_id[1:] != array.chain_id[:-1])
     
     # Convert mask to indices
     # Add 1, to shift the indices from the end of a chain
     # to the start of a new chain
-    chain_starts = np.where(chain_id_changes)[0] +1
+    chain_starts = np.where(res_id_decrement | chain_id_changes)[0] + 1
     
     # The first chain is not included yet -> Insert '[0]'
     if add_exclusive_stop:
@@ -124,6 +129,5 @@ def chain_iter(array):
     --------
     residue_iter
     """
-    # The exclusive stop is appended to the chain starts
     starts = get_chain_starts(array, add_exclusive_stop=True)
     return segment_iter(array, starts)

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -12,6 +12,7 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["get_chain_starts", "get_chains", "get_chain_count", "chain_iter"]
 
 import numpy as np
+from .resutil import *
 
 
 def get_chain_starts(array, add_exclusive_stop=False):
@@ -124,6 +125,5 @@ def chain_iter(array):
     residue_iter
     """
     # The exclusive stop is appended to the chain starts
-    starts = np.append(get_chain_starts(array), [array.array_length()])
-    for i in range(len(starts)-1):
-        yield array[..., starts[i] : starts[i+1]]
+    starts = get_chain_starts(array, add_exclusive_stop=True)
+    return segment_iter(array, starts)

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -9,7 +9,9 @@ atom level.
 
 __name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
-__all__ = ["get_chain_starts", "get_chains", "get_chain_count", "chain_iter"]
+__all__ = ["get_chain_starts", "apply_chain_wise", "spread_chain_wise",
+           "get_chain_masks", "get_chain_starts_for", "get_chain_positions",
+           "chain_iter", "get_chains", "get_chain_count", "chain_iter"]
 
 import numpy as np
 from .resutil import *
@@ -61,6 +63,169 @@ def get_chain_starts(array, add_exclusive_stop=False):
         return np.concatenate(([0], chain_starts, [array.array_length()]))
     else:
         return np.concatenate(([0], chain_starts))
+
+
+def apply_chain_wise(array, data, function, axis=None):
+    """
+    Apply a function to intervals of data, where each interval
+    corresponds to one chain.
+    
+    The function takes an atom array (stack) and an data array
+    (`ndarray`) of the same length. The function iterates through the
+    chain IDs of the atom array (stack) and identifies intervals of
+    the same ID. Then the data is
+    partitioned into the same intervals, and each interval (also an
+    :class:`ndarray`) is put as parameter into `function`. Each return value is
+    stored as element in the resulting :class:`ndarray`, therefore each element
+    corresponds to one chain. 
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack) to determine the chains from.
+    data : ndarray
+        The data, whose intervals are the parameter for `function`. Must
+        have same length as `array`.
+    function : function
+        The `function` must have either the form *f(data)* or
+        *f(data, axis)* in case `axis` is given. Every `function` call
+        must return a value with the same shape and data type.
+    axis : int, optional
+        This value is given to the `axis` parameter of `function`.
+        
+    Returns
+    -------
+    processed_data : ndarray
+        Chain-wise evaluation of `data` by `function`. The size of the
+        first dimension of this array is equal to the amount of
+        chains.
+        
+    See also
+    --------
+    apply_residue_wise
+    """
+    starts = get_chain_starts(array, add_exclusive_stop=True)
+    return apply_segment_wise(starts, data, function, axis)
+
+
+def spread_chain_wise(array, input_data):
+    """
+    Expand chain-wise data to atom-wise data.
+
+    Each value in the chain-wise input is assigned to all atoms of
+    this chain:
+    
+    ``output_data[i] = input_data[j]``,
+    *i* is incremented from atom to atom,
+    *j* is incremented every chain change.
+    
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack) to determine the chains from.
+    input_data : ndarray
+        The data to be spread. The length of axis=0 must be equal to
+        the amount of different chain IDs in `array`.
+        
+    Returns
+    -------
+    output_data : ndarray
+        Chain-wise spread `input_data`. Length is the same as
+        `array_length()` of `array`.
+        
+    See also
+    --------
+    spread_residue_wise
+    """
+    starts = get_chain_starts(array, add_exclusive_stop=True)
+    return spread_segment_wise(starts, input_data)
+
+
+def get_chain_masks(array, indices):
+    """
+    Get boolean masks indicating the chains to which the given atom
+    indices belong.
+
+    Parameters
+    ----------
+    array : AtomArray, shape=(n,) or AtomArrayStack, shape=(m,n)
+        The atom array (stack) to determine the chains from.
+    indices : ndarray, dtype=int, shape=(k,)
+        These indices indicate the atoms to get the corresponding
+        chains for.
+        Negative indices are not allowed.
+    
+    Returns
+    -------
+    chains_masks : ndarray, dtype=bool, shape=(k,n)
+        Multiple boolean masks, one for each given index in `indices`.
+        Each array masks the atoms that belong to the same chain as
+        the atom at the given index.
+    
+    See also
+    --------
+    get_residue_masks
+    """
+    starts = get_chain_starts(array, add_exclusive_stop=True)
+    return get_segment_masks(starts, indices)
+
+
+def get_chain_starts_for(array, indices):
+    """
+    For each given atom index, get the index that points to the
+    start of the chain that atom belongs to.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack) to determine the chains from.
+    indices : ndarray, dtype=int, shape=(k,)
+        These indices point to the atoms to get the corresponding
+        chain starts for.
+        Negative indices are not allowed.
+    
+    Returns
+    -------
+    start_indices : ndarray, dtype=int, shape=(k,)
+        The indices that point to the chain starts for the input
+        `indices`.
+    
+    See also
+    --------
+    get_residue_starts_for
+    """
+    starts = get_chain_starts(array, add_exclusive_stop=True)
+    return get_segment_starts_for(starts, indices)
+
+
+def get_chain_positions(array, indices):
+    """
+    For each given atom index, obtain the position of the chain
+    corresponding to this index in the input `array`.
+
+    For example, the position of the first chain in the atom array is
+    ``0``, the the position of the second chain is ``1``, etc.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The atom array (stack) to determine the chains from.
+    indices : ndarray, dtype=int, shape=(k,)
+        These indices point to the atoms to get the corresponding
+        chain positions for.
+        Negative indices are not allowed.
+    
+    Returns
+    -------
+    start_indices : ndarray, dtype=int, shape=(k,)
+        The indices that point to the position of the chains.
+    
+    See also
+    --------
+    get_residue_positions
+    """
+    starts = get_chain_starts(array, add_exclusive_stop=True)
+    return get_segment_positions(starts, indices)
 
 
 def get_chains(array):

--- a/src/biotite/structure/resutil.py
+++ b/src/biotite/structure/resutil.py
@@ -1,0 +1,178 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+__name__ = "biotite.structure"
+__author__ = "Patrick Kunzmann"
+__all__ = ["apply_segment_wise", "spread_segment_wise", "get_segment_masks",
+           "get_segment_starts_for", "get_segment_positions", "segment_iter"]
+
+import numpy as np
+
+
+def apply_segment_wise(starts, data, function, axis):
+    """
+    Generalized version of :func:`apply_residue_wise()` for
+    residues and chains.
+
+    Parameters
+    ----------
+    starts : ndarray, dtype=int
+        The sorted start indices of segments.
+        Includes exclusive stop, i.e. the length of the corresponding
+        atom array.
+    """
+    # The result array
+    processed_data = None
+    for i in range(len(starts)-1):
+        segment = data[starts[i]:starts[i+1]]
+        if axis == None:
+            value = function(segment)
+        else:
+            value = function(segment, axis=axis)
+        value = function(segment, axis=axis)
+        # Identify the shape of the resulting array by evaluation
+        # of the function return value for the first segment
+        if processed_data is None:
+            if isinstance(value, np.ndarray):
+                # Maximum length of the processed data
+                # is length of segment of size 1 -> length of all IDs
+                # (equal to atom array length)
+                processed_data = np.zeros(
+                    (len(starts)-1,) + value.shape, dtype=value.dtype
+                )
+            else:
+                # Scalar value -> one dimensional result array
+                processed_data = np.zeros(
+                    len(starts)-1, dtype=type(value)
+                )
+        # Write values into result arrays
+        processed_data[i] = value
+    return processed_data
+
+
+def spread_segment_wise(starts, input_data):
+    """
+    Generalized version of :func:`spread_residue_wise()`
+    for residues and chains.
+
+    Parameters
+    ----------
+    starts : ndarray, dtype=int
+        The sorted start indices of segments.
+        Includes exclusive stop, i.e. the length of the corresponding
+        atom array.
+    """
+    output_data = np.zeros(starts[-1], dtype=input_data.dtype)
+    for i in range(len(starts)-1):
+        start = starts[i]
+        stop = starts[i + 1]
+        output_data[start:stop] = input_data[i]
+    return output_data
+
+
+def get_segment_masks(starts, indices):
+    """
+    Generalized version of :func:`get_residue_masks()`
+    for residues and chains.
+
+    Parameters
+    ----------
+    starts : ndarray, dtype=int
+        The sorted start indices of segments.
+        Includes exclusive stop, i.e. the length of the corresponding
+        atom array.
+    """
+    indices = np.asarray(indices)
+    length = starts[-1]
+    masks = np.zeros((len(indices), length), dtype=bool)
+
+    if (indices < 0).any():
+        raise ValueError("This function does not support negative indices")
+    if (indices >= length).any():
+        index = np.min(np.where(indices >= length)[0])
+        raise ValueError(
+            f"Index {index} is out of range for "
+            f"an atom array with length {length}"
+        )
+    
+    insertion_points = np.searchsorted(starts, indices, side="right") - 1
+    for i, point in enumerate(insertion_points):
+        masks[i, starts[point] : starts[point+1]] = True
+    
+    return masks
+
+
+def get_segment_starts_for(starts, indices):
+    """
+    Generalized version of :func:`get_residue_starts_for()`
+    for residues and chains.
+
+    Parameters
+    ----------
+    starts : ndarray, dtype=int
+        The sorted start indices of segments.
+        Includes exclusive stop, i.e. the length of the corresponding
+        atom array.
+    """
+    indices = np.asarray(indices)
+    length = starts[-1]
+    # Remove exclusive stop
+    starts = starts[:-1]
+
+    if (indices < 0).any():
+        raise ValueError("This function does not support negative indices")
+    if (indices >= length).any():
+        index = np.min(np.where(indices >= length)[0])
+        raise ValueError(
+            f"Index {index} is out of range for "
+            f"an atom array with length {length}"
+        )
+    
+    insertion_points = np.searchsorted(starts, indices, side="right") - 1
+    return starts[insertion_points]
+
+
+def get_segment_positions(starts, indices):
+    """
+    Generalized version of :func:`get_residue_positions()`
+    for residues and chains.
+
+    Parameters
+    ----------
+    starts : ndarray, dtype=int
+        The sorted start indices of segments.
+        Includes exclusive stop, i.e. the length of the corresponding
+        atom array.
+    """
+    indices = np.asarray(indices)
+    length = starts[-1]
+    # Remove exclusive stop
+    starts = starts[:-1]
+
+    if (indices < 0).any():
+        raise ValueError("This function does not support negative indices")
+    if (indices >= length).any():
+        index = np.min(np.where(indices >= length)[0])
+        raise ValueError(
+            f"Index {index} is out of range for "
+            f"an atom array with length {length}"
+        )
+    
+    return np.searchsorted(starts, indices, side="right") - 1
+
+
+def segment_iter(array, starts):
+    """
+    Generalized version of :func:`residue_iter()`
+    for residues and chains.
+
+    Parameters
+    ----------
+    starts : ndarray, dtype=int
+        The sorted start indices of segments.
+        Includes exclusive stop, i.e. the length of the corresponding
+        atom array.
+    """
+    for i in range(len(starts)-1):
+        yield array[..., starts[i] : starts[i+1]]

--- a/tests/structure/test_chains.py
+++ b/tests/structure/test_chains.py
@@ -15,10 +15,24 @@ def array():
     return strucio.load_structure(join(data_dir("structure"), "1igy.mmtf"))
 
 def test_get_chain_starts(array):
+    """
+    Compare :func:`test_get_chain_starts()` with :func:`np.unique` in a
+    case where chain ID unambiguously identify chains.
+    """
     _, ref_starts = np.unique(array.chain_id, return_index=True)
     test_starts = struc.get_chain_starts(array)
     # All first occurences of a chain id are automatically chain starts
     assert set(ref_starts).issubset(set(test_starts))
+
+def test_get_chain_starts_same_id(array):
+    """
+    Expect correct number of chains in a case where two successive
+    chains have the same chain ID (as possible in an assembly).
+    """
+    # Concatenate two chains with same ID
+    array = array[array.chain_id == "A"]
+    array = array + array
+    assert len(struc.get_chain_starts(array)) == 2
 
 def test_get_chains(array):
     assert struc.get_chains(array).tolist() == ["A", "B", "C", "D", "E", "F"]

--- a/tests/structure/test_chains.py
+++ b/tests/structure/test_chains.py
@@ -31,8 +31,8 @@ def test_get_chain_starts_same_id(array):
     """
     # Concatenate two chains with same ID
     array = array[array.chain_id == "A"]
-    array = array + array
-    assert len(struc.get_chain_starts(array)) == 2
+    merged = array + array
+    assert struc.get_chain_starts(merged).tolist() == [0, array.array_length()]
 
 def test_get_chains(array):
     assert struc.get_chains(array).tolist() == ["A", "B", "C", "D", "E", "F"]

--- a/tests/structure/test_chains.py
+++ b/tests/structure/test_chains.py
@@ -34,6 +34,38 @@ def test_get_chain_starts_same_id(array):
     merged = array + array
     assert struc.get_chain_starts(merged).tolist() == [0, array.array_length()]
 
+def test_apply_chain_wise(array):
+    data = struc.apply_chain_wise(array, np.ones(len(array)), np.sum)
+    assert data.tolist() == [
+        len(array[array.chain_id == chain_id])
+        for chain_id in np.unique(array.chain_id)
+    ]
+
+def test_spread_chain_wise(array):
+    input_data = np.unique(array.chain_id)
+    output_data = struc.spread_chain_wise(array, input_data)
+    assert output_data.tolist() == array.chain_id.tolist()
+
+def test_get_chain_masks(array):
+    SAMPLE_SIZE = 100
+    np.random.seed(0)
+    indices = np.random.randint(0, array.array_length(), SAMPLE_SIZE)
+    test_masks = struc.get_chain_masks(array, indices)
+    for index, test_mask in zip(indices, test_masks):
+        ref_mask = array.chain_id == array.chain_id[index]
+        assert test_mask.tolist() == ref_mask.tolist()
+
+def test_get_chain_starts_for(array):
+    SAMPLE_SIZE = 100
+    np.random.seed(0)
+    indices = np.random.randint(0, array.array_length(), SAMPLE_SIZE)
+    ref_starts = np.array(
+        [np.where(mask)[0][0] for mask
+         in struc.get_chain_masks(array, indices)]
+    )
+    test_starts = struc.get_chain_starts_for(array, indices)
+    assert test_starts.tolist() == ref_starts.tolist()
+
 def test_get_chains(array):
     assert struc.get_chains(array).tolist() == ["A", "B", "C", "D", "E", "F"]
 


### PR DESCRIPTION
This PR adds further chain-level utilities analogous to residue-level utilities:

- `apply_chain_wise()`
- `spread_chain_wise()`
- `get_chain_masks()`
- `get_chain_starts_for()`
- `get_chain_positions()`

Common functionalities required by both `residues.py` and `chains.py` are moved into `resutil.py`.

Furthermore, a decreased residue ID is a further condition for a beginning chain as outlined in #389.