### PR TITLE
Increase performance of fetching via sra-tools

### DIFF
--- a/src/biotite/application/sra/__init__.py
+++ b/src/biotite/application/sra/__init__.py
@@ -5,6 +5,11 @@
 """
 A subpackage for obtaining sequencing data from the *NCBI*
 *sequence read archive* (SRA).
+
+It comprises two central classes:
+:class:`FastqDumpApp` downloads sequence reads in FASTQ format.
+If only sequences (and no scores) are required :class:`FastaDumpApp`
+writes sequence reads into FASTA format.
 """
 
 __name__ = "biotite.application.sra"

--- a/tests/application/test_sra.py
+++ b/tests/application/test_sra.py
@@ -2,22 +2,63 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+import itertools
 from os.path import join
 from tempfile import gettempdir
 import pytest
-from biotite.application.sra import FastqDumpApp
+from biotite.application.sra import FastqDumpApp, FastaDumpApp
 from biotite.sequence.io.fastq import FastqFile
+from biotite.sequence.io.fasta import FastaFile
 
 
-@pytest.mark.parametrize("custom_prefix", [False, True])
-def test_fastq_dump(custom_prefix):
+@pytest.mark.parametrize(
+    "app_class, custom_prefix", itertools.product(
+        [FastqDumpApp, FastaDumpApp],
+        [False, True]
+    )
+)
+def test_objects(app_class, custom_prefix):
+    """
+    Test return types of methods from the respective `Application` class.
+    """
+    # Small dataset for low server impact
+    UID = "ERR11344941"
+
     prefix = join(gettempdir(), "test_fastq") if custom_prefix else None
-    app = FastqDumpApp("SRR6986517", output_path_prefix=prefix)
+    app = app_class(UID, output_path_prefix=prefix)
     app.start()
     app.join()
 
-    for sequences_and_scores in app.get_sequences():
-        assert isinstance(sequences_and_scores, dict)
-    
-    for fastq_file in app.get_fastq():
-        assert isinstance(fastq_file, FastqFile)
+    for sequences in app.get_sequences():
+        assert isinstance(sequences, dict)
+
+    if app_class == FastqDumpApp:
+        for sequences_and_scores in app.get_sequences_and_scores():
+            assert isinstance(sequences_and_scores, dict)
+
+    if app_class == FastqDumpApp:
+        for fastq_file in app.get_fastq():
+            assert isinstance(fastq_file, FastqFile)
+    else:
+        for fasta_file in app.get_fasta():
+            assert isinstance(fasta_file, FastaFile)
+
+
+@pytest.mark.parametrize(
+    "app_class, custom_prefix", itertools.product(
+        [FastqDumpApp, FastaDumpApp],
+        [False, True]
+    )
+)
+def test_classmethod(app_class, custom_prefix):
+    """
+    Test return types of the `fetch()` class method.
+    """
+    UID = "ERR11344941"
+
+    prefix = join(gettempdir(), "test_fastq") if custom_prefix else None
+
+    sequences = app_class.fetch(UID, output_path_prefix=prefix)
+
+    for sequences in sequences:
+        assert isinstance(sequences, dict)


### PR DESCRIPTION
This PR increases the performance of `biotite.application.sra`:

- `prefetch` is called before `fasterq_dump`, as suggested [here](https://github.com/ncbi/sra-tools/wiki/08.-prefetch-and-fasterq-dump).
- `FastaDumpApp` is added, which decreases computation time by writing as FASTA instead of a FASTQ file, which omits the scores.