### PR TITLE
Fix Vina not recognizing metal elements

### DIFF
--- a/src/biotite/structure/io/pdbqt/file.py
+++ b/src/biotite/structure/io/pdbqt/file.py
@@ -18,8 +18,8 @@ from ...bonds import BondList, BondType, find_connected, find_rotatable_bonds
 
 PARAMETRIZED_ELEMENTS = [
     "H", "C", "N", "O", "P", "S",
-    "F", "CL", "BR", "I",
-    "MG", "CA", "MN", "FE", "ZN"
+    "F", "Cl", "Br", "I",
+    "Mg", "Ca", "Mn", "Fe", "Zn"
 ]
 
 
@@ -613,8 +613,8 @@ def convert_atoms(atoms, charges):
             atom_types[i] = "OA"
         elif element == "S":
             atom_types[i] = "SA"
-        elif element in PARAMETRIZED_ELEMENTS:
-            atom_types[i] = element
+        elif element.capitalize() in PARAMETRIZED_ELEMENTS:
+            atom_types[i] = element.capitalize()
         else:
             warnings.warn(
                 f"Element {element} is not paramtrized, "


### PR DESCRIPTION
This PR changes `PDBQTFile.set_structure()` so that atom elements are written capitalized instead of uppercase. This is necessary for *Vina* to recognize two-letter elements as atom types.