### PR TITLE
mdtraj 1.10 incompatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - numpy >=1.15, <2.0
   - requests >=2.12
   # Testing
-  - mdtraj >=1.9.3
+  - mdtraj >=1.9.3, <1.10
   - pytest >=7.0
   # Interfaced software in biotite.application (can also be installed separately)
   - autodock-vina


### PR DESCRIPTION
**Description:**
Pinning mdtraj version between >=1.9.3, <1.10 in environment.yml to address compatibility issues. mdtraj 1.10 was recently release and seems to not be fully backwards compatible. 

Changes Made:
Updated environment.yml file to specify mdtraj version as >=1.9.3, <1.10 to address compatibility issues caused by recent updates.

Testing:
mdtraj 1.10 resulted in tests that relied on the TNGTrajectoryFile object in mdtraj  to fail. 
For example, tests/structure/test_trajectory.py
After pinning mdtraj to <1.10 all the tests passed successfully again.