### PR TITLE
Implement NEP 29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biotite"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 description = "A comprehensive library for computational molecular biology"
 readme = "README.rst"
 authors = [{name = "The Biotite contributors"}]


### PR DESCRIPTION
This PR restricts the required Python version to the scheme presented in [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).