### PR TITLE
Faster continuous k-mer decomposition

### DIFF
--- a/src/biotite/sequence/align/kmeralphabet.pyx
+++ b/src/biotite/sequence/align/kmeralphabet.pyx
@@ -81,7 +81,7 @@ class KmerAlphabet(Alphabet):
     
     Notes
     -----
-    If the length of the `base_alphabet` is a multiple of 2 and no
+    If the length of the `base_alphabet` is a power of 2 and no
     spacing is given, :meth:`create_kmers()` employs a faster method
     using bit shifts.
     This method can be multiple times faster and requires constant time

--- a/src/biotite/sequence/align/kmeralphabet.pyx
+++ b/src/biotite/sequence/align/kmeralphabet.pyx
@@ -165,14 +165,11 @@ class KmerAlphabet(Alphabet):
 
         if spacing is None:
             self._spacing = None
-            self._create_kmers_func = self._create_continuous_kmers
         
         elif isinstance(spacing, str):
-            self._create_kmers_func = self._create_spaced_kmers
             self._spacing = _to_array_form(spacing)
         
         else:
-            self._create_kmers_func = self._create_spaced_kmers
             self._spacing = np.array(spacing, dtype=np.int64)
             self._spacing.sort()
             if (self._spacing < 0).any():
@@ -433,7 +430,10 @@ class KmerAlphabet(Alphabet):
         >>> print(["".join(kmer) for kmer in kmer_alphabet.decode_multiple(kmer_codes)])
         ['AT', 'TT', 'TG', 'GC', 'CT']
         """
-        return self._create_kmers_func(seq_code)
+        if self._spacing is None:
+            return self._create_continuous_kmers(seq_code)
+        else:
+            return self._create_spaced_kmers(seq_code)
     
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/src/biotite/sequence/align/kmertable.pyx
+++ b/src/biotite/sequence/align/kmertable.pyx
@@ -158,10 +158,10 @@ cdef class KmerTable:
     (reference ID, sequence position) tuples:
 
     >>> print(table)
-    TA: (0, 1), (0, 3), (1, 1)
     AG: (1, 2)
     AT: (0, 2)
     CT: (1, 0)
+    TA: (0, 1), (0, 3), (1, 1)
     TT: (0, 0)
 
     Find matches of the table with a sequence:
@@ -301,10 +301,10 @@ cdef class KmerTable:
         ...     2, sequences, ref_ids=[100, 101]
         ... )
         >>> print(table)
-        TA: (100, 1), (100, 3), (101, 1)
         AG: (101, 2)
         AT: (100, 2)
         CT: (101, 0)
+        TA: (100, 1), (100, 3), (101, 1)
         TT: (100, 0)
 
         Give an explicit compatible alphabet:
@@ -321,9 +321,9 @@ cdef class KmerTable:
         ...     2, [sequence], ignore_masks=[sequence.symbols == "N"]
         ... )
         >>> print(table)
-        TA: (0, 4)
         AC: (0, 0)
         CC: (0, 1)
+        TA: (0, 4)
         """
         # Check length of input lists
         if ref_ids is not None and len(ref_ids) != len(sequences):
@@ -431,21 +431,21 @@ cdef class KmerTable:
         >>> kmer_codes = [kmer_alphabet.create_kmers(s.code) for s in sequences]
         >>> for code in kmer_codes:
         ...     print(code)
-        [7676 9535 4429 9400 2119]
-        [ 7667 11839  4525  9404  2119]
+        [11701  4360  7879  9400  4419]
+        [ 6517  4364  7975 11704  4419]
         >>> table = KmerTable.from_kmers(
         ...     kmer_alphabet, kmer_codes
         ... )
         >>> print(table)
-        ITE: (0, 4), (1, 4)
-        QTI: (0, 2)
-        QBI: (1, 2)
-        NIQ: (1, 0)
-        BIQ: (0, 0)
-        TIT: (0, 3)
-        BIT: (1, 3)
         IQT: (0, 1)
         IQB: (1, 1)
+        ITE: (0, 4), (1, 4)
+        NIQ: (1, 0)
+        QTI: (0, 2)
+        QBI: (1, 2)
+        TIT: (0, 3)
+        BIQ: (0, 0)
+        BIT: (1, 3)
         """
         if not isinstance(kmer_alphabet, KmerAlphabet):
             raise TypeError(
@@ -534,10 +534,10 @@ cdef class KmerTable:
         ... )
         >>> merged_table = KmerTable.from_tables([table1, table2])
         >>> print(merged_table)
-        TA: (100, 1), (100, 3), (101, 1)
         AG: (101, 2)
         AT: (100, 2)
         CT: (101, 0)
+        TA: (100, 1), (100, 3), (101, 1)
         TT: (100, 0)
         """
         # Check for alphabet compatibility
