### PR TITLE
Relax runtime pin for NumPy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   # Biotite dependencies
   - msgpack-python >=0.5.6
   - networkx >=2.0
-  - numpy >=2.0
+  - numpy >=1.25
   - requests >=2.12
   # Testing
   # - mdtraj >=1.9.3, <1.10  # tempoarily disabled due to incompatibility with numpy 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,12 @@ classifiers = [
 ]
 
 dependencies = [
-  "requests >= 2.12",
-  "numpy >= 2.0",
+  # Wheels compiled with NumPy 2.0 are backward compatible with NumPy 1.x
+  # https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice
+  "numpy >= 1.25",
   "msgpack >= 0.5.6",
   "networkx >= 2.0",
+  "requests >= 2.12",
 ]
 dynamic = ["version"]
 

--- a/src/biotite/sequence/align/permutation.pyx
+++ b/src/biotite/sequence/align/permutation.pyx
@@ -245,7 +245,7 @@ class FrequencyPermutation(Permutation):
         # 'order' maps a permutation to a k-mer
         # Stability is important to get the same k-mer subset selection
         # on different architectures
-        order = np.argsort(counts, stable=True)
+        order = np.argsort(counts, kind="stable")
         # '_permutation_table' should perform the reverse mapping
         self._permutation_table = _invert_mapping(order)
         self._kmer_alph = kmer_alphabet


### PR DESCRIPTION
Currently, both, NumPy run and build time dependencies are pinned to `2.x`. However, wheels build with `2.x` are still compatible with `1.x`: https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice.
Hence, this PR allows `1.x` as runtime dependency