### PR TITLE
support for Path objects

### DIFF
--- a/src/biotite/file.py
+++ b/src/biotite/file.py
@@ -9,6 +9,8 @@ __all__ = ["File", "TextFile", "InvalidFileError"]
 import abc
 import io
 import warnings
+from pathlib import Path
+
 from .copyable import Copyable
 import copy
 
@@ -50,7 +52,6 @@ class File(Copyable, metaclass=abc.ABCMeta):
             representing the parsed file.
         """
         pass
-        
             
     def _deprecated_read(self, file, *args, **kwargs):
         """
@@ -104,7 +105,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
     @classmethod
     def read(cls, file, *args, **kwargs):
         # File name
-        if isinstance(file, str):
+        if isinstance(file, str) or isinstance(file, Path):
             with open(file, "r") as f:
                 lines = f.read().splitlines()
         # File object
@@ -133,7 +134,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
             The current line in the file.
         """
         # File name
-        if isinstance(file, str):
+        if isinstance(file, str) or isinstance(file, Path):
             with open(file, "r") as f:
                 yield from f
         # File object
@@ -153,7 +154,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
             The file to be written to.
             Alternatively a file path can be supplied.
         """
-        if isinstance(file, str):
+        if isinstance(file, str) or isinstance(file, Path):
             with open(file, "w") as f:
                 f.write("\n".join(self.lines) + "\n")
         else:
@@ -183,7 +184,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
             The lines of text to be written.
             Must not include line break characters.
         """
-        if isinstance(file, str):
+        if isinstance(file, str) or isinstance(file, Path):
             with open(file, "w") as f:
                 for line in lines:
                     f.write(line + "\n")
@@ -198,7 +199,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
         clone.lines = copy.copy(self.lines)
     
     def __str__(self):
-        return("\n".join(self.lines))
+        return "\n".join(self.lines)
 
 
 class InvalidFileError(Exception):

--- a/src/biotite/file.py
+++ b/src/biotite/file.py
@@ -9,7 +9,7 @@ __all__ = ["File", "TextFile", "InvalidFileError"]
 import abc
 import io
 import warnings
-from pathlib import Path
+from os import PathLike
 
 from .copyable import Copyable
 import copy
@@ -25,14 +25,14 @@ class File(Copyable, metaclass=abc.ABCMeta):
     In order to write the instance content into a file the
     :func:`write()` method is used.
     """
-    
+
     def __init__(self):
         # Support for deprecated instance method 'read()':
         # When creating an instance, the 'read()' class method is
         # replaced by the instance method, so that subsequent
         # 'read()' calls are delegated to the instance method
         self.read = self._deprecated_read
-    
+
     @classmethod
     @abc.abstractmethod
     def read(cls, file):
@@ -52,7 +52,7 @@ class File(Copyable, metaclass=abc.ABCMeta):
             representing the parsed file.
         """
         pass
-            
+
     def _deprecated_read(self, file, *args, **kwargs):
         """
         Support for deprecated instance method :func:`read()`.
@@ -69,7 +69,7 @@ class File(Copyable, metaclass=abc.ABCMeta):
         cls = type(self)
         new_file = cls.read(file, *args, **kwargs)
         self.__dict__.update(new_file.__dict__)
-    
+
     @abc.abstractmethod
     def write(self, file):
         """
@@ -82,7 +82,7 @@ class File(Copyable, metaclass=abc.ABCMeta):
             Alternatively a file path can be supplied.
         """
         pass
-        
+
 
 class TextFile(File, metaclass=abc.ABCMeta):
     """
@@ -97,7 +97,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
         List of string representing the lines in the text file.
         PROTECTED: Do not modify from outside.
     """
-    
+
     def __init__(self):
         super().__init__()
         self.lines = []
@@ -105,7 +105,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
     @classmethod
     def read(cls, file, *args, **kwargs):
         # File name
-        if isinstance(file, str) or isinstance(file, Path):
+        if is_open_compatible(file):
             with open(file, "r") as f:
                 lines = f.read().splitlines()
         # File object
