### PR TITLE
Fix annotated sequence slicing bug

### DIFF
--- a/src/biotite/sequence/annotation.py
+++ b/src/biotite/sequence/annotation.py
@@ -763,7 +763,8 @@ class AnnotatedSequence(Copyable):
                     )
                 seq_start = index.start - self._seqstart
             if index.stop is None:
-                index.start = len(self._sequence)
+                seq_stop = len(self._sequence)
+                index = slice(index.start, seq_stop, index.step)
             else:
                 seq_stop = index.stop - self._seqstart
             # New value for the sequence start, value is base position
@@ -804,7 +805,8 @@ class AnnotatedSequence(Copyable):
             else:
                 seq_start = index.start - self._seqstart
             if index.stop is None:
-                index.start = len(self._sequence)
+                seq_stop = len(self._sequence)
+                index = slice(index.start, seq_stop, index.step)
             else:
                 seq_stop = index.stop - self._seqstart
             # Item is a Sequence

--- a/src/biotite/sequence/annotation.py
+++ b/src/biotite/sequence/annotation.py
@@ -809,7 +809,6 @@ class AnnotatedSequence(Copyable):
                 seq_start = index.start - self._seqstart
             if index.stop is None:
                 seq_stop = len(self._sequence)
-                index = slice(index.start, seq_stop, index.step)
             else:
                 seq_stop = index.stop - self._seqstart
             # Item is a Sequence

--- a/src/biotite/sequence/annotation.py
+++ b/src/biotite/sequence/annotation.py
@@ -446,13 +446,16 @@ class Annotation(Copyable):
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            i_first = index.start
             # If no start or stop index is given, include all
-            if i_first is None:
+            if index.start is None:
                 i_first = -sys.maxsize
-            i_last = index.stop -1
-            if i_last is None:
+            else:
+                i_first = index.start
+            if index.stop is None:
                 i_last = sys.maxsize
+            else:
+                i_last = index.stop - 1
+            
             sub_annot = Annotation()
             for feature in self:
                 locs_in_scope = []

--- a/tests/sequence/test_annotation.py
+++ b/tests/sequence/test_annotation.py
@@ -62,10 +62,17 @@ def test_annotated_sequence():
     # test slicing with only stop
     annot_seq2 = annot_seq[:16]
     assert annot_seq2.sequence == seq.NucleotideSequence("ATGGCGTACGATTAG")
+    assert set([f.qual['note'] for f in annot_seq2.annotation]) == {'walker'}
     
     # test slicing with only start
     annot_seq3 = annot_seq[16:]
     assert annot_seq3.sequence == seq.NucleotideSequence("AAAAAAA")
+    assert set([f.qual['note'] for f in annot_seq3.annotation]) == {'poly-A'}
+    
+    # test slicing with start and stop
+    annot_seq4 = annot_seq[1:17]
+    assert annot_seq4.sequence == seq.NucleotideSequence("ATGGCGTACGATTAGA") # sequences are 1-indexed
+    assert set([f.qual['note'] for f in annot_seq4.annotation]) == {'walker', 'poly-A'}
     
     assert annot_seq[feature1] == seq.NucleotideSequence("ATAT")
     assert annot_seq[feature2] == seq.NucleotideSequence("AAAAAAA")

--- a/tests/sequence/test_annotation.py
+++ b/tests/sequence/test_annotation.py
@@ -58,8 +58,15 @@ def test_annotated_sequence():
     annot_seq = AnnotatedSequence(annotation, sequence)
     assert annot_seq[2] == "T"
     assert annot_seq.sequence[2] == "G"
+    
+    # test slicing with only stop
     annot_seq2 = annot_seq[:16]
     assert annot_seq2.sequence == seq.NucleotideSequence("ATGGCGTACGATTAG")
+    
+    # test slicing with only start
+    annot_seq3 = annot_seq[16:]
+    assert annot_seq3.sequence == seq.NucleotideSequence("AAAAAAA")
+    
     assert annot_seq[feature1] == seq.NucleotideSequence("ATAT")
     assert annot_seq[feature2] == seq.NucleotideSequence("AAAAAAA")
     annot_seq[feature1] = seq.NucleotideSequence("CCCC")


### PR DESCRIPTION
This PR is intended to fix a small bug I encountered when trying to index an `AnnotatedSequence` with a slice. 

Specifically, slicing forward from a start position without specifying a stop position was producing an error:

```python
sequence = NucleotideSequence("ATGGCGTACGATTAGAAAAAAA")
feature1 = Feature("misc_feature", [Location(1,2), Location(11,12)],
                   {"note" : "walker"})
feature2 = Feature("misc_feature", [Location(16,22)], {"note" : "poly-A"})
annotation = Annotation([feature1, feature2])
annot_seq = AnnotatedSequence(annotation, sequence)
```
---
Slicing with a stop but no start
```python
annot_seq[:16]
```
produces expected output
```
AnnotatedSequence(Annotation([Feature("misc_feature", [Location(11, 12, strand=Location.Strand.FORWARD, defect=Location.Defect.NONE), Location(1, 2, strand=Location.Strand.FORWARD, defect=Location.Defect.NONE)], qual={'note': 'walker'})]), NucleotideSequence("ATGGCGTACGATTAG", ambiguous=False), sequence_start=1)
```
---
slicing with a start but no stop
```python
annot_seq[16:]
```
yields an Attribute error
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[84], line 1
----> 1 annot_seq[16:]

File [~/.cache/pypoetry/virtualenvs/proteng-aQfWSUc--py3.10/lib/python3.10/site-packages/biotite/sequence/annotation.py:766](https://vscode-remote+ssh-002dremote-002bubugpu.vscode-resource.vscode-cdn.net/home/alexn/neuroscience/proteng/notebooks/~/.cache/pypoetry/virtualenvs/proteng-aQfWSUc--py3.10/lib/python3.10/site-packages/biotite/sequence/annotation.py:766), in AnnotatedSequence.__getitem__(self, index)
    764     seq_start = index.start - self._seqstart
    765 if index.stop is None:
--> 766     index.start = len(self._sequence)
    767 else:
    768     seq_stop = index.stop - self._seqstart

AttributeError: readonly attribute
```