@@ -597,21 +597,21 @@ cdef class KmerTable:
         >>> sequence = ProteinSequence("BIQTITE")
         >>> table = KmerTable.from_sequences(3, [sequence], ref_ids=[100])
         >>> print(table)
+        IQT: (100, 1)
         ITE: (100, 4)
         QTI: (100, 2)
-        BIQ: (100, 0)
         TIT: (100, 3)
-        IQT: (100, 1)
+        BIQ: (100, 0)
         >>> data = {kmer: table[kmer] for kmer in table}
         >>> print(data)
-        {2119: array([[100,   4]], dtype=uint32), 4429: array([[100,   2]], dtype=uint32), 7676: array([[100,   0]], dtype=uint32), 9400: array([[100,   3]], dtype=uint32), 9535: array([[100,   1]], dtype=uint32)}
+        {4360: array([[100,   1]], dtype=uint32), 4419: array([[100,   4]], dtype=uint32), 7879: array([[100,   2]], dtype=uint32), 9400: array([[100,   3]], dtype=uint32), 11701: array([[100,   0]], dtype=uint32)}
         >>> restored_table = KmerTable.from_positions(table.kmer_alphabet, data)
         >>> print(restored_table)
+        IQT: (100, 1)
         ITE: (100, 4)
         QTI: (100, 2)
-        BIQ: (100, 0)
         TIT: (100, 3)
-        IQT: (100, 1)
+        BIQ: (100, 0)
         """
         cdef int64 length
         cdef uint32* kmer_ptr
@@ -711,19 +711,19 @@ cdef class KmerTable:
         >>> sequence1 = ProteinSequence("BIQTITE")
         >>> table1 = KmerTable.from_sequences(3, [sequence1], ref_ids=[100])
         >>> print(table1)
+        IQT: (100, 1)
         ITE: (100, 4)
         QTI: (100, 2)
-        BIQ: (100, 0)
         TIT: (100, 3)
-        IQT: (100, 1)
+        BIQ: (100, 0)
         >>> sequence2 = ProteinSequence("TITANITE")
         >>> table2 = KmerTable.from_sequences(3, [sequence2], ref_ids=[101])
         >>> print(table2)
+        ANI: (101, 3)
         ITA: (101, 1)
         ITE: (101, 5)
-        ANI: (101, 3)
-        TAN: (101, 2)
         NIT: (101, 4)
+        TAN: (101, 2)
         TIT: (101, 0)
         >>> print(table1.match_table(table2))
         [[101   5 100   4]
@@ -870,11 +870,11 @@ cdef class KmerTable:
         >>> sequence1 = ProteinSequence("BIQTITE")
         >>> table = KmerTable.from_sequences(3, [sequence1], ref_ids=[100])
         >>> print(table)
+        IQT: (100, 1)
         ITE: (100, 4)
         QTI: (100, 2)
-        BIQ: (100, 0)
         TIT: (100, 3)
-        IQT: (100, 1)
+        BIQ: (100, 0)
         >>> sequence2 = ProteinSequence("TITANITE")
         >>> print(table.match(sequence2))
         [[  0 100   3]
@@ -986,21 +986,21 @@ cdef class KmerTable:
         >>> sequence = ProteinSequence("BIQTITE")
         >>> table = KmerTable.from_sequences(3, [sequence], ref_ids=[100])
         >>> print(table)
+        IQT: (100, 1)
         ITE: (100, 4)
         QTI: (100, 2)
-        BIQ: (100, 0)
         TIT: (100, 3)
-        IQT: (100, 1)
+        BIQ: (100, 0)
         >>> kmer_codes = table.get_kmers()
         >>> print(kmer_codes)
-        [2119 4429 7676 9400 9535]
+        [ 4360  4419  7879  9400 11701]
         >>> for code in kmer_codes:
         ...     print(table[code])
+        [[100   1]]
         [[100   4]]
         [[100   2]]
-        [[100   0]]
         [[100   3]]
-        [[100   1]]
+        [[100   0]]
         """
         cdef int64 kmer
         cdef ptr[:] ptr_array = self._ptr_array

--- a/tests/sequence/align/test_kmeralphabet.py
+++ b/tests/sequence/align/test_kmeralphabet.py
@@ -96,7 +96,7 @@ def test_create_continuous_kmers_fast(seed):
     LENGTH = 1000
     K = 5
 
-    # The alphabet must be multiple of 2 -> NucleotideSequence
+    # The alphabet must be power of 2 -> NucleotideSequence
     sequence = seq.NucleotideSequence(ambiguous=False)
     np.random.seed(seed)
     sequence.code = np.random.randint(len(sequence.alphabet), size=LENGTH)

--- a/tests/sequence/align/test_kmeralphabet.py
+++ b/tests/sequence/align/test_kmeralphabet.py
@@ -85,32 +85,6 @@ def test_create_continuous_kmers(kmer_alphabet):
     assert test_kmers.tolist() == ref_kmers
 
 
