### PR TITLE
Support chemical component parsing in `PDBxFile`

### DIFF
--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -9,6 +9,8 @@ __all__ = [
     "get_model_count",
     "get_structure",
     "set_structure",
+    "get_component",
+    "set_component",
     "list_assemblies",
     "get_assembly",
 ]
@@ -20,9 +22,29 @@ import numpy as np
 from ....file import InvalidFileError
 from ....sequence.seqtypes import NucleotideSequence, ProteinSequence
 from ...atoms import AtomArray, AtomArrayStack, repeat
+from ...bonds import BondList, BondType
 from ...box import unitcell_from_vectors, vectors_from_unitcell
 from ...filter import filter_first_altloc, filter_highest_occupancy_altloc
+from ...residues import get_residue_count
+from ...error import BadStructureError
 from ...util import matrix_rotate
+
+
+# Map 'chem_comp_bond' bond orders to 'BondType'...
+BOND_ORDER_TO_BOND_TYPE = {
+    ("SING", "N") : BondType.SINGLE,
+    ("DOUB", "N") : BondType.DOUBLE,
+    ("TRIP", "N") : BondType.TRIPLE,
+    ("QUAD", "N") : BondType.QUADRUPLE,
+    ("SING", "Y") : BondType.AROMATIC_SINGLE,
+    ("DOUB", "Y") : BondType.AROMATIC_DOUBLE,
+    ("TRIP", "Y") : BondType.AROMATIC_TRIPLE,
+}
+# ...and vice versa
+BOND_TYPE_TO_BOND_ORDER = {
+    bond_type: order for order, bond_type in BOND_ORDER_TO_BOND_TYPE.items()
+}
+
 
 _proteinseq_type_list = ["polypeptide(D)", "polypeptide(L)"]
 _nucleotideseq_type_list = [
@@ -152,6 +174,8 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
         If `use_author_fields` is true, the annotation arrays will be
         read from the ``auth_xxx`` fields (if applicable),
         otherwise from the the ``label_xxx`` fields.
+        If the requested field is not available, the respective other
+        field is taken as fallback.
 
     Returns
     -------
@@ -171,6 +195,9 @@ def get_structure(pdbx_file, model=None, data_block=None, altloc="first",
     extra_fields = [] if extra_fields is None else extra_fields
 
     atom_site_dict = pdbx_file.get_category("atom_site", data_block)
+    if atom_site_dict is None:
+        raise InvalidFileError("Missing 'atom_site' category in file")
+    
     models = atom_site_dict["pdbx_PDB_model_num"]
     model_starts = _get_model_starts(models)
     model_count = len(model_starts)
@@ -518,9 +545,7 @@ def set_structure(pdbx_file, array, data_block=None):
     atom_site_dict["auth_atom_id"] = atom_site_dict["label_atom_id"]
 
     if "atom_id" in annot_categories:
-        atom_site_dict["id"] = np.array([str(e) for e in array.atom_id])
-    else:
-        atom_site_dict["id"] = None
+        atom_site_dict["id"] = array.atom_id.astype(str)
     if "b_factor" in annot_categories:
         atom_site_dict["B_iso_or_equiv"] = np.array(
             [f"{b:.2f}" for b in array.b_factor]
@@ -576,14 +601,6 @@ def set_structure(pdbx_file, array, data_block=None):
         atom_site_dict["id"] = np.arange(
             1, len(atom_site_dict["group_PDB"]) + 1
         ).astype("U6")
-    if data_block is None:
-        data_blocks = pdbx_file.get_block_names()
-        if len(data_blocks) == 0:
-            raise TypeError(
-                "No data block is existent in PDBx file, must be specified"
-            )
-        else:
-            data_block = data_blocks[0]
     pdbx_file.set_category("atom_site", atom_site_dict, data_block)
 
     # Write box into file
@@ -619,6 +636,125 @@ def _determine_entity_id(chain_id):
             entity_id[i] = id_translation[chain_id[i]]
             id += 1
     return entity_id.astype(str)
+
+
+def get_component(pdbx_file, data_block=None, use_ideal_coord=True,
+                  include_bonds=False):
+    """
+    Create an :class:`AtomArray` for a chemical component from the
+    ``chem_comp_atom`` and optionally the ``chem_comp_bond`` categories
+    in a :class:`PDBxFile`.
+    """
+    atom_dict = pdbx_file.get_category(
+        "chem_comp_atom", block=data_block, expect_looped=True
+    )
+    if atom_dict is None:
+        raise InvalidFileError("Missing 'chem_comp_atom' category in file")
+    bond_dict = pdbx_file.get_category(
+        "chem_comp_bond", block=data_block, expect_looped=True
+    )
+
+    array = AtomArray(len(list(atom_dict.values())[0]))
+
+    array.res_name = atom_dict["comp_id"]
+    array.atom_name = atom_dict["atom_id"]
+    array.element = atom_dict["type_symbol"]
+    array.add_annotation("charge", int)
+    array.charge = np.array(
+        [int(c) if c != "?" else 0 for c in atom_dict["charge"]]
+    )
+    
+    coord_fields = [f"pdbx_model_Cartn_{dim}_ideal" for dim in ("x", "y", "z")]
+    alt_coord_fields = [f"model_Cartn_{dim}" for dim in ("x", "y", "z")]
+    if not use_ideal_coord:
+        # Swap with the fallback option
+        coord_fields, alt_coord_fields = alt_coord_fields, coord_fields
+    try:
+        for i, field in enumerate(coord_fields):
+            array.coord[:,i] = atom_dict[field]
+    except KeyError as err:
+        key = err.args[0]
+        warnings.warn(
+            f"Attribute '{key}' not found within 'chem_comp_atom' category. "
+            f"The fallback coordinates will be used instead",
+            UserWarning
+        )
+        for i, field in enumerate(alt_coord_fields):
+            array.coord[:,i] = atom_dict[field]
+    
+    if include_bonds:
+        if bond_dict is None:
+            warnings.warn(
+                f"Category 'chem_comp_bond' not found. "
+                f"No bonds will be parsed",
+                UserWarning
+            )
+        else:
+            bonds = BondList(array.array_length())
+            for atom1, atom2, order, aromatic_flag in zip(
+                bond_dict["atom_id_1"], bond_dict["atom_id_2"],
+                bond_dict["value_order"], bond_dict["pdbx_aromatic_flag"]
+            ):
+                atom_i = np.where(array.atom_name == atom1)[0][0]
+                atom_j = np.where(array.atom_name == atom2)[0][0]
+                bond_type = BOND_ORDER_TO_BOND_TYPE[order, aromatic_flag]
+                bonds.add_bond(atom_i, atom_j, bond_type)
+            array.bonds = bonds
+
+    return array
+
+
+def set_component(pdbx_file, array, data_block=None):
+    if get_residue_count(array) > 1:
+        raise BadStructureError(
+            "The input atom array must comprise only one residue"
+        )
+    res_name = array.res_name[0]
+
+    annot_categories = array.get_annotation_categories()
+    if "charge" in annot_categories:
+        charge = array.charge.astype("U2")
+    else:
+        charge = np.full(array.array_length(), "?", dtype="U2")
+
+    chem_comp_dict = OrderedDict()
+    chem_comp_dict["comp_id"] = np.full(array.array_length(), res_name)
+    chem_comp_dict["atom_id"] = np.copy(array.atom_name)
+    chem_comp_dict["alt_atom_id"] = chem_comp_dict["atom_id"]
+    chem_comp_dict["type_symbol"] = np.copy(array.element)
+    chem_comp_dict["charge"] = charge
+    chem_comp_dict["model_Cartn_x"] = np.copy(array.coord[:, 0])
+    chem_comp_dict["model_Cartn_y"] = np.copy(array.coord[:, 1])
+    chem_comp_dict["model_Cartn_z"] = np.copy(array.coord[:, 2])
+    chem_comp_dict["pdbx_model_Cartn_x_ideal"] = chem_comp_dict["model_Cartn_x"]
+    chem_comp_dict["pdbx_model_Cartn_y_ideal"] = chem_comp_dict["model_Cartn_y"]
+    chem_comp_dict["pdbx_model_Cartn_z_ideal"] = chem_comp_dict["model_Cartn_z"]
+    chem_comp_dict["pdbx_component_atom_id"] = chem_comp_dict["atom_id"]
+    chem_comp_dict["pdbx_component_comp_id"] = chem_comp_dict["comp_id"]
+    chem_comp_dict["pdbx_ordinal"] = np.arange(
+        1, array.array_length() + 1
+    ).astype(str)
+    pdbx_file.set_category("chem_comp_atom", chem_comp_dict, data_block)
+
+    if array.bonds is not None:
+        bond_array = array.bonds.as_array()
+        order_flags = []
+        aromatic_flags = []
+        for bond_type in bond_array[:,2]:
+            order_flag, aromatic_flag = BOND_TYPE_TO_BOND_ORDER[bond_type]
+            order_flags.append(order_flag)
+            aromatic_flags.append(aromatic_flag)
+
+        chem_comp_bond_dict = OrderedDict()
+        chem_comp_bond_dict["comp_id"] = np.full(len(bond_array), res_name)
+        chem_comp_bond_dict["atom_id_1"] = array.atom_name[bond_array[:,0]]
+        chem_comp_bond_dict["atom_id_2"] = array.atom_name[bond_array[:,1]]
+        chem_comp_bond_dict["value_order"] = np.array(order_flags)
+        chem_comp_bond_dict["pdbx_aromatic_flag"] = np.array(aromatic_flags)
+        chem_comp_bond_dict["pdbx_ordinal"] = np.arange(
+            1, len(bond_array) + 1
+        ).astype(str)
+        pdbx_file.set_category("chem_comp_bond", chem_comp_bond_dict, data_block)
 
 
 def list_assemblies(pdbx_file, data_block=None):

--- a/src/biotite/structure/io/pdbx/file.py
+++ b/src/biotite/structure/io/pdbx/file.py
@@ -10,7 +10,7 @@ import copy
 import shlex
 from collections.abc import MutableMapping
 import numpy as np
-from ....file import TextFile
+from ....file import TextFile, InvalidFileError
 
 
 class PDBxFile(TextFile, MutableMapping):
@@ -214,7 +214,10 @@ class PDBxFile(TextFile, MutableMapping):
             category.
         """
         if block is None:
-            block = self.get_block_names()[0]
+            try:
+                block = self.get_block_names()[0]
+            except IndexError:
+                raise InvalidFileError("File is empty")
         category_info = self._categories.get((block, category))
         if category_info is None:
             return None
@@ -308,7 +311,12 @@ class PDBxFile(TextFile, MutableMapping):
             appended at the end of the file.
         """
         if block is None:
-            block = self.get_block_names()[0]
+            try:
+                block = self.get_block_names()[0]
+            except IndexError:
+                raise InvalidFileError(
+                    "File is empty, give an explicit data block"
+                )
 
         # Determine whether the category is a looped category
         sample_category_value = list(category_dict.values())[0]

--- a/tests/structure/data/molecules/CYN.cif
+++ b/tests/structure/data/molecules/CYN.cif
@@ -1,0 +1,88 @@
+data_CYN
+# 
+_chem_comp.id                                    CYN 
+_chem_comp.name                                  "CYANIDE ION" 
+_chem_comp.type                                  NON-POLYMER 
+_chem_comp.pdbx_type                             HETAI 
+_chem_comp.formula                               "C N" 
+_chem_comp.mon_nstd_parent_comp_id               ? 
+_chem_comp.pdbx_synonyms                         ? 
+_chem_comp.pdbx_formal_charge                    -1 
+_chem_comp.pdbx_initial_date                     1999-07-08 
+_chem_comp.pdbx_modified_date                    2011-06-04 
+_chem_comp.pdbx_ambiguous_flag                   N 
+_chem_comp.pdbx_release_status                   REL 
+_chem_comp.pdbx_replaced_by                      ? 
+_chem_comp.pdbx_replaces                         CN 
+_chem_comp.formula_weight                        26.017 
+_chem_comp.one_letter_code                       ? 
+_chem_comp.three_letter_code                     CYN 
+_chem_comp.pdbx_model_coordinates_details        ? 
+_chem_comp.pdbx_model_coordinates_missing_flag   N 
+_chem_comp.pdbx_ideal_coordinates_details        ? 
+_chem_comp.pdbx_ideal_coordinates_missing_flag   N 
+_chem_comp.pdbx_model_coordinates_db_code        1B0B 
+_chem_comp.pdbx_subcomponent_list                ? 
+_chem_comp.pdbx_processing_site                  RCSB 
+# 
+loop_
+_chem_comp_atom.comp_id 
+_chem_comp_atom.atom_id 
+_chem_comp_atom.alt_atom_id 
+_chem_comp_atom.type_symbol 
+_chem_comp_atom.charge 
+_chem_comp_atom.pdbx_align 
+_chem_comp_atom.pdbx_aromatic_flag 
+_chem_comp_atom.pdbx_leaving_atom_flag 
+_chem_comp_atom.pdbx_stereo_config 
+_chem_comp_atom.model_Cartn_x 
+_chem_comp_atom.model_Cartn_y 
+_chem_comp_atom.model_Cartn_z 
+_chem_comp_atom.pdbx_model_Cartn_x_ideal 
+_chem_comp_atom.pdbx_model_Cartn_y_ideal 
+_chem_comp_atom.pdbx_model_Cartn_z_ideal 
+_chem_comp_atom.pdbx_component_atom_id 
+_chem_comp_atom.pdbx_component_comp_id 
+_chem_comp_atom.pdbx_ordinal 
+CYN C C C -1 1 N N N 6.708 -5.042 17.519 0.000 0.000 -0.611 C CYN 1 
+CYN N N N 0  1 N N N 6.693 -5.522 16.471 0.000 0.000 0.524  N CYN 2 
+# 
+_chem_comp_bond.comp_id              CYN 
+_chem_comp_bond.atom_id_1            C 
+_chem_comp_bond.atom_id_2            N 
+_chem_comp_bond.value_order          TRIP 
+_chem_comp_bond.pdbx_aromatic_flag   N 
+_chem_comp_bond.pdbx_stereo_config   N 
+_chem_comp_bond.pdbx_ordinal         1 
+# 
+loop_
+_pdbx_chem_comp_descriptor.comp_id 
+_pdbx_chem_comp_descriptor.type 
+_pdbx_chem_comp_descriptor.program 
+_pdbx_chem_comp_descriptor.program_version 
+_pdbx_chem_comp_descriptor.descriptor 
+CYN SMILES           ACDLabs              10.04 "[C-]#N"                    
+CYN SMILES_CANONICAL CACTVS               3.341 "[C-]#N"                    
+CYN SMILES           CACTVS               3.341 "[C-]#N"                    
+CYN SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 "[C-]#N"                    
+CYN SMILES           "OpenEye OEToolkits" 1.5.0 "[C-]#N"                    
+CYN InChI            InChI                1.03  InChI=1S/CN/c1-2/q-1        
+CYN InChIKey         InChI                1.03  XFXPMWWXUTWYJX-UHFFFAOYSA-N 
+# 
+loop_
+_pdbx_chem_comp_identifier.comp_id 
+_pdbx_chem_comp_identifier.type 
+_pdbx_chem_comp_identifier.program 
+_pdbx_chem_comp_identifier.program_version 
+_pdbx_chem_comp_identifier.identifier 
+CYN "SYSTEMATIC NAME" ACDLabs              10.04 cyanide 
+CYN "SYSTEMATIC NAME" "OpenEye OEToolkits" 1.5.0 cyanide 
+# 
+loop_
+_pdbx_chem_comp_audit.comp_id 
+_pdbx_chem_comp_audit.action_type 
+_pdbx_chem_comp_audit.date 
+_pdbx_chem_comp_audit.processing_site 
+CYN "Create component"  1999-07-08 RCSB 
+CYN "Modify descriptor" 2011-06-04 RCSB 
+# 

--- a/tests/structure/data/molecules/HWB.cif
+++ b/tests/structure/data/molecules/HWB.cif
@@ -1,0 +1,150 @@
+data_HWB
+#
+
+_chem_comp.id                                   HWB
+_chem_comp.name                                 cyanidin
+_chem_comp.type                                 NON-POLYMER
+_chem_comp.pdbx_type                            HETAIN
+_chem_comp.formula                              "C15 H11 O6"
+_chem_comp.mon_nstd_parent_comp_id              ?
+_chem_comp.pdbx_synonyms                        ?
+_chem_comp.pdbx_formal_charge                   1
+_chem_comp.pdbx_initial_date                    2018-12-29
+_chem_comp.pdbx_modified_date                   2019-12-20
+_chem_comp.pdbx_ambiguous_flag                  N
+_chem_comp.pdbx_release_status                  REL
+_chem_comp.pdbx_replaced_by                     ?
+_chem_comp.pdbx_replaces                        ?
+_chem_comp.formula_weight                       287.244
+_chem_comp.one_letter_code                      ?
+_chem_comp.three_letter_code                    HWB
+_chem_comp.pdbx_model_coordinates_details       ?
+_chem_comp.pdbx_model_coordinates_missing_flag  N
+_chem_comp.pdbx_ideal_coordinates_details       Corina
+_chem_comp.pdbx_ideal_coordinates_missing_flag  N
+_chem_comp.pdbx_model_coordinates_db_code       6QCH
+_chem_comp.pdbx_subcomponent_list               ?
+_chem_comp.pdbx_processing_site                 EBI
+#   #
+loop_
+_chem_comp_atom.comp_id
+_chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
+_chem_comp_atom.type_symbol
+_chem_comp_atom.charge
+_chem_comp_atom.pdbx_align
+_chem_comp_atom.pdbx_aromatic_flag
+_chem_comp_atom.pdbx_leaving_atom_flag
+_chem_comp_atom.pdbx_stereo_config
+_chem_comp_atom.model_Cartn_x
+_chem_comp_atom.model_Cartn_y
+_chem_comp_atom.model_Cartn_z
+_chem_comp_atom.pdbx_model_Cartn_x_ideal
+_chem_comp_atom.pdbx_model_Cartn_y_ideal
+_chem_comp_atom.pdbx_model_Cartn_z_ideal
+_chem_comp_atom.pdbx_component_atom_id
+_chem_comp_atom.pdbx_component_comp_id
+_chem_comp_atom.pdbx_ordinal
+HWB  O01  O1   O  0  1  N  N  N  -26.706  30.470  22.096  -4.652  -2.732   0.069  O01  HWB   1  
+HWB  C02  C1   C  0  1  Y  N  N  -25.913  29.989  21.043  -3.892  -1.607   0.030  C02  HWB   2  
+HWB  C03  C2   C  0  1  Y  N  N  -25.230  30.851  20.156  -4.512  -0.363  -0.094  C03  HWB   3  
+HWB  C04  C3   C  0  1  Y  N  N  -24.450  30.336  19.106  -3.768   0.784  -0.135  C04  HWB   4  
+HWB  O05  O2   O  0  1  N  N  N  -23.796  31.253  18.260  -4.379   1.990  -0.254  O05  HWB   5  
+HWB  C06  C4   C  0  1  Y  N  N  -24.350  28.896  18.957  -2.366   0.706  -0.052  C06  HWB   6  
+HWB  C07  C5   C  0  1  Y  N  N  -23.580  28.200  17.918  -1.559   1.862  -0.089  C07  HWB   7  
+HWB  C08  C6   C  0  1  Y  N  N  -23.575  26.746  17.893  -0.202   1.643   0.003  C08  HWB   8  
+HWB  O09  O3   O  0  1  N  N  N  -22.841  26.095  16.898   0.679   2.678  -0.021  O09  HWB   9  
+HWB  C10  C7   C  0  1  Y  N  N  -24.310  26.063  18.887   0.242   0.313   0.122  C10  HWB  10  
+HWB  O11  O4   O  1  1  Y  N  N  -24.982  26.758  19.760  -0.515  -0.630   0.147  O11  HWB  11  
+HWB  C12  C8   C  0  1  Y  N  N  -25.023  28.090  19.838  -1.728  -0.554   0.074  C12  HWB  12  
+HWB  C13  C9   C  0  1  Y  N  N  -25.821  28.621  20.892  -2.520  -1.711   0.118  C13  HWB  13  
+HWB  C14  C10  C  0  1  Y  N  N  -24.534  24.563  19.126   1.696   0.058   0.221  C14  HWB  14  
+HWB  C15  C11  C  0  1  Y  N  N  -25.686  24.294  19.849   2.314   0.013   1.471  C15  HWB  15  
+HWB  C16  C12  C  0  1  Y  N  N  -26.107  23.023  20.231   3.670  -0.226   1.562  C16  HWB  16  
+HWB  C17  C13  C  0  1  Y  N  N  -25.330  21.968  19.807   4.422  -0.420   0.412  C17  HWB  17  
+HWB  O18  O5   O  0  1  N  N  N  -25.797  20.722  20.114   5.757  -0.654   0.507  O18  HWB  18  
+HWB  C19  C14  C  0  1  Y  N  N  -24.207  22.172  18.990   3.810  -0.375  -0.839  C19  HWB  19  
+HWB  O20  O6   O  0  1  N  N  N  -23.481  21.047  18.564   4.549  -0.566  -1.965  O20  HWB  20  
+HWB  C21  C15  C  0  1  Y  N  N  -23.785  23.467  18.688   2.451  -0.143  -0.936  C21  HWB  21  
+HWB  H1   H1   H  0  1  N  N  N  -27.077  29.737  22.574  -4.823  -3.121  -0.800  H1   HWB  22  
+HWB  H2   H2   H  0  1  N  N  N  -25.308  31.920  20.286  -5.589  -0.305  -0.157  H2   HWB  23  
+HWB  H3   H3   H  0  1  N  N  N  -23.998  32.139  18.536  -4.604   2.402   0.591  H3   HWB  24  
+HWB  H4   H4   H  0  1  N  N  N  -23.024  28.761  17.181  -1.977   2.854  -0.183  H4   HWB  25  
+HWB  H5   H5   H  0  1  N  N  N  -22.928  25.155  17.003   0.885   3.039   0.852  H5   HWB  26  
+HWB  H6   H6   H  0  1  N  N  N  -26.348  27.960  21.565  -2.056  -2.681   0.213  H6   HWB  27  
+HWB  H7   H7   H  0  1  N  N  N  -26.303  25.133  20.137   1.732   0.164   2.368  H7   HWB  28  
+HWB  H8   H8   H  0  1  N  N  N  -26.995  22.873  20.827   4.147  -0.260   2.530  H8   HWB  29  
+HWB  H9   H9   H  0  1  N  N  N  -26.560  20.799  20.675   5.987  -1.591   0.579  H9   HWB  30  
+HWB  H10  H10  H  0  1  N  N  N  -23.917  20.257  18.861   4.608  -1.490  -2.245  H10  HWB  31  
+HWB  H11  H11  H  0  1  N  N  N  -22.882  23.622  18.117   1.976  -0.109  -1.905  H11  HWB  32  
+#   #
+loop_
+_chem_comp_bond.comp_id
+_chem_comp_bond.atom_id_1
+_chem_comp_bond.atom_id_2
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
+_chem_comp_bond.pdbx_stereo_config
+_chem_comp_bond.pdbx_ordinal
+HWB  O09  C08  SING  N  N   1  
+HWB  C08  C07  DOUB  Y  N   2  
+HWB  C08  C10  SING  Y  N   3  
+HWB  C07  C06  SING  Y  N   4  
+HWB  O05  C04  SING  N  N   5  
+HWB  O20  C19  SING  N  N   6  
+HWB  C21  C19  DOUB  Y  N   7  
+HWB  C21  C14  SING  Y  N   8  
+HWB  C10  C14  SING  N  N   9  
+HWB  C10  O11  DOUB  Y  N  10  
+HWB  C06  C04  DOUB  Y  N  11  
+HWB  C06  C12  SING  Y  N  12  
+HWB  C19  C17  SING  Y  N  13  
+HWB  C04  C03  SING  Y  N  14  
+HWB  C14  C15  DOUB  Y  N  15  
+HWB  O11  C12  SING  Y  N  16  
+HWB  C17  O18  SING  N  N  17  
+HWB  C17  C16  DOUB  Y  N  18  
+HWB  C12  C13  DOUB  Y  N  19  
+HWB  C15  C16  SING  Y  N  20  
+HWB  C03  C02  DOUB  Y  N  21  
+HWB  C13  C02  SING  Y  N  22  
+HWB  C02  O01  SING  N  N  23  
+HWB  O01  H1   SING  N  N  24  
+HWB  C03  H2   SING  N  N  25  
+HWB  O05  H3   SING  N  N  26  
+HWB  C07  H4   SING  N  N  27  
+HWB  O09  H5   SING  N  N  28  
+HWB  C13  H6   SING  N  N  29  
+HWB  C15  H7   SING  N  N  30  
+HWB  C16  H8   SING  N  N  31  
+HWB  O18  H9   SING  N  N  32  
+HWB  O20  H10  SING  N  N  33  
+HWB  C21  H11  SING  N  N  34  
+#   #
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+HWB  InChI             InChI                 1.03   "InChI=1S/C15H10O6/c16-8-4-11(18)9-6-13(20)15(21-14(9)5-8)7-1-2-10(17)12(19)3-7/h1-6H,(H4-,16,17,18,19,20)/p+1"  
+HWB  InChIKey          InChI                 1.03   VEVZSMAEJFVWIL-UHFFFAOYSA-O  
+HWB  SMILES_CANONICAL  CACTVS                3.385  "Oc1cc(O)c2cc(O)c([o+]c2c1)c3ccc(O)c(O)c3"  
+HWB  SMILES            CACTVS                3.385  "Oc1cc(O)c2cc(O)c([o+]c2c1)c3ccc(O)c(O)c3"  
+HWB  SMILES_CANONICAL  "OpenEye OEToolkits"  2.0.6  "c1cc(c(cc1c2c(cc3c(cc(cc3[o+]2)O)O)O)O)O"  
+HWB  SMILES            "OpenEye OEToolkits"  2.0.6  "c1cc(c(cc1c2c(cc3c(cc(cc3[o+]2)O)O)O)O)O"  
+#
+_pdbx_chem_comp_identifier.comp_id          HWB
+_pdbx_chem_comp_identifier.type             "SYSTEMATIC NAME"
+_pdbx_chem_comp_identifier.program          "OpenEye OEToolkits"
+_pdbx_chem_comp_identifier.program_version  2.0.6
+_pdbx_chem_comp_identifier.identifier       "2-[3,4-bis(oxidanyl)phenyl]chromenylium-3,5,7-triol"
+#   #
+loop_
+_pdbx_chem_comp_audit.comp_id
+_pdbx_chem_comp_audit.action_type
+_pdbx_chem_comp_audit.date
+_pdbx_chem_comp_audit.processing_site
+HWB  "Create component"  2018-12-29  EBI   
+HWB  "Initial release"   2019-12-25  RCSB  
+##

--- a/tests/structure/data/molecules/TYR.cif
+++ b/tests/structure/data/molecules/TYR.cif
@@ -1,0 +1,136 @@
+data_TYR
+#
+
+_chem_comp.id                                   TYR
+_chem_comp.name                                 TYROSINE
+_chem_comp.type                                 "L-PEPTIDE LINKING"
+_chem_comp.pdbx_type                            ATOMP
+_chem_comp.formula                              "C9 H11 N O3"
+_chem_comp.mon_nstd_parent_comp_id              ?
+_chem_comp.pdbx_synonyms                        ?
+_chem_comp.pdbx_formal_charge                   0
+_chem_comp.pdbx_initial_date                    1999-07-08
+_chem_comp.pdbx_modified_date                   2011-06-04
+_chem_comp.pdbx_ambiguous_flag                  N
+_chem_comp.pdbx_release_status                  REL
+_chem_comp.pdbx_replaced_by                     ?
+_chem_comp.pdbx_replaces                        ?
+_chem_comp.formula_weight                       181.189
+_chem_comp.one_letter_code                      Y
+_chem_comp.three_letter_code                    TYR
+_chem_comp.pdbx_model_coordinates_details       ?
+_chem_comp.pdbx_model_coordinates_missing_flag  N
+_chem_comp.pdbx_ideal_coordinates_details       ?
+_chem_comp.pdbx_ideal_coordinates_missing_flag  N
+_chem_comp.pdbx_model_coordinates_db_code       ?
+_chem_comp.pdbx_subcomponent_list               ?
+_chem_comp.pdbx_processing_site                 EBI
+#   #
+loop_
+_chem_comp_atom.comp_id
+_chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
+_chem_comp_atom.type_symbol
+_chem_comp_atom.charge
+_chem_comp_atom.pdbx_align
+_chem_comp_atom.pdbx_aromatic_flag
+_chem_comp_atom.pdbx_leaving_atom_flag
+_chem_comp_atom.pdbx_stereo_config
+_chem_comp_atom.model_Cartn_x
+_chem_comp_atom.model_Cartn_y
+_chem_comp_atom.model_Cartn_z
+_chem_comp_atom.pdbx_model_Cartn_x_ideal
+_chem_comp_atom.pdbx_model_Cartn_y_ideal
+_chem_comp_atom.pdbx_model_Cartn_z_ideal
+_chem_comp_atom.pdbx_component_atom_id
+_chem_comp_atom.pdbx_component_comp_id
+_chem_comp_atom.pdbx_ordinal
+TYR  N    N    N  0  1  N  N  N  5.005  5.256  15.563   1.320   0.952   1.428  N    TYR   1  
+TYR  CA   CA   C  0  1  N  N  S  5.326  6.328  16.507  -0.018   0.429   1.734  CA   TYR   2  
+TYR  C    C    C  0  1  N  N  N  4.742  7.680  16.116  -0.103   0.094   3.201  C    TYR   3  
+TYR  O    O    O  0  1  N  N  N  4.185  8.411  16.947   0.886  -0.254   3.799  O    TYR   4  
+TYR  CB   CB   C  0  1  N  N  N  6.836  6.389  16.756  -0.274  -0.831   0.907  CB   TYR   5  
+TYR  CG   CG   C  0  1  Y  N  N  7.377  5.438  17.795  -0.189  -0.496  -0.559  CG   TYR   6  
+TYR  CD1  CD1  C  0  1  Y  N  N  6.826  5.370  19.075   1.022  -0.589  -1.219  CD1  TYR   7  
+TYR  CD2  CD2  C  0  1  Y  N  N  8.493  4.624  17.565  -1.324  -0.102  -1.244  CD2  TYR   8  
+TYR  CE1  CE1  C  0  1  Y  N  N  7.308  4.536  20.061   1.103  -0.282  -2.563  CE1  TYR   9  
+TYR  CE2  CE2  C  0  1  Y  N  N  9.029  3.816  18.552  -1.247   0.210  -2.587  CE2  TYR  10  
+TYR  CZ   CZ   C  0  1  Y  N  N  8.439  3.756  19.805  -0.032   0.118  -3.252  CZ   TYR  11  
+TYR  OH   OH   O  0  1  N  N  N  8.954  2.936  20.781   0.044   0.420  -4.574  OH   TYR  12  
+TYR  OXT  OXT  O  0  1  N  Y  N  4.840  8.051  14.829  -1.279   0.184   3.842  OXT  TYR  13  
+TYR  H    H    H  0  1  N  N  N  5.621  4.925  15.064   1.977   0.225   1.669  H    TYR  14  
+TYR  H2   HN2  H  0  1  N  Y  N  5.288  5.511  14.617   1.365   1.063   0.426  H2   TYR  15  
+TYR  HA   HA   H  0  1  N  N  N  4.913  6.081  17.361  -0.767   1.183   1.489  HA   TYR  16  
+TYR  HB2  1HB  H  0  1  N  N  N  7.289  6.213  15.916   0.473  -1.585   1.152  HB2  TYR  17  
+TYR  HB3  2HB  H  0  1  N  N  N  7.063  7.294  17.023  -1.268  -1.219   1.134  HB3  TYR  18  
+TYR  HD1  HD1  H  0  1  N  N  N  6.097  5.913  19.272   1.905  -0.902  -0.683  HD1  TYR  19  
+TYR  HD2  HD2  H  0  1  N  N  N  8.887  4.627  16.723  -2.269  -0.031  -0.727  HD2  TYR  20  
+TYR  HE1  HE1  H  0  1  N  N  N  6.886  4.493  20.888   2.049  -0.354  -3.078  HE1  TYR  21  
+TYR  HE2  HE2  H  0  1  N  N  N  9.788  3.310  18.373  -2.132   0.523  -3.121  HE2  TYR  22  
+TYR  HH   HH   H  0  1  N  N  N  8.500  3.001  21.460  -0.123  -0.399  -5.059  HH   TYR  23  
+TYR  HXT  HXT  H  0  1  N  Y  N  4.475  8.893  14.585  -1.333  -0.030   4.784  HXT  TYR  24  
+#   #
+loop_
+_chem_comp_bond.comp_id
+_chem_comp_bond.atom_id_1
+_chem_comp_bond.atom_id_2
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
+_chem_comp_bond.pdbx_stereo_config
+_chem_comp_bond.pdbx_ordinal
+TYR  N    CA   SING  N  N   1  
+TYR  N    H    SING  N  N   2  
+TYR  N    H2   SING  N  N   3  
+TYR  CA   C    SING  N  N   4  
+TYR  CA   CB   SING  N  N   5  
+TYR  CA   HA   SING  N  N   6  
+TYR  C    O    DOUB  N  N   7  
+TYR  C    OXT  SING  N  N   8  
+TYR  CB   CG   SING  N  N   9  
+TYR  CB   HB2  SING  N  N  10  
+TYR  CB   HB3  SING  N  N  11  
+TYR  CG   CD1  DOUB  Y  N  12  
+TYR  CG   CD2  SING  Y  N  13  
+TYR  CD1  CE1  SING  Y  N  14  
+TYR  CD1  HD1  SING  N  N  15  
+TYR  CD2  CE2  DOUB  Y  N  16  
+TYR  CD2  HD2  SING  N  N  17  
+TYR  CE1  CZ   DOUB  Y  N  18  
+TYR  CE1  HE1  SING  N  N  19  
+TYR  CE2  CZ   SING  Y  N  20  
+TYR  CE2  HE2  SING  N  N  21  
+TYR  CZ   OH   SING  N  N  22  
+TYR  OH   HH   SING  N  N  23  
+TYR  OXT  HXT  SING  N  N  24  
+#   #
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+TYR  SMILES            ACDLabs               10.04  "O=C(O)C(N)Cc1ccc(O)cc1"  
+TYR  SMILES_CANONICAL  CACTVS                3.341  "N[C@@H](Cc1ccc(O)cc1)C(O)=O"  
+TYR  SMILES            CACTVS                3.341  "N[CH](Cc1ccc(O)cc1)C(O)=O"  
+TYR  SMILES_CANONICAL  "OpenEye OEToolkits"  1.5.0  "c1cc(ccc1C[C@@H](C(=O)O)N)O"  
+TYR  SMILES            "OpenEye OEToolkits"  1.5.0  "c1cc(ccc1CC(C(=O)O)N)O"  
+TYR  InChI             InChI                 1.03   "InChI=1S/C9H11NO3/c10-8(9(12)13)5-6-1-3-7(11)4-2-6/h1-4,8,11H,5,10H2,(H,12,13)/t8-/m0/s1"  
+TYR  InChIKey          InChI                 1.03   OUYCCCASQSFEME-QMMMGPOBSA-N  
+#   #
+loop_
+_pdbx_chem_comp_identifier.comp_id
+_pdbx_chem_comp_identifier.type
+_pdbx_chem_comp_identifier.program
+_pdbx_chem_comp_identifier.program_version
+_pdbx_chem_comp_identifier.identifier
+TYR  "SYSTEMATIC NAME"  ACDLabs               10.04  L-tyrosine  
+TYR  "SYSTEMATIC NAME"  "OpenEye OEToolkits"  1.5.0  "(2S)-2-amino-3-(4-hydroxyphenyl)propanoic acid"  
+#   #
+loop_
+_pdbx_chem_comp_audit.comp_id
+_pdbx_chem_comp_audit.action_type
+_pdbx_chem_comp_audit.date
+_pdbx_chem_comp_audit.processing_site
+TYR  "Create component"   1999-07-08  EBI   
+TYR  "Modify descriptor"  2011-06-04  RCSB  
+##

--- a/tests/structure/test_mol.py
+++ b/tests/structure/test_mol.py
@@ -9,8 +9,8 @@ from os.path import join, split, splitext
 from tempfile import TemporaryFile
 import numpy as np
 import pytest
-import biotite.structure.info as info
 import biotite.structure.io.mol as mol
+import biotite.structure.io.pdbx as pdbx
 from biotite.structure.bonds import BondType
 from biotite.structure.io.ctab import BOND_TYPE_MAPPING_REV
 from ..util import data_dir
@@ -85,15 +85,16 @@ def test_structure_conversion(path, omit_charge):
 def test_pdbx_consistency(path):
     """
     Check if the structure parsed from a MOL file is equal to the same
-    structure read from the *Chemical Component Dictionary* in PDBx
-    format.
+    structure read in PDBx format.
 
     In this case an SDF file is used, but it is compatible with the
     MOL format.
     """
-    mol_name = split(splitext(path)[0])[1]
-    ref_atoms = info.residue(mol_name)
-    # The CCD contains information about aromatic bond types,
+    cif_path = splitext(path)[0] + ".cif"
+
+    pdbx_file = pdbx.PDBxFile.read(cif_path)
+    ref_atoms = pdbx.get_component(pdbx_file, include_bonds=True)
+    # The PDBx test files contain information about aromatic bond types,
     # but the SDF test files do not
     ref_atoms.bonds.remove_aromaticity()
 

--- a/tests/structure/test_mol.py
+++ b/tests/structure/test_mol.py
@@ -93,7 +93,7 @@ def test_pdbx_consistency(path):
     cif_path = splitext(path)[0] + ".cif"
 
     pdbx_file = pdbx.PDBxFile.read(cif_path)
-    ref_atoms = pdbx.get_component(pdbx_file, include_bonds=True)
+    ref_atoms = pdbx.get_component(pdbx_file)
     # The PDBx test files contain information about aromatic bond types,
     # but the SDF test files do not
     ref_atoms.bonds.remove_aromaticity()

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -251,17 +251,14 @@ def test_component_conversion(path, use_ideal_coord):
     structure.
     """
     pdbx_file = pdbx.PDBxFile.read(path)
-    print(pdbx_file)
-    print("\n\nNEW FILE\n\n")
     ref_atoms = pdbx.get_component(
-        pdbx_file, use_ideal_coord=use_ideal_coord, include_bonds=True
+        pdbx_file, use_ideal_coord=use_ideal_coord
     )
 
     pdbx_file = pdbx.PDBxFile()
     pdbx.set_component(pdbx_file, ref_atoms, data_block="test")
-    print(pdbx_file)
     test_atoms = pdbx.get_component(
-        pdbx_file, use_ideal_coord=use_ideal_coord, include_bonds=True,
+        pdbx_file, use_ideal_coord=use_ideal_coord
     )
 
     assert test_atoms == ref_atoms

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -237,6 +237,36 @@ def test_get_assembly(pdb_id, model):
         assert assembly.array_length() % monomer_atom_count == 0
 
 
+@pytest.mark.parametrize(
+    "path, use_ideal_coord",
+    itertools.product(
+        glob.glob(join(data_dir("structure"), "molecules", "*.cif")),
+        [False, True]
+    ),
+)
+def test_component_conversion(path, use_ideal_coord):
+    """
+    After reading a component from a PDBx file, writing the component
+    back to a new file and reading it again should give the same
+    structure.
+    """
+    pdbx_file = pdbx.PDBxFile.read(path)
+    print(pdbx_file)
+    print("\n\nNEW FILE\n\n")
+    ref_atoms = pdbx.get_component(
+        pdbx_file, use_ideal_coord=use_ideal_coord, include_bonds=True
+    )
+
+    pdbx_file = pdbx.PDBxFile()
+    pdbx.set_component(pdbx_file, ref_atoms, data_block="test")
+    print(pdbx_file)
+    test_atoms = pdbx.get_component(
+        pdbx_file, use_ideal_coord=use_ideal_coord, include_bonds=True,
+    )
+
+    assert test_atoms == ref_atoms
+
+
 def test_get_sequence():
     file = pdbx.PDBxFile.read(join(data_dir("structure"), "5ugo.cif"))
     sequences = pdbx.get_sequence(file)


### PR DESCRIPTION
This PR adds the functions `structure.io.pdbx.get_component()` and `set_component()` to allow getting and setting chemical components from/to PDBx files via their `chem_comp` group of categories. Resolves #467 .