### PR TITLE
fix a bug in add two bond lists.

### DIFF
--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1005,7 +1005,7 @@ class BondList(Copyable):
         # maximum and redundant bond calculation
         merged_bond_list._bonds = merged_bonds
         merged_bond_list._max_bonds_per_atom = max(
-            self._max_bonds_per_atom, merged_bond_list._max_bonds_per_atom
+            self._max_bonds_per_atom, bond_list._max_bonds_per_atom
         )
         return merged_bond_list
 

--- a/tests/structure/test_bonds.py
+++ b/tests/structure/test_bonds.py
@@ -133,6 +133,19 @@ def test_modification(bond_list):
                                              [1, 4, 0]]
 
 
+def test_add_two_bond_list():
+    """
+    Test adding two `BondList` objects.
+    """
+    bond_list1 = struc.BondList(2, np.array([(0,1)])) # max_bond_per_atom=1
+    bond_list2 = struc.BondList(3, np.array([(0,1),(0,2)])) # max_bond_per_atom=2
+    added_list = bond_list1 + bond_list2
+    assert added_list._max_bonds_per_atom == 2
+    assert added_list.get_bonds(2)[0].tolist() == [3, 4]
+    assert added_list.as_array().tolist() == [[0, 1, 0],
+                                              [2, 3, 0],
+                                              [2, 4, 0]]
+
 def test_contains(bond_list):
     """
     Test whether `BondList` correctly identifies whether it contains a


### PR DESCRIPTION
after adding two bond list, `merged_bond_list` has wrong `_max_bonds_per_atom`.
```
import numpy as np
import biotite.structure as struc
bond_list1 = struc.BondList(2, np.array([(0,1)])) # max_bond_per_atom=1
bond_list2 = struc.BondList(3, np.array([(0,1),(0,2)])) # max_bond_per_atom=2
added_list = bond_list1 + bond_list2

print(f"{added_list._max_bonds_per_atom=}")

bonds, types = added_list.get_bonds(2)
print(f"{bonds.tolist()=} {types.tolist()=}")

print(f"{added_list.as_array().tolist()=}")

# output values:
# added_list._max_bonds_per_atom=1   (wrong, expected value is 2)
# bonds.tolist()=[3] types.tolist()=[0] (wrong, expect 2 bonds)
# added_list.as_array().tolist()=[[0, 1, 0], [2, 3, 0], [2, 4, 0]] (right)


```