### PR TITLE
Pad PDB lines to 80 characters

### DIFF
--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -65,6 +65,15 @@ class PDBFile(TextFile):
     >>> file.set_structure(array_stack_mod)
     >>> file.write(os.path.join(path_to_directory, "1l2y_mod.pdb"))
     """
+    @classmethod
+    def read(cls, file):
+        file = super().read(file)
+        # Pad lines with whitespace if lines are shorter
+        # than the required 80 characters
+        file.lines = [line.ljust(80) for line in file.lines]
+        return file
+
+
     def get_model_count(self):
         """
         Get the number of models contained in the PDB file.


### PR DESCRIPTION
This PR presents an alternative solution as #401 to fix reading PDB files that have a line length smaller than 80 characters.
Here too short lines are padded with whitespace, when the PDB file is read.