### PR TITLE
Allow chain IDs with more than one character in PDB structures

### DIFF
--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -612,7 +612,7 @@ class PDBFile(TextFile):
         if np.isnan(array.coord).any():
             raise BadStructureError("Coordinates contain 'NaN' values")
         if any([len(name) > 1 for name in array.chain_id]):
-            raise BadStructureError("Some chain IDs exceed 1 character")
+            warnings.warn("Some chain IDs exceed 1 character")
         if any([len(name) > 3 for name in array.res_name]):
             raise BadStructureError("Some residue names exceed 3 characters")
         if any([len(name) > 4 for name in array.atom_name]):

--- a/src/biotite/structure/io/pdbqt/file.py
+++ b/src/biotite/structure/io/pdbqt/file.py
@@ -363,7 +363,7 @@ class PDBQTFile(TextFile):
         if np.isnan(atoms.coord).any():
             raise BadStructureError("Coordinates contain 'NaN' values")
         if any([len(name) > 1 for name in atoms.chain_id]):
-            raise BadStructureError("Some chain IDs exceed 1 character")
+            warnings.warn("Some chain IDs exceed 1 character")
         if any([len(name) > 3 for name in atoms.res_name]):
             raise BadStructureError("Some residue names exceed 3 characters")
         if any([len(name) > 4 for name in atoms.atom_name]):


### PR DESCRIPTION
Chain IDs with more than one character do exist in deposited PDB structures and therefore should be allowed in the library.