### PR TITLE
Fix artifact name for source distribution

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -162,7 +162,7 @@ jobs:
       run: pipx run build --sdist
     - uses: actions/upload-artifact@v4
       with:
-        name: release-${{ matrix.dist }}
+        name: release-sdist
         path: dist//*.tar.gz
 
 


### PR DESCRIPTION
Currently the artifact name of the source distribution is `release-`. This PR renames it to `release-sdist`