@@ -116,7 +116,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
         file_object = cls(*args, **kwargs)
         file_object.lines = lines
         return file_object
-    
+
     @staticmethod
     def read_iter(file):
         """
@@ -134,7 +134,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
             The current line in the file.
         """
         # File name
-        if isinstance(file, str) or isinstance(file, Path):
+        if is_open_compatible(file):
             with open(file, "r") as f:
                 yield from f
         # File object
@@ -154,14 +154,14 @@ class TextFile(File, metaclass=abc.ABCMeta):
             The file to be written to.
             Alternatively a file path can be supplied.
         """
-        if isinstance(file, str) or isinstance(file, Path):
+        if is_open_compatible(file):
             with open(file, "w") as f:
                 f.write("\n".join(self.lines) + "\n")
         else:
             if not is_text(file):
                 raise TypeError("A file opened in 'text' mode is required")
             file.write("\n".join(self.lines) + "\n")
-    
+
     @staticmethod
     def write_iter(file, lines):
         """
@@ -184,7 +184,7 @@ class TextFile(File, metaclass=abc.ABCMeta):
             The lines of text to be written.
             Must not include line break characters.
         """
-        if isinstance(file, str) or isinstance(file, Path):
+        if is_open_compatible(file):
             with open(file, "w") as f:
                 for line in lines:
                     f.write(line + "\n")
@@ -193,11 +193,11 @@ class TextFile(File, metaclass=abc.ABCMeta):
                 raise TypeError("A file opened in 'text' mode is required")
             for line in lines:
                 file.write(line + "\n")
-    
+
     def __copy_fill__(self, clone):
         super().__copy_fill__(clone)
         clone.lines = copy.copy(self.lines)
-    
+
     def __str__(self):
         return "\n".join(self.lines)
 
@@ -237,3 +237,7 @@ def is_text(file):
         return True
     # for file wrappers, e.g. 'TemporaryFile'
     return hasattr(file, "file") and isinstance(file.file, io.TextIOBase)
+
+
+def is_open_compatible(file):
+    return isinstance(file, (str, bytes, PathLike))

--- a/src/biotite/structure/filter.py
+++ b/src/biotite/structure/filter.py
@@ -25,7 +25,14 @@ _ext_aa_list = ["ALA","ARG","ASN","ASP","CYS","GLN","GLU","GLY","HIS","ILE",
 
 _nucleotide_list = nucleotide_names()
 
-_solvent_list = ["HOH","SOL"]
+_solvent_list = ('1PE', '2HT', '2PE', '7PE', 'ACT', 'BEN', 'BME', 'BOG', 'BTB',
+                 'BU3', 'BUD', 'CIT', 'COM', 'CXS', 'DIO', 'DMS', 'DTD', 'DTT',
+                 'DTV', 'DVT', 'EDO', 'EOH', 'EPE', 'FLC', 'GBL', 'GG5', 'GLC',
+                 'GOL', 'HC4', 'HOH', 'HSJ', 'IPH', 'MES', 'MG8', 'MLA', 'MLI',
+                 'MOH', 'MPD', 'MRD', 'MSE', 'MXE', 'MYR', 'OCT', 'P4C', 'P4G',
+                 'P6G', 'PEG', 'PG0', 'PG4', 'PGE', 'PGF', 'PHU', 'PTL', 'SGM',
+                 'SIN', 'SOL', 'SRT', 'TAM', 'TAR', 'TBR', 'TCE', 'TFA', 'TLA',
+                 'TMA', 'TRS')
 
 
 def filter_monoatomic_ions(array):
@@ -49,7 +56,7 @@ def filter_monoatomic_ions(array):
     return (array.res_name == array.element)
 
 
-def filter_solvent(array):
+def filter_solvent(array, solvents=_solvent_list):
     """
     Filter all atoms of one array that are part of the solvent.
 
@@ -57,6 +64,8 @@ def filter_solvent(array):
     ----------
     array : AtomArray or AtomArrayStack
         The array to be filtered.
+    solvents: list or tuple
+        The list of solvent PDB 3-letter codes.
 
     Returns
     -------
