### PR TITLE
Fix typo in matrix parsing

### DIFF
--- a/src/biotite/sequence/align/matrix.py
+++ b/src/biotite/sequence/align/matrix.py
@@ -333,7 +333,7 @@ class SubstitutionMatrix(object):
         matrix_dict = {}
         for i in range(len(symbols1)):
             for j in range(len(symbols2)):
-                matrix_dict[(symbols1[i], symbols1[j])] = scores[i,j]
+                matrix_dict[(symbols1[i], symbols2[j])] = scores[i,j]
         return matrix_dict
     
     @staticmethod


### PR DESCRIPTION
Fixes typo in `dict_from_string()` that may lead to wrong score in substitution matrices with two different alphabets.