### PR TITLE
Handle embedded quote in mmcif

### DIFF
--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -6,6 +6,7 @@ __name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
 __all__ = ["CIFFile", "CIFBlock", "CIFCategory", "CIFColumn", "CIFData"]
 
+import re
 import itertools
 import shlex
 from collections.abc import MutableMapping, Sequence
@@ -449,7 +450,7 @@ class CIFCategory(_Component, MutableMapping):
         """
         category_dict = {}
         for line in lines:
-            parts = shlex.split(line)
+            parts = _split_one_line(line)
             column_name = parts[0].split(".")[1]
             column = parts[1]
             category_dict[column_name] = CIFColumn(column)
@@ -485,7 +486,7 @@ class CIFCategory(_Component, MutableMapping):
             # and quote removal if applicable,
             # bypassing the slow shlex module
             if expect_whitespace:
-                values = shlex.split(data_line)
+                values = _split_one_line(data_line)
             else:
                 values = data_line.split()
                 for k in range(len(values)):
@@ -652,7 +653,7 @@ class CIFBlock(_Component, MutableMapping):
                 # Special optimization for "atom_site":
                 # Even if the values are quote protected,
                 # no whitespace is expected in escaped values
-                # Therefore slow shlex.split() call is not necessary
+                # Therefore slow regex-based _split_one_line() call is not necessary
                 if key == "atom_site":
                     expect_whitespace = False
                 else:
@@ -1022,6 +1023,34 @@ def _multiline(value):
     if "\n" in value:
         return "\n;" + value + "\n;\n"
     return value
+
+
+def _split_one_line(line):
+    """
+    Split a line into its fields.
+    Supporting embedded quotes (' or "), like `'a dog's life'` to  `a dog's life`
+    """
+    # Define the patterns for different types of fields
+    single_quote_pattern = r"('(?:'(?! )|[^'])*')(?:\s|$)"
+    double_quote_pattern = r'("(?:"(?! )|[^"])*")(?:\s|$)'
+    unquoted_pattern = r"([^\s]+)"
+
+    # Combine the patterns using alternation
+    combined_pattern = (
+        f"{single_quote_pattern}|{double_quote_pattern}|{unquoted_pattern}"
+    )
+
+    # Find all matches
+    matches = re.findall(combined_pattern, line)
+
+    # Extract non-empty groups from the matches
+    fields = []
+    for match in matches:
+        field = next(group for group in match if group)
+        if field[0] == field[-1] == "'" or field[0] == field[-1] == '"':
+            field = field[1:-1]
+        fields.append(field)
+    return fields
 
 
 def _arrayfy(data):

--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -972,11 +972,11 @@ def _to_single(lines, is_looped):
                 j += 1
             if is_looped:
                 # Create a line for the multiline string only
-                processed_lines[out_i] = _quote(multi_line_str)
+                processed_lines[out_i] = f"'{multi_line_str}'"
                 out_i += 1
             else:
                 # Append multiline string to previous line
-                processed_lines[out_i - 1] += " " + _quote(multi_line_str)
+                processed_lines[out_i - 1] += " " + f"'{multi_line_str}'"
             in_i = j + 1
 
         elif not is_looped and lines[in_i][0] != "_":
@@ -999,10 +999,6 @@ def _quote(value):
     """
     if len(value) == 0:
         return "''"
-    elif len(value) >= 2 and value[0] == value[-1] == "'":
-        return value
-    elif len(value) >= 2 and value[0] == value[-1] == '"':
-        return value
     elif value[0] == "_":
         return "'" + value + "'"
     elif "'" in value:
@@ -1012,8 +1008,6 @@ def _quote(value):
     elif " " in value:
         return "'" + value + "'"
     elif "\t" in value:
-        return "'" + value + "'"
-    elif "\n" in value:
         return "'" + value + "'"
     else:
         return value

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -59,28 +59,21 @@ def test_escape(string, looped):
     assert test_value == ref_value
 
 
-def test_embedded_quote():
+@pytest.mark.parametrize(
+    "cif_line, expected_fields",
+    [
+        ["'' 'embed'quote' ", ['', "embed'quote"]],
+        ['2 "embed"quote" "\t\n"', ['2', 'embed"quote', '\t\n']],
+        [" 3 '' \"\" 'spac e' 'embed\"quote'", ['3', '', '', 'spac e', 'embed"quote']],
+        ["''' \"\"\" ''quoted''", ["'", '"', "'quoted'"]]
+    ]
+)
+def test_split_one_line(cif_line, expected_fields):
     """
     Test whether values that have an embedded quote are properly escaped.
     """
-    text_loop = (
-        "loop_\n"
-        "_entity.id\n" 
-        "_entity.type\n"
-        "_entity.src_method\n"
-        "_entity.pdbx_description\n"
-        "_entity.formula_weight\n"
-        "4 non-polymer syn 'HEXAETHYLENE GLYCOL'                                                    282.331\n"
-        """5 non-polymer syn '2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]' 510.816\n"""
-    )
-    test_category = pdbx.CIFCategory.deserialize(text_loop)
-    assert test_category["pdbx_description"].as_array(str).tolist() == [
-        'HEXAETHYLENE GLYCOL',
-        """2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]""",
-    ]
-    text_single = """_entity.pdbx_description '2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]'\n"""
-    test_category = pdbx.CIFCategory.deserialize(text_single)
-    assert test_category["pdbx_description"].as_item() == """2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]"""
+    assert pdbx.cif._split_one_line(cif_line) == expected_fields
+
 
 @pytest.mark.parametrize(
     "format, path, model",

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -59,6 +59,29 @@ def test_escape(string, looped):
     assert test_value == ref_value
 
 
+def test_embedded_quote():
+    """
+    Test whether values that have an embedded quote are properly escaped.
+    """
+    text_loop = (
+        "loop_\n"
+        "_entity.id\n" 
+        "_entity.type\n"
+        "_entity.src_method\n"
+        "_entity.pdbx_description\n"
+        "_entity.formula_weight\n"
+        "4 non-polymer syn 'HEXAETHYLENE GLYCOL'                                                    282.331\n"
+        """5 non-polymer syn '2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]' 510.816\n"""
+    )
+    test_category = pdbx.CIFCategory.deserialize(text_loop)
+    assert test_category["pdbx_description"].as_array(str).tolist() == [
+        'HEXAETHYLENE GLYCOL',
+        """2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]""",
+    ]
+    text_single = """_entity.pdbx_description '2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]'\n"""
+    test_category = pdbx.CIFCategory.deserialize(text_single)
+    assert test_category["pdbx_description"].as_item() == """2,2',2"-[1,2,3-BENZENE-TRIYLTRIS(OXY)]TRIS[N,N,N-TRIETHYLETHANAMINIUM]"""
+
 @pytest.mark.parametrize(
     "format, path, model",
     itertools.product(


### PR DESCRIPTION
 fix #570

use 3 regex patterns to match fields in one line for handle embed quote in mmcif file:
```
  single_quote_pattern = r"('(?:'(?! )|[^'])*')(?:\s|$)"
  double_quote_pattern = r'("(?:"(?! )|[^"])*")(?:\s|$)'
  unquoted_pattern = r"([^\s]+)"
```

GPT4 explain single_quote_pattern:

> This regex `single_quote_pattern = r"('(?:'(?! )|[^'])*')(?:\s|$)"` is engineered to identify and extract substrings enclosed in single quotes from a larger text, with a particular sensitivity to handle internal apostrophes correctly. Let's dissect this expression to understand how it functions:
> 
> 1. **`'`**: This matches the opening single quote `'` of the target substring.
> 
> 2. **`(?: ... )`**: This is a non-capturing group, which means it groups the contained pattern parts without storing the matched substring. This is used here mainly for grouping purposes without needing backreferences.
> 
> 3. **`'(?! )`**: This is a negative lookahead assertion that matches a single quote `'` only if it's not immediately followed by a space ` `. This allows the regex to match apostrophes within words (like in contractions such as `don't`) without treating them as the end of the quoted substring.
> 
> 4. **`|`**: The logical OR operator presents an alternative within the non-capturing group. It separates the negative lookahead for internal apostrophes from the next part of the pattern.
> 
> 5. **`[^']`**: This is a negated character class that matches any character except a single quote `'`. This part of the expression ensures that the regex consumes all characters within the quotes until it encounters the next single quote, which might signify the end of the quoted substring.
> 
> 6. **`*`**: This quantifier applies to the non-capturing group, allowing the contained pattern to repeat any number of times — including zero times — thus enabling the regex to match quoted substrings of any length.
> 
> 7. **`'`**: Matches the closing single quote of the substring.
> 
> 8. **`(?:\s|$)`**: Another non-capturing group that operates as a condition for what follows the closing quote. It matches either:
>    - **`\s`**: A whitespace character, ensuring that the quoted substring is followed by a space, or
>    - **`$`**: The end of a line or string, allowing for the quoted substring to appear at the end of the text.
> 
> #### The Key Points:
> - The pattern is designed to efficiently target substrings enclosed in single quotes within a larger string or document.
> - It smartly handles situations where an apostrophe is part of the enclosed text (like in contractions) without mistakenly recognizing it as the end of the quoted section.
> - By requiring the quoted substring to be followed by a space or the end of the text, it imposes a sensible boundary condition to identify discrete quoted substrings within a flow of text.
> 
> This regex could be particularly useful in text parsing applications where accurately distinguishing between quoted strings and regular text is crucial, such as in natural language processing tasks, data extraction, or in developing syntax highlighters for code editors.