@@ -64,7 +73,7 @@ def filter_solvent(array):
         This array is `True` for all indices in `array`, where the atom
         belongs to the solvent.
     """
-    return np.in1d(array.res_name, _solvent_list)
+    return np.in1d(array.res_name, solvents)
 
 
 def filter_nucleotides(array):

--- a/src/biotite/structure/filter.py
+++ b/src/biotite/structure/filter.py
@@ -25,14 +25,7 @@ _ext_aa_list = ["ALA","ARG","ASN","ASP","CYS","GLN","GLU","GLY","HIS","ILE",
 
 _nucleotide_list = nucleotide_names()
 
-_solvent_list = ('1PE', '2HT', '2PE', '7PE', 'ACT', 'BEN', 'BME', 'BOG', 'BTB',
-                 'BU3', 'BUD', 'CIT', 'COM', 'CXS', 'DIO', 'DMS', 'DTD', 'DTT',
-                 'DTV', 'DVT', 'EDO', 'EOH', 'EPE', 'FLC', 'GBL', 'GG5', 'GLC',
-                 'GOL', 'HC4', 'HOH', 'HSJ', 'IPH', 'MES', 'MG8', 'MLA', 'MLI',
-                 'MOH', 'MPD', 'MRD', 'MSE', 'MXE', 'MYR', 'OCT', 'P4C', 'P4G',
-                 'P6G', 'PEG', 'PG0', 'PG4', 'PGE', 'PGF', 'PHU', 'PTL', 'SGM',
-                 'SIN', 'SOL', 'SRT', 'TAM', 'TAR', 'TBR', 'TCE', 'TFA', 'TLA',
-                 'TMA', 'TRS')
+_solvent_list = ["HOH","SOL"]
 
 
 def filter_monoatomic_ions(array):
@@ -56,7 +49,7 @@ def filter_monoatomic_ions(array):
     return (array.res_name == array.element)
 
 
-def filter_solvent(array, solvents=_solvent_list):
+def filter_solvent(array):
     """
     Filter all atoms of one array that are part of the solvent.
 
@@ -64,8 +57,6 @@ def filter_solvent(array, solvents=_solvent_list):
     ----------
     array : AtomArray or AtomArrayStack
         The array to be filtered.
-    solvents: list or tuple
-        The list of solvent PDB 3-letter codes.
 
     Returns
     -------
@@ -73,7 +64,7 @@ def filter_solvent(array, solvents=_solvent_list):
         This array is `True` for all indices in `array`, where the atom
         belongs to the solvent.
     """
-    return np.in1d(array.res_name, solvents)
+    return np.in1d(array.res_name, _solvent_list)
 
 
 def filter_nucleotides(array):

--- a/src/biotite/structure/io/mmtf/file.py
+++ b/src/biotite/structure/io/mmtf/file.py
@@ -12,7 +12,7 @@ import struct
 import copy
 import numpy as np
 import msgpack
-from ....file import File, is_binary
+from ....file import File, is_binary, is_open_compatible
 from ...error import BadStructureError
 from .decode import decode_array
 from .encode import encode_array
@@ -67,7 +67,7 @@ class MMTFFile(File, MutableMapping):
         """
         mmtf_file = MMTFFile()
         # File name
-        if isinstance(file, str):
+        if is_open_compatible(file):
             with open(file, "rb") as f:
                 mmtf_file._content = msgpack.unpackb(
                     f.read(), use_list=True, raw=False
@@ -94,7 +94,7 @@ class MMTFFile(File, MutableMapping):
         packed_bytes = msgpack.packb(
             self._content, use_bin_type=True, default=_encode_numpy
         )
-        if isinstance(file, str):
+        if is_open_compatible(file):
             with open(file, "wb") as f:
                 f.write(packed_bytes)
         else:


### PR DESCRIPTION
`Path` objects provide an OS-agnostic interface to the filesystem and are compatible with the built-in `open` function. However, using them in biotite raises an error and requires an explicit opening externally. I believe they should be handled the same way as the `str` in this case.