### PR TITLE
Fix compilation warning about deprecated NumPy API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ dependencies = ["hatch-cython"]
 [tool.hatch.build.targets.wheel.hooks.cython.options]
 include_numpy = true
 compile_py = false
+define_macros = [
+    ["NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"],
+]
 
 [build-system]
 requires = [


### PR DESCRIPTION
Fixes the `Using deprecated NumPy API` warning.