### PR TITLE
Get 4x4 transformation matrix from `AffineTransform`

### DIFF
--- a/src/biotite/structure/superimpose.py
+++ b/src/biotite/structure/superimpose.py
@@ -60,10 +60,43 @@ class AffineTransformation:
             with transformations applied.
             Only coordinates are returned, if coordinates were given in
             `atoms`.
+
+        Examples
+        --------
+
+        >>> coord = np.arange(15).reshape(5,3)
+        >>> print(coord)
+        [[ 0  1  2]
+         [ 3  4  5]
+         [ 6  7  8]
+         [ 9 10 11]
+         [12 13 14]]
+        >>> # Rotates 90 degrees around the z-axis
+        >>> transform = AffineTransformation(
+        ...     center_translation=np.array([0,0,0]),
+        ...     rotation=np.array([
+        ...         [0, -1,  0],
+        ...         [1,  0,  0],
+        ...         [0,  0,  1]
+        ...     ]),
+        ...     target_translation=np.array([0,0,0])
+        ... )
+        >>> print(transform.apply(coord))
+        [[ -1.   0.   2.]
+         [ -4.   3.   5.]
+         [ -7.   6.   8.]
+         [-10.   9.  11.]
+         [-13.  12.  14.]]
+
         """
         mobile_coord = coord(atoms)
         original_shape = mobile_coord.shape
         mobile_coord = _reshape_to_3d(mobile_coord)
+        if mobile_coord.shape[0] != self.rotation.shape[0]:
+            raise IndexError(
+                f"Number of transformations is {self.rotation.shape[0]}, "
+                f"but number of structure models is {mobile_coord.shape[0]}"
+            )
 
         superimposed_coord = mobile_coord.copy()
         superimposed_coord += self.center_translation[:, np.newaxis, :]
@@ -77,6 +110,93 @@ class AffineTransformation:
             superimposed = atoms.copy()
             superimposed.coord = superimposed_coord
             return superimposed
+
+
+    def as_matrix(self):
+        """
+        Get the translations and rotation as a combined 4x4
+        transformation matrix.
+
+        Multiplying this matrix with coordinates in the form
+        *(x, y, z, 1)* will apply the same transformation as
+        :meth:`apply()` to coordinates in the form *(x, y, z)*.
+
+        Returns
+        -------
+        transformation_matrix : ndarray, shape=(m,4,4), dtype=float
+            The transformation matrix.
+            *m* is the number of models in the transformation.
+
+        Examples
+        --------
+
+        >>> coord = np.arange(15).reshape(5,3)
+        >>> print(coord)
+        [[ 0  1  2]
+         [ 3  4  5]
+         [ 6  7  8]
+         [ 9 10 11]
+         [12 13 14]]
+        >>> # Rotates 90 degrees around the z-axis
+        >>> transform = AffineTransformation(
+        ...     center_translation=np.array([0,0,0]),
+        ...     rotation=np.array([
+        ...         [0, -1,  0],
+        ...         [1,  0,  0],
+        ...         [0,  0,  1]
+        ...     ]),
+        ...     target_translation=np.array([0,0,0])
+        ... )
+        >>> print(transform.apply(coord))
+        [[ -1.   0.   2.]
+         [ -4.   3.   5.]
+         [ -7.   6.   8.]
+         [-10.   9.  11.]
+         [-13.  12.  14.]]
+        >>> # Use a 4x4 matrix for transformation as alternative
+        >>> coord_4 = np.concatenate([coord, np.ones((len(coord), 1))], axis=-1)
+        >>> print(coord_4)
+        [[ 0.  1.  2.  1.]
+         [ 3.  4.  5.  1.]
+         [ 6.  7.  8.  1.]
+         [ 9. 10. 11.  1.]
+         [12. 13. 14.  1.]]
+        >>> print((transform.as_matrix()[0] @ coord_4.T).T)
+        [[ -1.   0.   2.   1.]
+         [ -4.   3.   5.   1.]
+         [ -7.   6.   8.   1.]
+         [-10.   9.  11.   1.]
+         [-13.  12.  14.   1.]]
+
+        """
+        n_models = self.rotation.shape[0]
+        rotation_mat = _3d_identity(n_models, 4)
+        rotation_mat[:, :3, :3] = self.rotation
+        center_translation_mat = _3d_identity(n_models, 4)
+        center_translation_mat[:, :3, 3] = self.center_translation
+        target_translation_mat = _3d_identity(n_models, 4)
+        target_translation_mat[:, :3, 3] = self.target_translation
+        return target_translation_mat @ rotation_mat @ center_translation_mat
+
+
+def _expand_dims(array, n_dims):
+    """
+    Expand the dimensions of an `ndarray` to a certain number of
+    dimensions.
+    """
+    while array.ndim < n_dims:
+        array = array[np.newaxis, ...]
+    return array
+
+
+def _3d_identity(m, n):
+    """
+    Create an array of *m* identity matrices of shape *(n, n)*
+    """
+    matrices = np.zeros((m, n, n), dtype=float)
+    indices = np.arange(n)
+    matrices[:, indices, indices] = 1
+    return matrices
 
 
 def superimpose(fixed, mobile, atom_mask=None):

--- a/src/biotite/structure/superimpose.py
+++ b/src/biotite/structure/superimpose.py
@@ -35,11 +35,13 @@ class AffineTransformation:
     ----------
     center_translation, rotation, target_translation : ndarray
         Same as the parameters.
+        The dimensions are always expanded to *(m,3)* or *(m,3,3)*,
+        respectively.
     """
     def __init__(self, center_translation, rotation, target_translation):
-        self.center_translation = center_translation
-        self.rotation = rotation
-        self.target_translation = target_translation
+        self.center_translation = _expand_dims(center_translation, 2)
+        self.rotation = _expand_dims(rotation, 3)
+        self.target_translation = _expand_dims(target_translation, 2)
 
 
     def apply(self, atoms):

--- a/tests/structure/test_superimpose.py
+++ b/tests/structure/test_superimpose.py
@@ -11,7 +11,39 @@ import pytest
 import biotite.structure as struc
 import biotite.structure.io as strucio
 import biotite.structure as struc
+from biotite.structure.superimpose import _multi_matmul as multi_matmul
 from ..util import data_dir
+
+
+def test_transform_as_matrix():
+    """
+    Check if the 4x4 matrix obtained from
+    :meth:`AffineTransformation.as_matrix()` transforms coordinates in
+    the same way as :meth:`AffineTransformation.apply()`.
+    """
+    N_MODELS = 10
+    N_COORD = 100
+
+    np.random.seed(0)
+    orig_coord = np.random.rand(N_MODELS, N_COORD, 3)
+    transform = struc.AffineTransformation(
+        center_translation=np.random.rand(N_MODELS, 3),
+        # This is not really a rotation matrix,
+        # but the same maths apply
+        rotation=np.random.rand(N_MODELS, 3, 3),
+        target_translation=np.random.rand(N_MODELS, 3)
+    )
+
+    ref_coord = transform.apply(orig_coord)
+
+    orig_coord_4 = np.concatenate(
+        [orig_coord, np.ones((N_MODELS, N_COORD, 1))], axis=-1
+    )
+    test_coord_4 = multi_matmul(transform.as_matrix(), orig_coord_4)
+    test_coord = test_coord_4[..., :3]
+
+    assert test_coord.flatten().tolist() \
+        == pytest.approx(ref_coord.flatten().tolist(), abs=1e-6)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds the method `AffineTransform.get_matrix()` which allows getting the the superimposition transformation as 4x4 matrix.