### PR TITLE
Fix slicing with annotation on minus strand

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -14,3 +14,4 @@ CONTRIBUTORS
 - Danny P. Farrell <https://github.com/danpf>
 - Daniel Ferrer Vinals <https://github.com/ferrervi>
 - Jincai Yang <https://github.com/0ut0fcontrol>
+- Tom Eulenfeld <https://github.com/trichter>

--- a/src/biotite/sequence/annotation.py
+++ b/src/biotite/sequence/annotation.py
@@ -455,7 +455,7 @@ class Annotation(Copyable):
                 i_last = sys.maxsize
             else:
                 i_last = index.stop - 1
-            
+
             sub_annot = Annotation()
             for feature in self:
                 locs_in_scope = []
@@ -744,7 +744,7 @@ class AnnotatedSequence(Copyable):
                     locs, key=lambda loc: loc.last, reverse=True
                 )
             # Merge the sequences corresponding to the ordered locations
-            for loc in sorted(locs, key=lambda loc: loc.first):
+            for loc in sorted_locs:
                 slice_start = loc.first - self._seqstart
                 # +1 due to exclusive stop
                 slice_stop = loc.last - self._seqstart +1

--- a/tests/sequence/test_annotation.py
+++ b/tests/sequence/test_annotation.py
@@ -58,26 +58,33 @@ def test_annotated_sequence():
     annot_seq = AnnotatedSequence(annotation, sequence)
     assert annot_seq[2] == "T"
     assert annot_seq.sequence[2] == "G"
-    
+
     # test slicing with only stop
     annot_seq2 = annot_seq[:16]
     assert annot_seq2.sequence == seq.NucleotideSequence("ATGGCGTACGATTAG")
     assert set([f.qual['note'] for f in annot_seq2.annotation]) == {'walker'}
-    
+
     # test slicing with only start
     annot_seq3 = annot_seq[16:]
     assert annot_seq3.sequence == seq.NucleotideSequence("AAAAAAA")
     assert set([f.qual['note'] for f in annot_seq3.annotation]) == {'poly-A'}
-    
+
     # test slicing with start and stop
     annot_seq4 = annot_seq[1:17]
     assert annot_seq4.sequence == seq.NucleotideSequence("ATGGCGTACGATTAGA") # sequences are 1-indexed
     assert set([f.qual['note'] for f in annot_seq4.annotation]) == {'walker', 'poly-A'}
-    
+
     assert annot_seq[feature1] == seq.NucleotideSequence("ATAT")
     assert annot_seq[feature2] == seq.NucleotideSequence("AAAAAAA")
     annot_seq[feature1] = seq.NucleotideSequence("CCCC")
     assert annot_seq.sequence == seq.NucleotideSequence("CCGGCGTACGCCTAGAAAAAAA")
+
+    # test slicing with feature on minus strand
+    feature3 = Feature("misc_feature", [Location(1,4), Location(8,12)])
+    feature4 = Feature("misc_feature_minus", [
+        Location(1,4,strand=Location.Strand.REVERSE),
+        Location(8,12,strand=Location.Strand.REVERSE)])
+    assert annot_seq[feature4] == annot_seq[feature3].reverse().complement()
 
 def test_reverse_complement():
     gb_file = gb.GenBankFile.read(join(data_dir("sequence"), "ec_bl21.gb"))


### PR DESCRIPTION
Hi! This is an awesome project! Very nice work.

I stumbled upon a small bug. The `sorted_locs` variable is not used in `annotation.py`. The effect is that, when slicing with a feature with at least two locations on the minus strand, we get the wrong sequence.

I added a test to demonstrate the problem and fixed it.