### PR TITLE
Fix #426

### DIFF
--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -53,7 +53,7 @@ def test_array_conversion(path, model, hybrid36, include_bonds):
         else:
             raise
     
-    if hybrid36 and (array1.res_id < 1).any():
+    if hybrid36 and (array1.res_id < 0).any():
         with pytest.raises(
             ValueError,
             match="Only positive integers can be converted "


### PR DESCRIPTION
This PR fixes #426 .
`test_pdb.py::test_array_conversion()` failed due to simple error in the test itself, as a `res_id` of 0 is indeed convertible into hybrid36.
`test_mmtf.py::test_array_conversion()` failed for a more serious reason:

The MMTF file defines two different `HIS` `groupType` in its `groupList`, depicting different protonation. Previously, the correct `groupType` was determined using a fast check: If a `groupType` with the same number of atoms already exists, that one is selected.
However, in this case the two `HIS` `groupType` have unfortunately the same number of atoms, leading to selection of an *wrong* `HIS` `groupType`.

This fix replaces the fast check with a thorough check of the entire  `groupType`. Although this will affect performance at least a little, I see no other way to guarantee correctness for such cases.