### PR TITLE
Update tests to current PDB version

### DIFF
--- a/src/biotite/database/pubchem/query.py
+++ b/src/biotite/database/pubchem/query.py
@@ -628,11 +628,11 @@ class SubstructureQuery(SuperOrSubstructureQuery):
 
     >>> # CID of alanine
     >>> print(search(SubstructureQuery(cid=5950, number=5)))
-    [5950, 602, 71080, 3081884, 449619]
+    [5950, 602, 71080, 3081884, 65370]
     >>> # AtomArray of alanine
     >>> atom_array = residue("ALA")
     >>> print(search(SubstructureQuery.from_atoms(atom_array, number=5)))
-    [5950, 602, 71080, 3081884, 449619]
+    [5950, 602, 71080, 3081884, 65370]
     """
 
     def search_type(self):

--- a/src/biotite/database/rcsb/query.py
+++ b/src/biotite/database/rcsb/query.py
@@ -139,7 +139,7 @@ class BasicQuery(SingleQuery):
     
     >>> query = BasicQuery("tc5b")
     >>> print(search(query))
-    ['1L2Y']
+    ['1L2Y', '8ANM', '8ANH', '8ANG', '8ANI']
     """
     def __init__(self, term):
         super().__init__()

--- a/tests/database/test_rcsb.py
+++ b/tests/database/test_rcsb.py
@@ -18,6 +18,8 @@ from ..util import cannot_connect_to, data_dir
 
 
 RCSB_URL = "https://www.rcsb.org/"
+# Search term that should only find the entry 1L2Y
+TC5B_TERM = "Miniprotein Construct TC5b"
 
 
 @pytest.mark.skipif(
@@ -59,7 +61,7 @@ def test_fetch_invalid(format):
 
 
 def test_search_basic():
-    query = rcsb.BasicQuery("tc5b")
+    query = rcsb.BasicQuery(TC5B_TERM)
     assert rcsb.search(query) == ["1L2Y"]
     assert rcsb.count(query) == 1
 
@@ -71,7 +73,8 @@ def test_search_basic():
             "pdbx_serial_crystallography_sample_delivery_injection.preparation",
             False,
             {},
-            ["6IG7", "6IG6", "7JRI", "7JR5", "7QX4", "7QX5", "7QX6", "7QX7"]
+            ["6IG7", "6IG6", "7JRI", "7JR5", "7QX4", "7QX5", "7QX6", "7QX7",
+             "8A2O", "8A2P"]
         ),
         (
             "audit_author.name",
@@ -91,7 +94,7 @@ def test_search_basic():
             "struct.title",
             False,
             {"contains_words": "tc5b"},
-            ["1L2Y"]
+            ["1L2Y", "8ANH", "8ANM", "8ANG", "8ANI"]
         ),
         (
             "reflns.d_resolution_high",
@@ -213,7 +216,7 @@ def test_search_composite():
     reason="RCSB PDB is not available"
 )
 def test_search_return_type(return_type, expected):
-    query = rcsb.BasicQuery("tc5b")
+    query = rcsb.BasicQuery(TC5B_TERM)
     assert rcsb.search(query, return_type) == expected
     assert rcsb.count(query, return_type) == len(expected)
 


### PR DESCRIPTION
This PR fixes the `database.rcsb` unit tests by updating tests results to the current state of the PDB. 