### PR TITLE
Read assemblies from PDB/MMTF files and symmetry mates from PDB files

### DIFF
--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -1369,10 +1369,10 @@ def repeat(atoms, coord):
         annot = np.tile(atoms.get_annotation(category), repetitions)
         repeated.set_annotation(category, annot)
     if atoms.bonds is not None:
-        bonds = atoms.bonds
+        repeated_bonds = atoms.bonds.copy()
         for _ in range(repetitions-1):
-            bonds += atoms.bonds
-        repeated.bonds = bonds
+            repeated_bonds += atoms.bonds
+        repeated.bonds = repeated_bonds
     if atoms.box is not None:
         repeated.box = atoms.box.copy()
     

--- a/src/biotite/structure/io/mmtf/__init__.py
+++ b/src/biotite/structure/io/mmtf/__init__.py
@@ -12,6 +12,7 @@ performance, than the text based file formats.
 __name__ = "biotite.structure.io.mmtf"
 __author__ = "Patrick Kunzmann"
 
+from .assembly import *
 from .file import *
 from .convertfile import *
 from .convertarray import *

--- a/src/biotite/structure/io/mmtf/assembly.py
+++ b/src/biotite/structure/io/mmtf/assembly.py
@@ -1,0 +1,112 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+__name__ = "biotite.structure.io.mmtf"
+__author__ = "Patrick Kunzmann"
+__all__ = ["get_assembly"]
+
+
+import numpy as np
+from .convertfile import get_structure
+from ...chains import get_chain_starts
+from ...util import matrix_rotate
+from ....file import InvalidFileError
+
+
+def list_assemblies(file):
+    return [assembly["name"] for assembly in file["bioAssemblyList"]]
+
+
+def get_assembly(file, assembly_id=None, model=None, altloc="first",
+                 extra_fields=[], include_bonds=False):
+    structure = get_structure(
+        file, model, altloc, extra_fields, include_bonds
+    )
+
+    # Get transformations for chosen assembly
+    selected_assembly = None
+    if not "bioAssemblyList" in file:
+        raise InvalidFileError(
+                "File does not contain assembly information "
+                "(missing 'bioAssemblyList')"
+            )
+    for assembly in file["bioAssemblyList"]:
+        current_assembly_id = assembly["name"]
+        transform_list = assembly["transformList"]
+        if assembly_id is None or current_assembly_id == assembly_id:
+            selected_assembly = transform_list
+            break
+    if selected_assembly is None:
+        raise KeyError(
+            f"The assembly ID '{assembly_id}' is not found"
+        )
+    
+    # In most cases the transformations in an assembly applies to all
+    # atoms equally ('apply_to_all == True')
+    # If this is the case, the selection of atoms for each
+    # transformation can be omitted, improving the performance
+    chain_index_count = len(file["chainNameList"])
+    apply_to_all = True
+    for transformation in selected_assembly:
+        # If the number of affected chains matches the number of total
+        # chains, all atoms are affected
+        if len(transformation["chainIndexList"]) != chain_index_count:
+            apply_to_all = False
+    # If the transformations in the assembly do not apply to all atoms,
+    # but only to certain chains we need the ranges of these chains
+    # in the base structure (the asymmetric unit)
+    if not apply_to_all:
+        chains_starts = get_chain_starts(
+            structure, add_exclusive_stop=True
+        )
+        # Furthermore the number of chains determined by Biotite via
+        # 'get_chain_starts()' must corresponds to the number of chains
+        # in the MMTF file
+        # If this is not the case the assembly cannot be read using
+        # this function due to the shortcoming in 'get_structure()'
+        if len(chains_starts) != chain_index_count:
+            raise NotImplementedError(
+                "The structure file is not suitable for this function, as the "
+                "number of chains in the file do not match the automatically "
+                "detected number of chains"
+            )
+    
+    # Apply transformations for set of chains (or all chains) and add
+    # the transformed atoms to assembly
+    assembly = None
+    for transformation in selected_assembly:
+        if apply_to_all:
+            affected_coord = structure.coord
+        else:
+            # Mask atoms affected by this transformation
+            affected_mask = np.zeros(structure.array_length(), dtype=bool)
+            for chain_i in transformation["chainIndexList"]:
+                chain_start = chains_starts[chain_i]
+                chain_stop = chains_starts[chain_i+1]
+                affected_mask[chain_start : chain_stop] = True
+            affected_coord = structure.coord[..., affected_mask, :]
+        # Apply the transformation
+        transformed_coord = _apply_transformation(
+            affected_coord, transformation["matrix"]
+        )
+        sub_assembly = structure.copy()
+        sub_assembly.coord = transformed_coord
+        # Add transformed coordinates to assembly
+        if assembly is None:
+            assembly = sub_assembly
+        else:
+            assembly += sub_assembly
+    
+    return assembly
+
+
+def _apply_transformation(coord, mmtf_matrix):
+    # Obtain matrix from flattened form
+    matrix = np.array(mmtf_matrix).reshape(4, 4)
+    # Separate rotation and translation part
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    coord = matrix_rotate(coord, rotation)
+    coord += translation
+    return coord

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -9,7 +9,8 @@ subpackages.
 
 __name__ = "biotite.structure.io.pdb"
 __author__ = "Patrick Kunzmann"
