### PR TITLE
Adding a temp_dir parameter to the VinaApp

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -11,3 +11,4 @@ CONTRIBUTORS
 - Claude J. Rogers <https://github.com/claudejrogers>
 - Ivan Reveguk <https://github.com/edikedik>
 - Jan H. Krumbach <https://github.com/JHKru>
+- Benjamin E. Mayer <https://github.com/entropybit>

--- a/src/biotite/application/autodock/app.py
+++ b/src/biotite/application/autodock/app.py
@@ -45,6 +45,8 @@ class VinaApp(LocalApp):
         By default, the receptor has no flexibility.
     bin_path : str, optional
         Path to the *Vina* binary.
+    temp_dir : str, optional
+        Path that will be used instead of /tmp for creating temporary files.
 
     Examples
     --------
@@ -63,7 +65,7 @@ class VinaApp(LocalApp):
     ... )
     """
     def __init__(self, ligand, receptor, center, size, flexible=None,
-                 bin_path="vina"):
+                 bin_path="vina", temp_dir=None):
         super().__init__(bin_path)
 
         if ligand.bonds is None:
@@ -88,16 +90,16 @@ class VinaApp(LocalApp):
             ))
         
         self._ligand_file  = NamedTemporaryFile(
-            "w", suffix=".pdbqt", delete=False
+            "w", suffix=".pdbqt", delete=False, dir=temp_dir
         )
         self._receptor_file  = NamedTemporaryFile(
-            "w", suffix=".pdbqt", delete=False
+            "w", suffix=".pdbqt", delete=False, dir=temp_dir
         )
         self._receptor_flex_file  = NamedTemporaryFile(
-            "w", suffix=".pdbqt", delete=False
+            "w", suffix=".pdbqt", delete=False, dir=temp_dir
         )
         self._out_file  = NamedTemporaryFile(
-            "r", suffix=".pdbqt", delete=False
+            "r", suffix=".pdbqt", delete=False, dir=temp_dir
         )
     
     @requires_state(AppState.CREATED)


### PR DESCRIPTION
Using the VinaApp for docking creates temporary files. In the original implementation those are just stored in /tmp which usually is fine. However, if one wants to use VinaApp for (large scale) docking on a cluster there might not be a /tmp folder or the path to it might be somewhere else.  Usually a distributed file system is available as scratch which is perfectly fine with handling a lot of short living files. Therefore, one might want to or even need to have control over where the tempory files are created.  I propose to simply add a parameter temp_dir that defaults to None which we will set the NamedTemporaryFiles parameter dir to. If dir is set to None it will just create a file under /tmp otherwise the given path is used. This can be tested by doing:

```python
x=NamedTemporaryFile()
y=NamedTemporaryFile(dir=None)
z=NamedTemporaryFile(dir=".")
print(x.name)
print(y.name)
print(z.name)
```
which will create 3 different termporary files and print their full path.