### PR TITLE
Refactor interface to RCSB search API

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -48,6 +48,13 @@
             "MotifQuery",
             "StructureQuery"
         ],
+        "Sorting and grouping" : [
+            "Sorting",
+            "Grouping",
+            "DepositGrouping",
+            "IdentityGrouping",
+            "UniprotGrouping"
+        ],
         "Search and fetch" : [
             "count",
             "search",

--- a/doc/tutorial/src/database.py
+++ b/doc/tutorial/src/database.py
@@ -105,6 +105,30 @@ composite_query = query1 & ~query2
 print(rcsb.search(composite_query))
 
 ########################################################################
+# Often the structures behind the obtained PDB IDs have degree of
+# redundancy.
+# For example they may represent the same protein sequences or result
+# from the same set of experiments.
+# You may use :class:`Grouping` of structures to group redundant
+# entries or even return only single representatives of each group.
+
+query = rcsb.BasicQuery("Transketolase")
+# Group PDB IDs from the same collection
+print(rcsb.search(
+    query, group_by=rcsb.DepositGrouping(), return_groups=True
+))
+# Get only a single representative of each group
+print(rcsb.search(
+    query, group_by=rcsb.DepositGrouping(), return_groups=False
+))
+
+########################################################################
+# Note that grouping may omit PDB IDs in search results, if such PDB IDs
+# cannot be grouped.
+# In the example shown above, not all structures 
+# For example in the case shown above only a few PDB entries were
+# uploaded as collection and hence are part of the search results.
+#
 # Fetching files from the NCBI Entrez database
 # --------------------------------------------
 # 

--- a/src/biotite/application/viennarna/rnafold.py
+++ b/src/biotite/application/viennarna/rnafold.py
@@ -174,16 +174,6 @@ class RNAfoldApp(LocalApp):
         -------
         mfe : float
             The minimum free energy.
-
-        Examples
-        --------
-
-        >>> sequence = NucleotideSequence("CGACGTAGATGCTAGCTGACTCGATGC")
-        >>> app = RNAfoldApp(sequence)
-        >>> app.start()
-        >>> app.join()
-        >>> print(app.get_mfe())
-        -1.3
         """
         warnings.warn(
             "'get_mfe()' is deprecated, use 'get_free_energy()' instead",

--- a/tests/database/test_rcsb.py
+++ b/tests/database/test_rcsb.py
@@ -141,7 +141,7 @@ def test_search_sequence():
         ref_sequence, "protein", min_identity=IDENTIY_CUTOFF
     )
     test_ids = rcsb.search(query)
-    assert test_ids >= 2
+    assert len(test_ids) >= 2
 
     for id in test_ids:
         fasta_file = fasta.FastaFile.read(rcsb.fetch(id, "fasta"))
@@ -286,7 +286,6 @@ def test_search_content_types():
         rcsb.search(query, content_types=[])
     with pytest.raises(ValueError):
         rcsb.count(query, content_types=[])
-
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR makes the following changes to `biotite.structure.database.rcsb` `search()` and `count()`:

- Add support for computational structures (e.g. from Alphafold DB) via the `content_types` parameter. This ability should work well with #465 .
- Add support for grouping via the new `group_by` and `return_groups` parameters. The type of grouping is selected via `Grouping` subclasses. This resolves #411 .
- Add support for ascending sorting with the `Sorting` class.