### PR TITLE
Support changes in Matplotlib API

### DIFF
--- a/doc/examples/scripts/structure/base_pairs.py
+++ b/doc/examples/scripts/structure/base_pairs.py
@@ -61,7 +61,7 @@ for residue_name, residue_id in zip(residue_names, residue_ids):
 base_pairs = struc.base_pairs(nucleotides)
 pseudoknot_order = struc.pseudoknots(base_pairs)[0]
 
-# Draw the arcs between basepairs
+# Draw the arcs between base pairs
 for (base1, base2), order in zip(base_pairs, pseudoknot_order):
     arc_center = (
         np.mean((nucleotides.res_id[base1],nucleotides.res_id[base2])), 1.5
@@ -80,7 +80,7 @@ for (base1, base2), order in zip(base_pairs, pseudoknot_order):
     else:
         linestyle = ":"
     arc = Arc(
-        arc_center, arc_diameter, arc_diameter, 180, theta1=180, theta2=0,
+        arc_center, arc_diameter, arc_diameter, theta1=0, theta2=180,
         color=color, linewidth=1.5, linestyle=linestyle
     )
     ax.add_patch(arc)

--- a/doc/examples/scripts/structure/peoe_visualization.py
+++ b/doc/examples/scripts/structure/peoe_visualization.py
@@ -77,7 +77,7 @@ ball_sizes = np.array(
 
 # Gradient of ray strength
 # The ray size is proportional to the absolute charge value
-ray_full_sizes = ball_sizes + np.abs(charges) * RAY_SCALE   
+ray_full_sizes = ball_sizes + np.abs(charges) * RAY_SCALE
 ray_sizes = np.array([
     np.linspace(ray_full_sizes[i], ball_sizes[i], N_RAY_STEPS, endpoint=False)
     for i in range(molecule.array_length())
@@ -104,7 +104,7 @@ for atom in molecule:
         ha="center", va="center", zorder=100
     )
 
-# Plots the rays
+# Plot the rays
 for i in range(N_RAY_STEPS):
     ax.scatter(
         *molecule.coord.T, s=ray_sizes[i]**2, c=colors,
@@ -112,10 +112,13 @@ for i in range(N_RAY_STEPS):
     )
 
 # Plot the colorbar
-color_bar = fig.colorbar(ScalarMappable(
-    norm=Normalize(vmin=-max_charge, vmax=max_charge),
-    cmap=color_map
-))
+color_bar = fig.colorbar(
+    ScalarMappable(
+        norm=Normalize(vmin=-max_charge, vmax=max_charge),
+        cmap=color_map
+    ),
+    ax=ax
+)
 color_bar.set_label("Partial charge (e)", color="white")
 color_bar.ax.yaxis.set_tick_params(color="white")
 color_bar.outline.set_edgecolor("white")

--- a/src/biotite/visualize.py
+++ b/src/biotite/visualize.py
@@ -35,7 +35,7 @@ def set_font_size_in_coord(text, width=None, height=None, mode="unlocked"):
     Instead of having the font size fixed in 'pt', the size of the text
     scales to the specied width/height and adapts to changes in the
     plot's width/height.
-    The scaling can be proportional or non-proportional, depending 
+    The scaling can be proportional or non-proportional, depending
     the `mode`.
 
     Parameters
@@ -75,7 +75,7 @@ def set_font_size_in_coord(text, width=None, height=None, mode="unlocked"):
     This behavior is not equal for all initial font sizes (in 'pt'),
     the boundaries for an initial size of 1 'pt' seem to be most exact.
     """
-    from matplotlib.transforms import Bbox
+    from matplotlib.transforms import Bbox, Affine2D
     from matplotlib.patheffects import AbstractPathEffect
 
     class TextScaler(AbstractPathEffect):
@@ -98,7 +98,7 @@ def set_font_size_in_coord(text, width=None, height=None, mode="unlocked"):
                 raise
             bbox = text.get_window_extent(renderer)
             bbox = Bbox(ax.transData.inverted().transform(bbox))
-            
+
             if self._mode == "proportional":
                 if self._width is None:
                     # Proportional scaling based on height
@@ -122,9 +122,9 @@ def set_font_size_in_coord(text, width=None, height=None, mode="unlocked"):
                 scale = min(scale_x, scale_y)
                 scale_x, scale_y = scale, scale
 
-            affine = affine.identity().scale(scale_x, scale_y) + affine
+            affine = Affine2D().scale(scale_x, scale_y) + affine
             renderer.draw_path(gc, tpath, affine, rgbFace)
-    
+
     if mode in ["unlocked", "minimum", "maximum"]:
         if width is None or height is None:
             raise TypeError(
@@ -146,8 +146,6 @@ try:
     # Only create this class when matplotlib is installed
     from matplotlib.transforms import Bbox
     from matplotlib.patches import FancyArrow
-    from matplotlib.patheffects import AbstractPathEffect
-    import matplotlib.pyplot as plt
 
     class AdaptiveFancyArrow(FancyArrow):
         """
@@ -178,7 +176,7 @@ try:
             Other parameters that are used in the constructor of
             `FancyArrow`.
         """
-        
+
         def __init__(self, x, y, dx, dy,
                      tail_width, head_width, head_ratio, draw_head=True,
                      shape="full", **kwargs):
@@ -219,7 +217,7 @@ try:
                 # only draw the arrow head with reduced length
                 head_length = arrow_length
             if not self._draw_head:
-                head_length = 0 
+                head_length = 0
 
             # Renew the arrow's properties
             super().__init__(
@@ -231,7 +229,7 @@ try:
             )
             self.set_clip_path(self.axes.patch)
             super().draw(renderer)
-        
+
         # Override to replace docstring
         # Removes warning:
         # unknown document: /tutorials/intermediate/constrainedlayout_guide
@@ -245,7 +243,7 @@ try:
             return super().set_in_layout(in_layout)
 
 except ImportError:
-    
+
     # Dummy class that propagates a meaningful error,
     # i.e. that Matplotlib is not installed
     class AdaptiveFancyArrow():


### PR DESCRIPTION
This PR addresses the changes in Matplotlib API in recent version:

- It replaces the `Transform.identity()` function when scaled letters (e.g. in a sequence logo) are plotted.
- It removes usage of deprecated Matplotlib functionalities in the example gallery.