### PR TITLE
Refactor `remove_pbc()`

### DIFF
--- a/src/biotite/structure/box.py
+++ b/src/biotite/structure/box.py
@@ -413,9 +413,9 @@ def remove_pbc(atoms, selection=None):
             new_atoms.coord[..., mask, :], atoms.box
         )
         # Put center of molecule into box
-        center = centroid(atoms.coord[..., mask, :])[..., np.newaxis, :]
+        center = centroid(new_atoms.coord[..., mask, :])[..., np.newaxis, :]
         center_in_box = move_inside_box(
-            center, atoms.box
+            center, new_atoms.box
         )
         new_atoms.coord[..., mask, :] += (center_in_box - center)
 

--- a/src/biotite/structure/box.py
+++ b/src/biotite/structure/box.py
@@ -20,6 +20,9 @@ import numpy as np
 import numpy.linalg as linalg
 from .util import vector_dot
 from .atoms import repeat
+from .molecules import get_molecule_masks
+from .chains import get_chain_masks
+from .geometry import centroid
 from .error import BadStructureError
 
 
@@ -353,38 +356,30 @@ def move_inside_box(coord, box):
 
 def remove_pbc(atoms, selection=None):
     """
-    Remove segmentation caused by periodic boundary conditions from a
-    given structure.
+    Remove segmentation caused by periodic boundary conditions from each
+    molecule in the given structure.
 
-    In this process the first atom (of the selection) is taken as origin
-    and is moved inside the box.
-    All other coordinates are assembled relative to the origin.
+    In this process the centroid of each molecule is moved into the
+    dimensions of the box.
+    To determine the molecules the structure is required to have an
+    associated `BondList`.
+    Otherwise segmentation removal is performed on a per-chain basis.
     
     Parameters
     ----------
-    atoms : AtomArray or AtomArrayStack
+    atoms : AtomArray, shape=(n,) or AtomArrayStack, shape=(m,n)
         The potentially segmented structure.
         The :attr:`box` attribute must be set in the structure.
-    selection : str or (iterable object of) ndarray, dtype=bool, shape=(n,), optional
-        Specifies which part(s) of structure are sanitized, i.e the
+        An associated :attr:`bonds` attribute is recommended.
+    selection : ndarray, dtype=bool, shape=(n,)
+        Specifies which parts of `atoms` are sanitized, i.e the
         segmentation is removed.
-        If a string is given, the value is interpreted as the chain ID
-        to be selected.
-        If a boolean mask is given, the corresponding atoms are
-        selected. 
-        If multiple boolean masks are given, each selection
-        is treated as separate assembly process, independent of all
-        other selections.
-        Consequently, giving multiple boolean masks has the same result
-        as calling the functions multiple times with each mask
-        separately.
-        An atom must not be selected more than one time.
-
     
     Returns
     -------
     sanitized_atoms : AtomArray or AtomArrayStack
-        The input structure with removed periodic boundary conditions.
+        The input structure with removed segmentation over periodic
+        boundaries.
     
     See also
     --------
@@ -392,54 +387,35 @@ def remove_pbc(atoms, selection=None):
 
     Notes
     -----
-    It is not recommended to select regions of the
-    structure with distances from one atom to the next atom that are
-    larger than half of the box size
-    (e.g. the solvent, chain transitions).
-    In this case, multiple selections should be given, with a single
-    molecule selected in each selection.
-
-    Internally the function uses :func:`remove_pbc_from_coord()`.
+    This function ensures that adjacent atoms in the input
+    :class:`AtomArray`/:class:`AtomArrayStack` are spatially close to
+    each other, i.e. their distance to each other is be smaller than the
+    half box size.
     """
     if atoms.box is None:
         raise BadStructureError(
             "The 'box' attribute must be set in the structure"
         )
     new_atoms = atoms.copy()
-    
-    if selection is None:
-        new_atoms.coord = remove_pbc_from_coord(
-            atoms.coord, atoms.box
-        )
 
