### PR TITLE
Fix line length of 'CRYST1' record

### DIFF
--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -700,7 +700,7 @@ class PDBFile(TextFile):
             self.lines.append(
                 f"CRYST1{a:>9.3f}{b:>9.3f}{c:>9.3f}"
                 f"{np.rad2deg(alpha):>7.2f}{np.rad2deg(beta):>7.2f}"
-                f"{np.rad2deg(gamma):>7.2f} P 1           1"
+                f"{np.rad2deg(gamma):>7.2f} P 1           1          "
             )
         is_stack = coords.shape[0] > 1
         for model_num, coord_i in enumerate(coords, start=1):


### PR DESCRIPTION
This PR changes `biotite.io.pdb.PDBFile()` to make it write `CRYST1` records of length 80 instead of 70. This Problem was reported in https://github.com/biotite-dev/fastpdb/pull/4.