### PR TITLE
Put CCD subset under regular Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 tests/structure/data/* linguist-vendored
 tests/sequence/data/* linguist-vendored
 src/biotite/sequence/align/matrix_data/* linguist-vendored
-src/biotite/structure/info/ccd/components.bcif filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -38,8 +38,6 @@ jobs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
       - name: Install cibuildwheel
         # MAKE SURE THIS STAYS IN SYNC WITH THE LOWER GHA cibuildwheel
         run: pipx install cibuildwheel==2.16.5
@@ -75,8 +73,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
 
       # QEMU enables building/testing for non-native architectures (ie arm64)
       # at the cost of speed
@@ -108,8 +104,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
       - uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: environment.yml
@@ -145,8 +139,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: biotite-dev
@@ -168,8 +160,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        lfs: true
     - name: Build source distribution
       run: pipx run build --sdist
     - uses: actions/upload-artifact@v3
@@ -190,8 +180,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        lfs: true
     - uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -168,6 +168,39 @@ jobs:
         path: dist//*.tar.gz
 
 
+  make-ccd:
+    name: Compile the CCD subset for structure.info from the wwPDB CCD
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: biotite-dev
+        miniforge-variant: Mambaforge
+        python-version: "3.10"
+        channels: conda-forge,defaults
+    - name: Build distribution
+      run: pip wheel -w dist .
+    - name: Install distribution
+      run: pip install .//dist//*.whl pytest
+    - name: Compile CCD subset
+      run: python setup_ccd.py
+    - name: Zip CCD
+      run: |
+          cd src/biotite/structure/info
+          zip -r ${{ github.workspace }}//dist//ccd.zip ccd
+          cd ${{ github.workspace }}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ccd
+        path: dist//ccd.zip
+
+
   make-docs:
     name: Build documentation
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -76,16 +76,6 @@ Install from source
 
 You can also install Biotite from the
 `project repository <https://github.com/biotite-dev/biotite>`_.
-The repository uses `Git LFS <https://git-lfs.com/>`_ to store large binary
-files, which needs to be installed first.
-
-.. note::
-   In case installing *Git LFS* is not an option: The binary file can also be
-   downloaded manually from
-   `here <https://github.com/biotite-dev/biotite/raw/info/src/biotite/structure/info/ccd/components.bcif>`.
-   Then the ``biotite/structure/info/ccd/components.bcif`` file in the
-   repository needs to be replaced with the downloaded file.
-
 After cloning the repository, navigate to its top-level directory (the one
 ``setup.py`` is in) and type the following:
 
@@ -100,6 +90,20 @@ Type the following in the top-level directory:
 .. code-block:: console
 
    $ pip install -e .
+
+Updating the Chemical Component Dictionary
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :mod:`biotite.structure.info` subpackage contains a subset from the
+`PDB Chemical Component Dictionary (CCD) <https://www.wwpdb.org/data/ccd>`_.
+The repository ships a potentially outdated version of this subset.
+To update this subset to the current upstream CCD version, run
+
+.. code-block:: console
+
+   $ python setup_ccd.py
+
+Afterwards, install *Biotite* again.
 
 
 Common issues and solutions

--- a/src/biotite/structure/charges.pyx
+++ b/src/biotite/structure/charges.pyx
@@ -17,7 +17,7 @@ from libc.math cimport isnan
 
 import warnings
 import numpy as np
-from biotite.structure import BondType
+from .bonds import BondType
 
 
 ctypedef np.float32_t float32

--- a/src/biotite/structure/charges.pyx
+++ b/src/biotite/structure/charges.pyx
@@ -12,14 +12,12 @@ __name__ = "biotite.structure"
 __author__ = "Jacob Marcel Anter, Patrick Kunzmann"
 __all__ = ["partial_charges"]
 
-cimport cython
 cimport numpy as np
 from libc.math cimport isnan
 
 import warnings
 import numpy as np
-from .info import residue
-from biotite.structure import AtomArray, BondType
+from biotite.structure import BondType
 
 
 ctypedef np.float32_t float32
@@ -99,7 +97,7 @@ cdef dict EN_PARAM_BTYPE = {
 
     "I": {
         int(BondType.SINGLE):   (9.90, 7.96, 0.96)
-    }        
+    }
 }
 
 cdef dict EN_PARAM_BPARTNERS = {
@@ -176,7 +174,7 @@ def _get_parameters(elements, bond_types, amount_of_binding_partners):
     amount_of_binding_partners: ndarray, dtype=int
         The array containing information about the amount of binding
         partners of the respective atom.
-    
+
     Returns
     -------
     parameters: NumPy array, dtype=float, shape=(n,3)
@@ -274,7 +272,7 @@ def _get_parameters(elements, bond_types, amount_of_binding_partners):
                     )
                     has_valence_key_error = True
                 parameters_v[i, :] = np.nan
-    
+
 
     # Error and warning handling
     if np.all(bond_types == BondType.ANY):
@@ -334,7 +332,7 @@ def _get_parameters(elements, bond_types, amount_of_binding_partners):
             f"Parameters required for computation of "
             f"electronegativity aren't available for the following "
             f"atoms: {', '.join(unique_list)}. "
-            f"Their electronegativity is given as NaN.", 
+            f"Their electronegativity is given as NaN.",
             UserWarning
         )
 
@@ -359,7 +357,7 @@ def partial_charges(atom_array, int iteration_step_num=6, charges=None):
         The :class:`AtomArray` to get the partial charge values for.
         Must have an associated `BondList`.
     iteration_step_num: int, optional
-        The number of iteration steps is an optional argument and can be 
+        The number of iteration steps is an optional argument and can be
         chosen by the user depending on the desired precision of the
         result. If no value is entered by the user, the default value
         ``6`` will be used.
@@ -371,13 +369,13 @@ def partial_charges(atom_array, int iteration_step_num=6, charges=None):
         input `atom_array` is used.
         If neither of them is given, the formal charges of all atoms
         will be arbitrarily set to zero.
-    
+
     Returns
     -------
     charges: ndarray, dtype=float32
         The partial charge values of the individual atoms in the input
         `atom_array`.
-    
+
     Notes
     -----
     A :class:`BondList` must be associated to the input
@@ -399,7 +397,7 @@ def partial_charges(atom_array, int iteration_step_num=6, charges=None):
 
     References
     ----------
-    
+
     .. footbibliography::
 
     Examples
@@ -418,7 +416,7 @@ def partial_charges(atom_array, int iteration_step_num=6, charges=None):
             f"The input AtomArray doesn't possess an associated "
             f"BondList."
         )
-    
+
     if charges is None:
         try:
             # Implicitly this creates a copy of the charges
@@ -473,11 +471,11 @@ def partial_charges(atom_array, int iteration_step_num=6, charges=None):
     cdef float32[:] en_values_v
 
     for _ in range(iteration_step_num):
-        # In the beginning of each iteration step, the damping factor is 
+        # In the beginning of each iteration step, the damping factor is
         # halved in order to guarantee rapid convergence
         damping *= 0.5
         # Calculate electronegativity via vectorization:
-        # X = a + bQ + cQ^2 
+        # X = a + bQ + cQ^2
         charge_factor = np.stack((
             np.ones(atom_array.array_length()),
             charges,

--- a/src/biotite/structure/info/atoms.py
+++ b/src/biotite/structure/info/atoms.py
@@ -6,7 +6,6 @@ __name__ = "biotite.structure.info"
 __author__ = "Patrick Kunzmann"
 __all__ = ["residue"]
 
-from ..io.pdbx import get_component
 from .ccd import get_ccd
 
 
@@ -70,6 +69,9 @@ def residue(res_name):
      ['CB' 'HB3']
      ['OXT' 'HXT']]
     """
+    # Avoid circular import
+    from ..io.pdbx import get_component
+
     component = get_component(get_ccd(), res_name=res_name)
     component.hetero[:] = res_name not in non_hetero_residues
     return component

--- a/src/biotite/structure/info/ccd.py
+++ b/src/biotite/structure/info/ccd.py
@@ -8,7 +8,6 @@ __all__ = ["get_ccd", "get_from_ccd"]
 
 from pathlib import Path
 import numpy as np
-from ..io.pdbx.bcif import BinaryCIFFile
 
 
 CCD_DIR = Path(__file__).parent / "ccd"
@@ -32,6 +31,9 @@ def get_ccd():
     ccd : BinaryCIFFile
         The CCD.
     """
+    # Avoid circular import
+    from ..io.pdbx.bcif import BinaryCIFFile
+
     global _ccd_block
     if _ccd_block is None:
         # Load CCD once and cache it for subsequent calls

--- a/src/biotite/structure/info/ccd/README.rst
+++ b/src/biotite/structure/info/ccd/README.rst
@@ -1,3 +1,8 @@
 These files are based on the
 `Chemical Component Dictionary <https://www.wwpdb.org/data/ccd>`_
 and were created using ``setup_ccd.py``.
+
+To keep the size of the repository small, the original commit should be
+rewritten, if the formats of the affected files are compatible with the
+original ones.
+The name of the commit is ``Add CCD dataset``.

--- a/src/biotite/structure/io/ctab.py
+++ b/src/biotite/structure/io/ctab.py
@@ -13,7 +13,7 @@ __all__ = ["read_structure_from_ctab", "write_structure_to_ctab"]
 
 import warnings
 import numpy as np
-from biotite.structure.error import BadStructureError
+from ..error import BadStructureError
 from ..atoms import AtomArray, AtomArrayStack
 from ..bonds import BondList, BondType
 


### PR DESCRIPTION
As explained in #541 and #542, these efforts to implement #530 brought more problems than benefits. Hence, the CCD will be put under regular Git version control again (as opposed to LFS) and a periodic update of the CCD will not be implemented.