-    elif isinstance(selection, str):
-        # Chain ID
-        selection = (atoms.chain_id == selection)
-        new_atoms.coord[..., selection, :] = remove_pbc_from_coord(
-            atoms.coord[..., selection, :], atoms.box
+    if atoms.bonds is not None:
+        molecule_masks = get_molecule_masks(atoms)
+    else:
+        molecule_masks = get_chain_masks(atoms)
+
+    for mask in molecule_masks:
+        if selection is not None:
+            mask &= selection
+        # Remove segmentation in molecule
+        new_atoms.coord[..., mask] = remove_pbc_from_coord(
+            new_atoms.coord[..., mask]
         )
-    
-    elif isinstance(selection, np.ndarray) and selection.ndim == 1:
-        # Single boolean mask
-        new_atoms.coord[..., selection, :] = remove_pbc_from_coord(
-            atoms.coord[..., selection, :], atoms.box
+        # Put center of molecule into box
+        center = centroid(atoms.coord[..., mask])[..., np.newaxis, :]
+        center_in_box = move_inside_box(
+            center, atoms.box
         )
-    
-    elif isinstance(selection, Iterable):
-        # Iterable of boolean masks
-        selections = np.stack(list(selection))
-        # Test whether an atom was selected multiple times
-        sel_count = np.count_nonzero(selections, axis=0)
-        if (sel_count > 1).any():
-            first_pos = np.where((sel_count > 1))[0][0]
-            raise ValueError(
-                f"Atom at index {first_pos} was selected "
-                f"{sel_count[first_pos]} times"
-            )
-        for selection in selections:
-            new_atoms.coord[..., selection, :] = remove_pbc_from_coord(
-                atoms.coord[..., selection, :], atoms.box
-            )
+        new_atoms.coord[..., mask] += (center_in_box - center)
 
     return new_atoms
 

--- a/src/biotite/structure/box.py
+++ b/src/biotite/structure/box.py
@@ -22,7 +22,6 @@ from .util import vector_dot
 from .atoms import repeat
 from .molecules import get_molecule_masks
 from .chains import get_chain_masks
-from .geometry import centroid
 from .error import BadStructureError
 
 
@@ -392,6 +391,9 @@ def remove_pbc(atoms, selection=None):
     each other, i.e. their distance to each other is be smaller than the
     half box size.
     """
+    # Avoid circular import
+    from .geometry import centroid
+    
     if atoms.box is None:
         raise BadStructureError(
             "The 'box' attribute must be set in the structure"

--- a/tests/structure/test_box.py
+++ b/tests/structure/test_box.py
@@ -150,107 +150,86 @@ def test_remove_pbc_unsegmented(multi_model):
 
 
 @pytest.mark.parametrize(
-    "multi_model, translation_vector",
+    "multi_model, seed",
     itertools.product(
         [False, True],
-        [(20,30,40), (-11, 33, 22), (-40, -50, -60)]
+        range(10)
     )
 )
-def test_remove_pbc_restore(multi_model, translation_vector):
-    CUTOFF = 5.0
-    
-    def get_matrices(array):
-        """
-        Create a periodic and non-periodic adjacency matrix.
-        """
-        nonlocal CUTOFF
+def test_remove_pbc_restore(multi_model, seed):
+    BUFFER = 5
+
+    def get_distance_matrices(array):
         if isinstance(array, struc.AtomArray):
-            matrix     = struc.CellList(array, CUTOFF, periodic=False) \
-                        .create_adjacency_matrix(CUTOFF)
-            matrix_pbc = struc.CellList(array, CUTOFF, periodic=True) \
-                        .create_adjacency_matrix(CUTOFF)
-        elif isinstance(array, struc.AtomArrayStack):
-            matrix = np.array(
-                [struc.CellList(model, CUTOFF, periodic=False)
-                 .create_adjacency_matrix(CUTOFF)
-                 for model in array]
-                )
-            matrix_pbc = np.array(
-                [struc.CellList(model, CUTOFF, periodic=True)
-                 .create_adjacency_matrix(CUTOFF)
-                 for model in array]
+            matrix = struc.distance(
+                array.coord[:, np.newaxis, :],
+                array.coord[np.newaxis, :, :],
+                box=None
             )
+            matrix_pbc = struc.distance(
+                array.coord[:, np.newaxis, :],
+                array.coord[np.newaxis, :, :],
+                box=array.box
+            )
+        elif isinstance(array, struc.AtomArrayStack):
+            matrices = [get_distance_matrices(model) for model in array]
+            matrix = np.stack([m[0] for m in matrices])
+            matrix_pbc = np.stack([m[1] for m in matrices])
         return matrix, matrix_pbc
     
-    def assert_equal_matrices(array, matrix1, matrix2, periodic):
-        """
-        Due to numerical instability, entries in both matrices might
-        be different, when the distance of atoms is almost equal to
-        the cutoff distance of the matrix.
-        This function checks, whether two atoms with unequal entries
-        in the matrices are near the cutoff distance.
-        """
-        nonlocal CUTOFF
-        indices = np.where(matrix1 != matrix2)
-        for index in range(len(indices[0])):
-            if len(indices) == 2:
-                # multi_model = False -> AtomArray
-                m = None
-                i = indices[0][index]
-                j = indices[1][index]
-                box = array.box if periodic else None
-                distance = struc.distance(array[i], array[j], box=box)
-            if len(indices) == 3:
-                # multi_model = True -> AtomArrayStack
-                m = indices[0][index]
-                i = indices[1][index]
-                j = indices[2][index]
-                box = array.box[m] if periodic else None
-                distance = struc.distance(array[m,i], array[m,j], box=box)
-            try:
-                assert distance == pytest.approx(CUTOFF, abs=1e-4)
-            except AssertionError:
-                print(f"Model {m}, Atoms {i} and {j}")
-                raise
-    
     stack = load_structure(
-        join(data_dir("structure"), "1gya.mmtf"), include_bonds=True
+        join(data_dir("structure"), "1l2y.mmtf"), include_bonds=True
     )
-    #!#
-    #stack = stack[..., struc.filter_amino_acids(stack)]
-    #!#
+    
+    # Only consider a single molecule
+    # -> remove all other atoms (in this case some unbound hydrogen)
+    mol_masks = struc.get_molecule_masks(stack)
+    largest_mask = mol_masks[np.argmax(np.count_nonzero(mol_masks, axis=-1))]
+    stack = stack[..., largest_mask]
+
+    # Create a relatively tight box around the protein
     stack.box = np.array([
-        np.diag(np.max(coord, axis=0) - np.min(coord, axis=0) + 10)
+        np.diag(np.max(coord, axis=0) - np.min(coord, axis=0) + BUFFER)
         for coord in stack.coord
     ])
-    stack.coord -= np.min(stack.coord, axis=-2)[:, np.newaxis, :] - 5
+    stack.coord -= np.min(stack.coord, axis=-2)[:, np.newaxis, :] + BUFFER / 2
     if multi_model:
         array = stack
     else:
         array = stack[0]
+    ref_matrix, ref_matrix_pbc = get_distance_matrices(array)
 
-    # Use adjacency matrices instead of pairwise distances
-    # for computational efficiency
-    ref_matrix, ref_matrix_pbc = get_matrices(array)
-
+    ## Segment protein
+    np.random.seed(seed)
+    size = (array.stack_depth(), 3) if isinstance(array, struc.AtomArrayStack) else 3
+    translation_vector = np.sum(
+        np.random.uniform(-5, 5, size)[:, np.newaxis] * array.box,
+        axis=-2
+    )[..., np.newaxis, :]
+    # Move atoms over periodic boundary...
     array = struc.translate(array, translation_vector)
+    # ... and enforce segmentation
     array.coord = struc.move_inside_box(array.coord, array.box)
-    moved_matrix, moved_matrix_pbc = get_matrices(array)
-    # The translation and the periodic move should not
-    # alter PBC-aware pairwise distances
-    assert_equal_matrices(array, ref_matrix_pbc, moved_matrix_pbc, True)
-    # Non-PBC-aware distances should change,
-    # otherwise the atoms do not go over the periodic boundary
-    # and the test does not make sense
-    with pytest.raises(AssertionError):
-        assert_equal_matrices(array, ref_matrix, moved_matrix, False)
+    # Check if segmentation was achieved
+    # This is a prerequisite to properly test 'remove_pbc()'
+    segment_matrix, segment_matrix_pbc = get_distance_matrices(array)
+    assert not np.allclose(segment_matrix, ref_matrix, atol=1e-4)
+    assert np.allclose(segment_matrix_pbc, ref_matrix_pbc, atol=1e-4)
 
+    ## Remove segmentation again via 'remove_pbc()'
     array = struc.remove_pbc(array)
-    restored_matrix, restored_matrix_pbc = get_matrices(array)
-    # Both adjacency matrices should be equal to the original ones,
-    # as the structure should be completely restored
-    assert_equal_matrices(array, ref_matrix_pbc, restored_matrix_pbc, True)
-    assert_equal_matrices(array, ref_matrix,     restored_matrix,     False)
+    # Now the pairwise atom distances should be the same
+    # as in the beginning again
+    test_matrix, test_matrix_pbc = get_distance_matrices(array)
+    assert np.allclose(test_matrix, ref_matrix, atol=1e-4)
+    assert np.allclose(test_matrix_pbc, ref_matrix_pbc, atol=1e-4)
+
+    # The centroid of the structure should be inside the box dimensions
+    centroid = struc.centroid(array)
+    assert np.all(
+        (centroid > np.zeros(3)) &
+        (centroid < np.sum(array.box, axis=-2))
+    )
 
 
 @pytest.mark.parametrize("multi_model", [True, False])

--- a/tests/structure/test_box.py
+++ b/tests/structure/test_box.py
@@ -4,6 +4,7 @@
 
 from os.path import join
 import itertools
+import warnings
 import numpy as np
 import pytest
 import biotite.structure as struc
@@ -126,23 +127,26 @@ def test_repeat_box(multi_model):
     assert repeat_array[..., :array.array_length()] == array
 
 
-def test_remove_pbc_unsegmented():
+@pytest.mark.parametrize("multi_model", [True, False])
+def test_remove_pbc_unsegmented(multi_model):
     """
     `remove_pbc()` should not alter unsegmented structures,
     when the structure is entirely in the box.
-    Exclude the solvent, due to high distances between each atom. 
     """
-    ref_array = load_structure(join(data_dir("structure"), "3o5r.mmtf"))
+    model = None if multi_model else 1
+    ref_array = load_structure(
+        join(data_dir("structure"), "3o5r.mmtf"),
+        model=model,
+        include_bonds=True
+    )
     # Center structure in box
     centroid = struc.centroid(ref_array)
     box_center = np.diag(ref_array.box) / 2
     ref_array = struc.translate(ref_array, box_center-centroid)
-    # Remove solvent
-    ref_array = ref_array[~struc.filter_solvent(ref_array)]
-    array = struc.remove_pbc(ref_array)
+    test_array = struc.remove_pbc(ref_array)
 
-    assert ref_array.equal_annotation_categories(array)
-    assert np.allclose(ref_array.coord, array.coord)
+    assert ref_array.equal_annotation_categories(test_array)
+    assert np.allclose(ref_array.coord, test_array.coord)
 
 
 @pytest.mark.parametrize(
@@ -209,7 +213,12 @@ def test_remove_pbc_restore(multi_model, translation_vector):
                 print(f"Model {m}, Atoms {i} and {j}")
                 raise
     
-    stack = load_structure(join(data_dir("structure"), "1gya.mmtf"))
+    stack = load_structure(
+        join(data_dir("structure"), "1gya.mmtf"), include_bonds=True
+    )
+    #!#
+    #stack = stack[..., struc.filter_amino_acids(stack)]
+    #!#
     stack.box = np.array([
         np.diag(np.max(coord, axis=0) - np.min(coord, axis=0) + 10)
         for coord in stack.coord
@@ -245,7 +254,7 @@ def test_remove_pbc_restore(multi_model, translation_vector):
 
 
 @pytest.mark.parametrize("multi_model", [True, False])
-def test_remove_pbc_selections(multi_model):
+def test_remove_pbc_selection(multi_model):
     """
     This test makes no assertions, it only test whether an exception
     occurs, when the `selection` parameter is given in `remove_pbc()`.
@@ -254,12 +263,11 @@ def test_remove_pbc_selections(multi_model):
     if multi_model:
         array = struc.stack([array, array])
     
-    struc.remove_pbc(array)
-    struc.remove_pbc(array, array.chain_id[0])
-    struc.remove_pbc(array, struc.filter_amino_acids(array))
-    struc.remove_pbc(array, [struc.filter_amino_acids(array),
-                       (array.res_name == "FK5")])
-    # Expect error when selectinf an atom multiple times
-    with pytest.raises(ValueError):
-        struc.remove_pbc(array, [struc.filter_amino_acids(array),
-                                 (array.atom_name == "CA")])
+    select_all = np.ones(array.array_length(), dtype=bool)
+    select_none = np.zeros(array.array_length(), dtype=bool)
+    assert struc.remove_pbc(array, select_all) == struc.remove_pbc(array)
+    with warnings.catch_warnings():
+        # A warning due to a zero-division (centroid of empty list of
+        # atoms) is raised here
+        warnings.simplefilter("ignore")
+        assert struc.remove_pbc(array, select_none) == array

--- a/tests/structure/test_box.py
+++ b/tests/structure/test_box.py
@@ -221,7 +221,7 @@ def test_remove_pbc_restore(multi_model, translation_vector):
         array = stack[0]
 
     # Use adjacency matrices instead of pairwise distances
-    # for compuational efficiency
+    # for computational efficiency
     ref_matrix, ref_matrix_pbc = get_matrices(array)
 
     array = struc.translate(array, translation_vector)


### PR DESCRIPTION
This PR refactors `remove_pbc()`:

- PCB removal is conducted for each molecule separately
- Not the first atom but the centroid of a molecule is placed within the box
- The `selection` can only be a boolean matrix