### PR TITLE
Return empty dot bracket notation when no basepairs are found

### DIFF
--- a/src/biotite/structure/dotbracket.py
+++ b/src/biotite/structure/dotbracket.py
@@ -57,6 +57,8 @@ def dot_bracket_from_structure(
     .. footbibliography::
     """
     basepairs = base_pairs(nucleic_acid_strand)
+    if len(base_pairs) == 0:
+        return ['']
     basepairs = get_residue_positions(nucleic_acid_strand, basepairs)
     length = get_residue_count(nucleic_acid_strand)
     return dot_bracket(basepairs, length, scores=scores,

--- a/src/biotite/structure/dotbracket.py
+++ b/src/biotite/structure/dotbracket.py
@@ -57,7 +57,7 @@ def dot_bracket_from_structure(
     .. footbibliography::
     """
     basepairs = base_pairs(nucleic_acid_strand)
-    if len(base_pairs) == 0:
+    if len(basepairs) == 0:
         return ['']
     basepairs = get_residue_positions(nucleic_acid_strand, basepairs)
     length = get_residue_count(nucleic_acid_strand)


### PR DESCRIPTION
This PR fixes #556.

If no base pairs are found in `biotite.structure.base_pairs()`, `biotite.structure.dot_bracket_from_structure()` now returns a single empty string.