### PR TITLE
Fix `Atom` `__repr__()` (#602)

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -4,6 +4,7 @@ CONTRIBUTORS
 - Fabrice Allain <https://github.com/f-allain>
 - Jacob Marcel Anter <https://github.com/JacobAnter>
 - Daniel Bauer <https://github.com/dnlbauer>
+- Lukas Jarosch <https://github.com/ljarosch>
 - Patrick Kunzmann <https://github.com/padix-key>
 - Tom David Müller <https://github.com/t0mdavid-m>
 - Thomas Nevolianis <https://github.com/thomasnevolianis>

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -497,6 +497,7 @@ class Atom(Copyable):
         self.coord = coord
 
     def __repr__(self):
+        """Represent Atom as a string for debugging."""
         # print out key-value pairs and format strings in quotation marks
         annot_parts = [
             f'{key}="{value}"' if isinstance(value, str) else f'{key}={value}'

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -497,15 +497,14 @@ class Atom(Copyable):
         self.coord = coord
 
     def __repr__(self):
-        """Represent Atom as a string for debugging."""
-        annot = 'chain_id="' + self._annot["chain_id"] + '"'
-        annot = annot + ', res_id=' + str(self._annot["res_id"])
-        annot = annot + ', ins_code="' + self._annot["ins_code"] + '"'
-        annot = annot + ', res_name="' + self._annot["res_name"] + '"'
-        annot = annot + ', hetero=' + str(self._annot["hetero"])
-        annot = annot + ', atom_name="' + self._annot["atom_name"] + '"'
-        annot = annot + ', element="' + self._annot["element"] + '"'
-        return f'Atom(np.{np.array_repr(self.coord)}, {annot})'
+        # print out key-value pairs and format strings in quotation marks
+        annot_parts = [
+            f'{key}="{value}"' if isinstance(value, str) else f'{key}={value}'
+            for key, value in self._annot.items()
+        ]
+
+        annot = ', '.join(annot_parts)
+        return f'Atom(np.{np.array_repr(self.coord)}, {annot})'    
 
     @property
     def shape(self):


### PR DESCRIPTION
This changes the hardcoded `Atom` `__repr__()` to a more general version that will additionally print custom added attributes.

**EDIT**: Fixes #602.