### PR TITLE
Fix ignored image scrapers in gallery

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -164,7 +164,7 @@ sphinx_gallery_conf = {
     "doc_module"                : ("biotite",),
     # Set the NCBI API key
     "reset_modules"             : (key.set_ncbi_api_key_from_env,),
-    "remove_config_comments": True,
+    "remove_config_comments"    : False,
 }
 
 


### PR DESCRIPTION
Currently the custom image scrapers do not work, as the config comments triggering them are filtered out automatically. This PR temporarily disables config comment removal until a better solution is found.