### PR TITLE
`Numpy 2.0` is used when installing `Biotite`via pip.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 # this should be manually updated as the minimum python version increases
 dependencies = [
   "requests >= 2.12",
-  "numpy >= 1.14.5, <= 2.0",
+  "numpy >= 1.14.5, < 2.0",
   "msgpack >= 0.5.6",
   "networkx >= 2.0",
 ]


### PR DESCRIPTION
Currently `Numpy 2.0` is installed along `Biotite` via pip. This causes issues with imports as version 2.0 is not officially supported by `Biotite` yet. This PR fixes this issue.

@padix-key are there any other potential places in the code that we need to adjust? 