-__all__ = ["get_model_count", "get_structure", "set_structure"]
+__all__ = ["get_model_count", "get_structure", "set_structure",
+           "list_assemblies", "get_assembly"]
 
 
 def get_model_count(pdb_file):
@@ -113,3 +114,14 @@ def set_structure(pdb_file, array, hybrid36=False):
     and all inter-residue connections.
     """
     pdb_file.set_structure(array, hybrid36)
+
+
+def list_assemblies(pdb_file):
+    return pdb_file.list_assemblies()
+
+
+def get_assembly(pdb_file, assembly_id=None, model=None, altloc="first",
+                 extra_fields=[], include_bonds=False):
+    return pdb_file.get_assembly(
+        assembly_id, model, altloc, extra_fields, include_bonds
+    )

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -10,7 +10,7 @@ subpackages.
 __name__ = "biotite.structure.io.pdb"
 __author__ = "Patrick Kunzmann"
 __all__ = ["get_model_count", "get_structure", "set_structure",
-           "list_assemblies", "get_assembly"]
+           "list_assemblies", "get_assembly", "get_symmetry_mates"]
 
 
 def get_model_count(pdb_file):
@@ -49,7 +49,7 @@ def get_structure(pdb_file, model=None, altloc="first", extra_fields=[],
         :class:`AtomArray` from the atoms corresponding to the given
         model number (starting at 1).
         Negative values are used to index models starting from the last
-        model insted of the first model.
+        model instead of the first model.
         If this parameter is omitted, an :class:`AtomArrayStack`
         containing all models will be returned, even if the structure
         contains only one model.
@@ -117,11 +117,168 @@ def set_structure(pdb_file, array, hybrid36=False):
 
 
 def list_assemblies(pdb_file):
+    """
+    List the biological assemblies that are available for the
+    structure in the given file.
+
+    This function receives the data from the ``REMARK 300`` records
+    in the file.
+    Consequently, this remark must be present in the file.
+
+    Parameters
+    ----------
+    pdb_file : PDBFile
+        The file object.
+
+    Returns
+    -------
+    assemblies : list of str
+        A list that contains the available assembly IDs.
+    
+    Examples
+    --------
+    >>> import os.path
+    >>> file = PDBFile.read(os.path.join(path_to_structures, "1f2n.pdb"))
+    >>> print(list_assemblies(file))
+    ['1']
+    """
     return pdb_file.list_assemblies()
 
 
 def get_assembly(pdb_file, assembly_id=None, model=None, altloc="first",
                  extra_fields=[], include_bonds=False):
+    """
+    Build the given biological assembly.
+
+    This function receives the data from ``REMARK 350`` records in
+    the file.
+    Consequently, this remark must be present in the file.
+
+    Parameters
+    ----------
+    pdb_file : PDBFile
+        The file object.
+    assembly_id : str
+        The assembly to build.
+        Available assembly IDs can be obtained via
+        :func:`list_assemblies()`.
+    model : int, optional
+        If this parameter is given, the function will return an
+        :class:`AtomArray` from the atoms corresponding to the given
+        model number (starting at 1).
+        Negative values are used to index models starting from the
+        last model instead of the first model.
+        If this parameter is omitted, an :class:`AtomArrayStack`
+        containing all models will be returned, even if the
+        structure contains only one model.
+    altloc : {'first', 'occupancy', 'all'}
+        This parameter defines how *altloc* IDs are handled:
+            - ``'first'`` - Use atoms that have the first
+                *altloc* ID appearing in a residue.
+            - ``'occupancy'`` - Use atoms that have the *altloc* ID
+                with the highest occupancy for a residue.
+            - ``'all'`` - Use all atoms.
+                Note that this leads to duplicate atoms.
+                When this option is chosen, the ``altloc_id``
+                annotation array is added to the returned structure.
+    extra_fields : list of str, optional
+        The strings in the list are optional annotation categories
+        that should be stored in the output array or stack.
+        These are valid values:
+        ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and
+        ``'charge'``.
+    include_bonds : bool, optional
+        If set to true, a :class:`BondList` will be created for the
+        resulting :class:`AtomArray` containing the bond information
+        from the file.
+        All bonds have :attr:`BondType.ANY`, since the PDB format
+        does not support bond orders.
+
+    Returns
+    -------
+    assembly : AtomArray or AtomArrayStack
+        The assembly.
+        The return type depends on the `model` parameter.
+    
+    Examples
+    --------
+
+    >>> import os.path
+    >>> file = PDBFile.read(os.path.join(path_to_structures, "1f2n.pdb"))
+    >>> assembly = get_assembly(file, model=1)
+    """
     return pdb_file.get_assembly(
         assembly_id, model, altloc, extra_fields, include_bonds
+    )
+
+
+def get_symmetry_mates(pdb_file, model=None, altloc="first",
+                        extra_fields=[], include_bonds=False):
+    """
+    Build a structure model containing all symmetric copies
+    of the structure within a single unit cell, given by the space
+    group.
+
+    This function receives the data from ``REMARK 290`` records in
+    the file.
+    Consequently, this remark must be present in the file, which is
+    usually only true for crystal structures.
+
+    Parameters
+    ----------
+    pdb_file : PDBFile
+        The file object.
+    model : int, optional
+        If this parameter is given, the function will return an
+        :class:`AtomArray` from the atoms corresponding to the given
+        model number (starting at 1).
+        Negative values are used to index models starting from the
+        last model instead of the first model.
+        If this parameter is omitted, an :class:`AtomArrayStack`
+        containing all models will be returned, even if the
+        structure contains only one model.
+    altloc : {'first', 'occupancy', 'all'}
+        This parameter defines how *altloc* IDs are handled:
+            - ``'first'`` - Use atoms that have the first
+                *altloc* ID appearing in a residue.
+            - ``'occupancy'`` - Use atoms that have the *altloc* ID
+                with the highest occupancy for a residue.
+            - ``'all'`` - Use all atoms.
+                Note that this leads to duplicate atoms.
+                When this option is chosen, the ``altloc_id``
+                annotation array is added to the returned structure.
+    extra_fields : list of str, optional
+        The strings in the list are optional annotation categories
+        that should be stored in the output array or stack.
+        These are valid values:
+        ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and
+        ``'charge'``.
+    include_bonds : bool, optional
+        If set to true, a :class:`BondList` will be created for the
+        resulting :class:`AtomArray` containing the bond information
+        from the file.
+        All bonds have :attr:`BondType.ANY`, since the PDB format
+        does not support bond orders.
+
+    Returns
+    -------
+    symmetry_mates : AtomArray or AtomArrayStack
+        All atoms within a single unit cell.
+        The return type depends on the `model` parameter.
+    
+    Notes
+    -----
+    To expand the structure beyond a single unit cell, use
+    :func:`repeat_box()` with the return value as its
+    input.
+    
+    Examples
+    --------
+
+    >>> import os.path
+    >>> file = PDBFile.read(os.path.join(path_to_structures, "1aki.pdb"))
+    >>> atoms_in_unit_cell = get_symmetry_mates(file, model=1)
+    """
+    return pdb_file.get_symmetry_mates(
+        model, altloc, extra_fields, include_bonds
     )

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -20,8 +20,6 @@ from ...filter import (
     filter_solvent,
 )
 from .hybrid36 import encode_hybrid36, decode_hybrid36, max_hybrid36_number
-import copy
-from warnings import warn
 
 # slice objects for readability
 # ATOM/HETATM
@@ -420,7 +418,9 @@ class PDBFile(TextFile):
                     atom_name = array.atom_name[idx]
                     array.element[idx] = guess_element(atom_name)
                     rep_num += 1
-            warn("{} elements were guessed from atom_name.".format(rep_num))
+            warnings.warn(
+                "{} elements were guessed from atom_name.".format(rep_num)
+            )
         
         # Fill in coordinates
         if isinstance(array, AtomArray):
@@ -563,9 +563,9 @@ class PDBFile(TextFile):
         else:
             max_atoms, max_residues = 99999, 9999
         if array.array_length() > max_atoms:
-            warn(f"More then {max_atoms:,} atoms per model")
+            warnings.warn(f"More then {max_atoms:,} atoms per model")
         if (array.res_id > max_residues).any():
-            warn(f"Residue IDs exceed {max_residues:,}")
+            warnings.warn(f"Residue IDs exceed {max_residues:,}")
         if np.isnan(array.coord).any():
             raise ValueError("Coordinates contain 'NaN' values")
         if any([len(name) > 1 for name in array.chain_id]):

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -785,7 +785,7 @@ class PDBFile(TextFile):
                     "File does not transformation expression for assemblies"
                 )
             else:
-                raise IndexError(
+                raise KeyError(
                     f"The assembly ID '{assembly_id}' is not found"
                 )
         assembly_lines = remark_lines[assembly_start_i : assembly_stop_i]
@@ -814,7 +814,7 @@ class PDBFile(TextFile):
                 else:
                     # Chain specification has finished
                     # BIOMT lines start directly after chain specification
-                    transform_start = j
+                    transform_start = start + j
                     break
             # Parse transformations from BIOMT lines
             if transform_start is None:
@@ -822,7 +822,7 @@ class PDBFile(TextFile):
                     "No 'BIOMT' records found for chosen assembly"
                 )
             rotations, translations = _parse_transformations(
-                assembly_lines[transform_start + 1 : stop]
+                assembly_lines[transform_start : stop]
             )
             # Filter affected chains
             sub_structure = structure[

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -644,6 +644,20 @@ def list_assemblies(pdbx_file, data_block=None):
     assemblies : dict of str -> str
         A dictionary that maps an assembly ID to a description of the
         corresponding assembly.
+    
+    Examples
+    --------
+    >>> import os.path
+    >>> file = PDBxFile.read(os.path.join(path_to_structures, "1f2n.cif"))
+    >>> assembly_ids = list_assemblies(file)
+    >>> for key, val in assembly_ids.items():
+    ...     print(f"'{key}' : '{val}'")
+    '1' : 'complete icosahedral assembly'
+    '2' : 'icosahedral asymmetric unit'
+    '3' : 'icosahedral pentamer'
+    '4' : 'icosahedral 23 hexamer'
+    '5' : 'icosahedral asymmetric unit, std point frame'
+    '6' : 'crystal asymmetric unit, crystal frame'
     """
     assembly_category = pdbx_file.get_category(
         "pdbx_struct_assembly", data_block, expect_looped=True
@@ -673,7 +687,9 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
     pdbx_file : PDBxFile
         The file object.
     assembly_id : str
-        The assembly to build
+        The assembly to build.
+        Available assembly IDs can be obtained via
+        :func:`list_assemblies()`.
     model : int, optional
         If this parameter is given, the function will return an
         :class:`AtomArray` from the atoms corresponding to the given
@@ -723,6 +739,13 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
     -------
     assembly : AtomArray or AtomArrayStack
         The assembly. The return type depends on the `model` parameter.
+    
+    Examples
+    --------
+
+    >>> import os.path
+    >>> file = PDBxFile.read(os.path.join(path_to_structures, "1f2n.cif"))
+    >>> assembly = get_assembly(file, model=1)
     """
     assembly_gen_category = pdbx_file.get_category(
         "pdbx_struct_assembly_gen", data_block, expect_looped=True

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -776,7 +776,6 @@ def get_assembly(pdbx_file, assembly_id=None, model=None, data_block=None,
             operations = _parse_operation_expression(op_expr)
             asym_ids = asym_id_expr.split(",")
             # Filter affected asym IDs
-            sub_structure = structure
             sub_structure = structure[
                 ..., np.isin(structure.label_asym_id, asym_ids)
             ]

--- a/tests/structure/test_box.py
+++ b/tests/structure/test_box.py
@@ -7,6 +7,7 @@ import itertools
 import numpy as np
 import pytest
 import biotite.structure as struc
+import biotite.structure.io.mmtf as mmtf
 from biotite.structure.io import load_structure
 from ..util import data_dir, cannot_import
 
@@ -113,10 +114,16 @@ def test_conversion_to_fraction(len_a, len_b, len_c,
     assert np.allclose(coords, new_coords)
 
 
-def test_repeat_box():
-    array = load_structure(join(data_dir("structure"), "3o5r.mmtf"))
+@pytest.mark.parametrize("multi_model", [False, True])
+def test_repeat_box(multi_model):
+    model = None if multi_model else 1
+    array = mmtf.get_structure(
+        mmtf.MMTFFile.read(join(data_dir("structure"), "3o5r.mmtf")),
+        model=model, include_bonds=True
+    )
     repeat_array, _ = struc.repeat_box(array)
-    assert repeat_array[:array.array_length()] == array
+    assert repeat_array.array_length() == array.array_length() * 27
+    assert repeat_array[..., :array.array_length()] == array
 
 
 def test_remove_pbc_unsegmented():

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -3,6 +3,7 @@
 # information.
 
 from tempfile import TemporaryFile
+import warnings
 import itertools
 import glob
 from os.path import join, splitext
@@ -263,7 +264,8 @@ def test_id_overflow():
     a.element = np.full(length, "C")
     
     # Write stack to pdb file and make sure a warning is thrown
-    with pytest.warns(UserWarning):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         temp = TemporaryFile("w+")
         pdb_file = pdb.PDBFile()
         pdb_file.set_structure(a)

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -383,10 +383,12 @@ def test_get_symmetry_mates(model):
     path = join(data_dir("structure"), "1aki.pdb")
     pdb_file = pdb.PDBFile.read(path)
     original_structure = pdb_file.get_structure(model=model)
-    cell_sizes = np.diagonal(original_structure.box)
     if model is None:
         # The unit cell is the same for every model
-        cell_sizes = cell_sizes[0]
+        box = original_structure.box[0]
+    else:
+        box = original_structure.box
+    cell_sizes = np.diagonal(box)
 
     symmetry_mates = pdb_file.get_symmetry_mates(model=model)
     

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -264,8 +264,7 @@ def test_id_overflow():
     a.element = np.full(length, "C")
     
     # Write stack to pdb file and make sure a warning is thrown
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with pytest.warns(UserWarning):
         temp = TemporaryFile("w+")
         pdb_file = pdb.PDBFile()
         pdb_file.set_structure(a)
@@ -285,12 +284,12 @@ def test_id_overflow():
     temp.close()
     
     # Write stack as hybrid-36 pdb file: no warning should be thrown
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         temp = TemporaryFile("w+")
         tmp_pdb_file = pdb.PDBFile()
         tmp_pdb_file.set_structure(a, hybrid36=True)
         tmp_pdb_file.write(temp)
-    assert len(record) == 0
 
     # Manually check if the output is written as correct hybrid-36
     temp.seek(0)


### PR DESCRIPTION
This PR adds `get_assembly()` and `list_assemblies()` to `structure.io.pdb` and  `structure.io.mmtf` analogous to the functions in `structure.io.pdbx`.
In addtion, it adds `get_symmetry_mates()` to `structure.io.pdb`.
As foundation for the changes in `structure.io.pdb` `PDBFile` now also offers the `get_remark()` method to parse `REMARK`
records.

Furthermore, a `MemoryError` issue in `structure.repeat_box()`, that appeared on structures with associated `BondList`, was fixed.