### PR TITLE
Restrict NumPy to 1.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   # Biotite dependencies
   - msgpack-python >=0.5.6
   - networkx >=2.0
-  - numpy >=1.15
+  - numpy >=1.15, <2.0
   - requests >=2.12
   # Testing
   - mdtraj >=1.9.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 # this should be manually updated as the minimum python version increases
 dependencies = [
   "requests >= 2.12",
-  "numpy >= 1.14.5",
+  "numpy >= 1.14.5, <= 2.0",
   "msgpack >= 0.5.6",
   "networkx >= 2.0",
 ]


### PR DESCRIPTION
Following the recommendation in https://github.com/numpy/numpy/issues/24300, the NumPy version is restricted to 1.x, as NumPy 2.0 will be published soon introducing some incompatibilities. In a second step Biotite will be prepared for NumPy 2.0 in #529.