### PR TITLE
Add repair functions

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -286,7 +286,8 @@
         ],
         "Repair" : [
             "renumber_atom_ids",
-            "renumber_res_ids"
+            "renumber_res_ids",
+            "create_continuous_res_ids"
         ],
         "Residue level utility" : [
             "get_residue_starts",

--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -287,7 +287,8 @@
         "Repair" : [
             "renumber_atom_ids",
             "renumber_res_ids",
-            "create_continuous_res_ids"
+            "create_continuous_res_ids",
+            "infer_elements"
         ],
         "Residue level utility" : [
             "get_residue_starts",

--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -284,6 +284,10 @@
             "check_bond_continuity",
             "check_linear_continuity"
         ],
+        "Repair" : [
+            "renumber_atom_ids",
+            "renumber_res_ids"
+        ],
         "Residue level utility" : [
             "get_residue_starts",
             "get_residues",

--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -120,6 +120,7 @@ from .mechanics import *
 from .molecules import *
 from .pseudoknots import *
 from .rdf import *
+from .repair import *
 from .residues import *
 from .chains import *
 from .sasa import *

--- a/src/biotite/structure/integrity.py
+++ b/src/biotite/structure/integrity.py
@@ -12,7 +12,7 @@ __author__ = "Patrick Kunzmann, Daniel Bauer"
 __all__ = ["check_id_continuity", "check_atom_id_continuity",
            "check_res_id_continuity", "check_backbone_continuity",
            "check_duplicate_atoms", "check_bond_continuity",
-           "check_linear_continuity", "renumber_atom_ids", "renumber_res_ids"]
+           "check_linear_continuity"]
 
 import numpy as np
 import warnings
@@ -32,17 +32,17 @@ def check_id_continuity(array):
     """
     Check if the residue IDs are incremented by more than 1 or
     decremented, from one atom to the next one.
-    
+
     An increment by more than 1 is as strong clue for missing residues,
     a decrement means probably a start of a new chain.
 
     DEPRECATED: Use :func:`check_res_id_continuity()` instead.
-    
+
     Parameters
     ----------
     array : AtomArray or AtomArrayStack
         The array to be checked.
-    
+
     Returns
     -------
     discontinuity : ndarray, dtype=int
@@ -60,14 +60,14 @@ def check_atom_id_continuity(array):
     """
     Check if the atom IDs are incremented by more than 1 or
     decremented, from one atom to the next one.
-    
+
     An increment by more than 1 is as strong clue for missing atoms.
-    
+
     Parameters
     ----------
     array : AtomArray or AtomArrayStack
         The array to be checked.
-    
+
     Returns
     -------
     discontinuity : ndarray, dtype=int
@@ -81,15 +81,15 @@ def check_res_id_continuity(array):
     """
     Check if the residue IDs are incremented by more than 1 or
     decremented, from one atom to the next one.
-    
+
     An increment by more than 1 is as strong clue for missing residues,
     a decrement means probably a start of a new chain.
-    
+
     Parameters
     ----------
     array : AtomArray or AtomArrayStack
         The array to be checked.
-    
+
     Returns
     -------
     discontinuity : ndarray, dtype=int
@@ -168,7 +168,7 @@ def check_backbone_continuity(array, min_len=1.2, max_len=1.8):
     """
     Check if the (peptide or phosphate) backbone atoms have
     non-reasonable distance to the next atom.
-    
+
     A large or very small distance is a very strong clue, that there is
     no bond between those atoms, therefore the chain is discontinued.
 
@@ -206,16 +206,16 @@ def check_duplicate_atoms(array):
     """
     Check if a structure contains duplicate atoms, i.e. two atoms in a
     structure have the same annotations (coordinates may be different).
-    
+
     Duplicate atoms may appear, when a structure has occupancy for an
     atom at two or more positions or when the *altloc* positions are
     improperly read.
-    
+
     Parameters
     ----------
     array : AtomArray or AtomArrayStack
         The array to be checked.
-    
+
     Returns
     -------
     duplicate : ndarray, dtype=int
@@ -232,7 +232,7 @@ def check_duplicate_atoms(array):
         for annot in annots:
             # For each annotation array filter out the atoms until
             # index i that have an unequal annotation
-            # to the atom at index i 
+            # to the atom at index i
             is_dublicate &= (annot[:i] == annot[i])
         # After checking all annotation arrays,
         # if there still is any duplicate to the atom at index i,
@@ -255,7 +255,7 @@ def check_in_box(array):
     ----------
     array : AtomArray or AtomArrayStack
         The array to be checked.
-    
+
     Returns
     -------
     outside : ndarray, dtype=int
@@ -266,54 +266,3 @@ def check_in_box(array):
     box = array.box
     fractions = coord_to_fraction(array, box)
     return np.where(((fractions >= 0) & (fractions < 1)).all(axis=-1))[0]
-
-
-def renumber_atom_ids(array, start=None):
-    """
-    Renumber the atom IDs of the given array.
-
-    Parameters
-    ----------
-    array : AtomArray or AtomArrayStack
-        The array to be checked.
-    start : int, optional
-        The starting index for renumbering.
-        The first ID in the array is taken by default.
-
-    Returns
-    -------
-    array : AtomArray or AtomArrayStack
-        The renumbered array.
-    """
-    if "atom_id" not in array.get_annotation_categories():
-        raise ValueError("The atom array must have the 'atom_id' annotation")
-    if start is None:
-        start = array.atom_id[0]
-    array.atom_id = np.arange(start, array.shape[-1]+1)
-    return array
-    
-
-def renumber_res_ids(array, start=None):
-    """
-    Renumber the residue IDs of the given array.
-
-    Parameters
-    ----------
-    array : AtomArray or AtomArrayStack
-        The array to be checked.
-    start : int, optional
-        The starting index for renumbering.
-        The first ID in the array is taken by default.
-    
-    Returns
-    -------
-    array : AtomArray or AtomArrayStack
-        The renumbered array.
-    """
-    if start is None:
-        start = array.res_id[0]
-    diff = np.diff(array.res_id)
-    diff[diff != 0] = 1
-    new_res_ids =  np.concatenate(([start], diff)).cumsum()
-    array.res_id = new_res_ids
-    return array

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -13,7 +13,7 @@ __all__ = ["load_structure", "save_structure"]
 
 import os.path
 import io
-from ..atoms import AtomArray, AtomArrayStack
+from ..atoms import AtomArrayStack
 
 
 def load_structure(file_path, template=None, **kwargs):
@@ -224,42 +224,3 @@ def _as_single_model_if_possible(atoms):
         return atoms[0]
     else:
         return atoms
-
-
-# Helper function to estimate elements from atom names
-_elements = [elem.upper() for elem in
-["H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na", "Mg",
-"Al", "Si", "P", "S", "Cl", "Ar", "K", "Ca", "Sc", "Ti", "V", "Cr", "Mn", "Fe",
-"Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y",
-"Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Te",
-"I", "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb",
-"Dy", "Ho", "Er", "Tm", "Yb", "Lu", "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt",
-"Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th", "Pa",
-"U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr", "Rf",
-"Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn", "Nh", "Fl", "Mc", "Lv", "Ts",
-"Og"]
-]
-def _guess_element(atom_name):
-    # remove digits (1H -> H)
-    elem = "".join([i for i in atom_name if not i.isdigit()])
-    elem = elem.upper()
-    if len(elem) == 0:
-        return ""
-
-    # Some often used elements for biomolecules
-    if elem.startswith("C") or elem.startswith("N") or \
-        elem.startswith("O") or elem.startswith("S") or \
-        elem.startswith("H"):
-        return elem[0]
-
-    # Exactly match element abbreviations
-    try:
-        return _elements[_elements.index(elem[:2])]
-    except ValueError:
-        try:
-            return _elements[_elements.index(elem[0])]
-        except ValueError:
-            pass
-
-    return ""
-

--- a/src/biotite/structure/repair.py
+++ b/src/biotite/structure/repair.py
@@ -10,12 +10,15 @@ __name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = ["renumber_atom_ids", "renumber_res_ids"]
 
+import warnings
 import numpy as np
 
 
 def renumber_atom_ids(array, start=None):
     """
     Renumber the atom IDs of the given array.
+
+    DEPRECATED.
 
     Parameters
     ----------
@@ -30,6 +33,10 @@ def renumber_atom_ids(array, start=None):
     array : AtomArray or AtomArrayStack
         The renumbered array.
     """
+    warnings.warn(
+      "'renumber_atom_ids()' is deprecated",
+        DeprecationWarning
+    )
     if "atom_id" not in array.get_annotation_categories():
         raise ValueError("The atom array must have the 'atom_id' annotation")
     if start is None:
@@ -43,6 +50,8 @@ def renumber_res_ids(array, start=None):
     """
     Renumber the residue IDs of the given array, so that are continuous.
 
+    DEPRECATED.
+
     Parameters
     ----------
     array : AtomArray or AtomArrayStack
@@ -56,6 +65,10 @@ def renumber_res_ids(array, start=None):
     array : AtomArray or AtomArrayStack
         The renumbered array.
     """
+    warnings.warn(
+      "'renumber_res_ids()' is deprecated",
+        DeprecationWarning
+    )
     if start is None:
         start = array.res_id[0]
     diff = np.diff(array.res_id)

--- a/src/biotite/structure/repair.py
+++ b/src/biotite/structure/repair.py
@@ -1,0 +1,66 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+"""
+This module contains functionalities for repairing malformed structures.
+"""
+
+__name__ = "biotite.structure"
+__author__ = "Patrick Kunzmann"
+__all__ = ["renumber_atom_ids", "renumber_res_ids"]
+
+import numpy as np
+
+
+def renumber_atom_ids(array, start=None):
+    """
+    Renumber the atom IDs of the given array.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The array to be checked.
+    start : int, optional
+        The starting index for renumbering.
+        The first ID in the array is taken by default.
+
+    Returns
+    -------
+    array : AtomArray or AtomArrayStack
+        The renumbered array.
+    """
+    if "atom_id" not in array.get_annotation_categories():
+        raise ValueError("The atom array must have the 'atom_id' annotation")
+    if start is None:
+        start = array.atom_id[0]
+    array = array.copy()
+    array.atom_id = np.arange(start, array.shape[-1]+1)
+    return array
+
+
+def renumber_res_ids(array, start=None):
+    """
+    Renumber the residue IDs of the given array, so that are continuous.
+
+    Parameters
+    ----------
+    array : AtomArray or AtomArrayStack
+        The array to be checked.
+    start : int, optional
+        The starting index for renumbering.
+        The first ID in the array is taken by default.
+
+    Returns
+    -------
+    array : AtomArray or AtomArrayStack
+        The renumbered array.
+    """
+    if start is None:
+        start = array.res_id[0]
+    diff = np.diff(array.res_id)
+    diff[diff != 0] = 1
+    new_res_ids =  np.concatenate(([start], diff)).cumsum()
+    array = array.copy()
+    array.res_id = new_res_ids
+    return array

--- a/tests/structure/test_generalio.py
+++ b/tests/structure/test_generalio.py
@@ -5,7 +5,6 @@
 from tempfile import NamedTemporaryFile
 import biotite.structure as struc
 import biotite.structure.io as strucio
-from biotite.structure.io.general import _guess_element
 import glob
 import os
 from os.path import join, splitext
@@ -173,32 +172,3 @@ def test_small_molecule():
     os.remove(temp.name)
 
     assert test_array == ref_array
-
-
-@pytest.mark.parametrize(
-    "name,expected",
-    [("CA", "C"),
-     ("C", "C"),
-     ("CB", "C"),
-     ("OD1", "O"),
-     ("HD21", "H"),
-     ("1H", "H"),
-     ("CL", "C"),
-     ("HE", "H"),
-     ("SD", "S"),
-     ("NA", "N"),
-     ("NX", "N"),
-     ("BE", "BE"),
-     ("BEA", "BE"),
-     ("K", "K"),
-     ("KA", "K"),
-     ("QWERT", "")]
-)
-def test_guess_element(name, expected):
-    """
-    Check if elements are correctly guessed based on known examples.
-    Elements are automatically guessed in GRO and PDB files where the
-    *element* column is missing.
-    """
-    result = _guess_element(name)
-    assert result == expected

--- a/tests/structure/test_integrity.py
+++ b/tests/structure/test_integrity.py
@@ -3,7 +3,7 @@
 # information.
 
 import biotite.structure as struc
-import biotite.structure.io.npz as npz
+import biotite.structure.io.pdbx as pdbx
 import numpy as np
 from os.path import join
 from ..util import data_dir
@@ -12,8 +12,10 @@ import pytest
 
 @pytest.fixture
 def sample_array():
-    file = npz.NpzFile.read(join(data_dir("structure"), "1l2y.npz"))
-    return file.get_structure()[0]
+    pdbx_file = pdbx.BinaryCIFFile.read(
+        join(data_dir("structure"), "1l2y.bcif")
+    )
+    return pdbx.get_structure(pdbx_file, model=1)
 
 @pytest.fixture
 def gapped_sample_array(sample_array):
@@ -63,15 +65,3 @@ def test_bond_continuity_check(gapped_sample_array):
 def test_duplicate_atoms_check(duplicate_sample_array):
     discon = struc.check_duplicate_atoms(duplicate_sample_array)
     assert discon.tolist() == [42,234]
-
-def test_renum_res_ids(gapped_sample_array): 
-    renumbered_array = struc.renumber_res_ids(gapped_sample_array)
-    # if renumbering was successful, this should not raise
-    with pytest.raises(AssertionError):
-        test_res_id_continuity_check(renumbered_array)
-
-def test_renum_atom_ids(gapped_sample_array):
-    renumbered_array = struc.renumber_atom_ids(gapped_sample_array)
-    # if renumbering was successful, this should not raise
-    with pytest.raises(AssertionError):
-        test_atom_id_continuity_check(renumbered_array)

--- a/tests/structure/test_pdb.py
+++ b/tests/structure/test_pdb.py
@@ -210,7 +210,7 @@ def test_extra_fields(hybrid36):
 
 
 @pytest.mark.filterwarnings("ignore")
-def test_guess_elements():
+def test_inferred_elements():
     # Read valid pdb file
     path = join(data_dir("structure"), "1l2y.pdb")
     pdb_file = pdb.PDBFile.read(path)

--- a/tests/structure/test_repair.py
+++ b/tests/structure/test_repair.py
@@ -1,0 +1,48 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+import biotite.structure as struc
+import biotite.structure.io.pdbx as pdbx
+import numpy as np
+from os.path import join
+from ..util import data_dir
+import pytest
+
+
+@pytest.fixture
+def single_chain():
+    pdbx_file = pdbx.BinaryCIFFile.read(
+        join(data_dir("structure"), "1l2y.bcif")
+    )
+    return pdbx.get_structure(pdbx_file, model=1)
+
+
+@pytest.fixture
+def multi_chain(single_chain):
+    other_chain = single_chain.copy()
+    other_chain.chain_id[:] = "B"
+    return single_chain + other_chain
+
+
+@pytest.mark.parametrize("restart_each_chain", [False, True])
+def test_create_continuous_res_ids(multi_chain, restart_each_chain):
+    """
+    Check if continuous residue IDs are restored, after removing a
+    residue.
+    """
+    # Remove a residue
+    multi_chain = multi_chain[multi_chain.res_id != 5]
+    # Restore continuity
+    multi_chain.res_id = struc.create_continuous_res_ids(
+        multi_chain, restart_each_chain=restart_each_chain
+    )
+
+    test_res_ids, _ = struc.get_residues(multi_chain)
+    if restart_each_chain:
+        assert test_res_ids.tolist() == np.concatenate(
+            [np.arange(len(test_res_ids) // 2) + 1] * 2
+        ).tolist()
+    else:
+        assert test_res_ids.tolist() \
+            == (np.arange(len(test_res_ids)) + 1).tolist()

--- a/tests/structure/test_repair.py
+++ b/tests/structure/test_repair.py
@@ -46,3 +46,29 @@ def test_create_continuous_res_ids(multi_chain, restart_each_chain):
     else:
         assert test_res_ids.tolist() \
             == (np.arange(len(test_res_ids)) + 1).tolist()
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [("CA", "C"),
+     ("C", "C"),
+     ("CB", "C"),
+     ("OD1", "O"),
+     ("HD21", "H"),
+     ("1H", "H"),
+     #("CL", "CL"),  # This is an edge case where inference is difficult
+     ("HE", "H"),
+     ("SD", "S"),
+     ("NA", "N"),
+     ("NX", "N"),
+     ("BE", "BE"),
+     ("BEA", "BE"),
+     ("K", "K"),
+     ("KA", "K"),
+     ("QWERT", "")]
+)
+def test_infer_elements(name, expected):
+    """
+    Check if elements are correctly guessed based on known examples.
+    """
+    assert struc.infer_elements([name])[0] == expected


### PR DESCRIPTION
This PR adds functions to repair malformed structures, namely `create_continuous_res_ids()` and `infer_elements()`.
Furthermore, `renumber_atom_ids()` and `renumber_res_ids()` are deprecated