-N = 10
-@pytest.mark.parametrize("seed", range(N))
-def test_create_continuous_kmers_fast(seed):
-    """
-    Test :meth:`create_kmers()` using the fast bit shift method.
-    against the naive implementation.
-    The input sequence code is randomly created.
-    """
-    LENGTH = 1000
-    K = 5
-
-    # The alphabet must be power of 2 -> NucleotideSequence
-    sequence = seq.NucleotideSequence(ambiguous=False)
-    np.random.seed(seed)
-    sequence.code = np.random.randint(len(sequence.alphabet), size=LENGTH)
-    kmer_alphabet = align.KmerAlphabet(sequence.alphabet, K)
-    
-    test_kmer_codes = kmer_alphabet.create_kmers(sequence.code)
-
-    # Replace the fast method by the naive method
-    kmer_alphabet._create_kmers_func = kmer_alphabet._create_continuous_kmers
-    ref_kmer_codes = kmer_alphabet.create_kmers(sequence.code)
-
-    assert test_kmer_codes.tolist() == ref_kmer_codes.tolist()
-
-
 N = 50
 @pytest.mark.parametrize("seed", range(N))
 def test_create_spaced_kmers(kmer_alphabet, spaced_kmer_alphabet, seed):

--- a/tests/sequence/align/test_kmeralphabet.py
+++ b/tests/sequence/align/test_kmeralphabet.py
@@ -85,6 +85,32 @@ def test_create_continuous_kmers(kmer_alphabet):
     assert test_kmers.tolist() == ref_kmers
 
 
+N = 10
+@pytest.mark.parametrize("seed", range(N))
+def test_create_continuous_kmers_fast(seed):
+    """
+    Test :meth:`create_kmers()` using the fast bit shift method.
+    against the naive implementation.
+    The input sequence code is randomly created.
+    """
+    LENGTH = 1000
+    K = 5
+
+    # The alphabet must be multiple of 2 -> NucleotideSequence
+    sequence = seq.NucleotideSequence(ambiguous=False)
+    np.random.seed(seed)
+    sequence.code = np.random.randint(len(sequence.alphabet), size=LENGTH)
+    kmer_alphabet = align.KmerAlphabet(sequence.alphabet, K)
+    
+    test_kmer_codes = kmer_alphabet.create_kmers(sequence.code)
+
+    # Replace the fast method by the naive method
+    kmer_alphabet._create_kmers_func = kmer_alphabet._create_continuous_kmers
+    ref_kmer_codes = kmer_alphabet.create_kmers(sequence.code)
+
+    assert test_kmer_codes.tolist() == ref_kmer_codes.tolist()
+
+
 N = 50
 @pytest.mark.parametrize("seed", range(N))
 def test_create_spaced_kmers(kmer_alphabet, spaced_kmer_alphabet, seed):


### PR DESCRIPTION
This PR introduces a faster method for `create_kmers()` that uses the *k*-mer from the previous position to compute the next position. This way lopping over *k* is not necessary anymore as opposed to the current method.
The performance increase is clear (orange: naive, green: new method):

![benchmark_1](https://user-images.githubusercontent.com/28051833/234803071-993c3852-9844-4d87-b780-56e46844d408.png)

The following script was used to create the benchmarks:

```python
import time
import numpy as np
import biotite
import biotite.sequence as seq
import biotite.sequence.align as align
import matplotlib.pyplot as plt


LENGTH = 1_000_000
MAX_K = 12
N = 100


orig_durations = []
new_durations = []

sequence = seq.NucleotideSequence(ambiguous=False)
np.random.seed(0)
sequence.code = np.random.randint(len(sequence.alphabet), size=LENGTH)

k_values = np.arange(2, MAX_K+1)
for k in k_values:
    kmer_alph = align.KmerAlphabet(sequence.alphabet, k)

    now = time.time_ns()
    for _  in range(N):
        kmer_codes = kmer_alph.create_kmers(sequence.code)
    new_durations.append((time.time_ns() - now) / N * 1e-6)

    kmer_alph._create_kmers_func = kmer_alph._create_continuous_kmers

    now = time.time_ns()
    for _  in range(N):
        kmer_codes = kmer_alph.create_kmers(sequence.code)
    orig_durations.append((time.time_ns() - now) / N * 1e-6)

fig, ax = plt.subplots()
ax.plot(
    k_values, orig_durations, color=biotite.colors["orange"],
    marker="o", linestyle="None"
)
ax.plot(
    k_values, new_durations, color=biotite.colors["green"],
    marker="o", linestyle="None"
)
ax.set_xlabel("k")
ax.set_ylabel("Duration (ms)")
plt.show()
```

For easier implementation the *k*-mer ordering in the alphabet is reversed.