### PR TITLE
support for YASARA PETWORLD Cif files.

### DIFF
--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -465,6 +465,7 @@ class CIFCategory(_Component, MutableMapping):
         column_names = []
         i = 0
         for key_line in lines:
+            key_line = key_line.strip()
             if key_line[0] == "_":
                 # Key line
                 key = key_line.split(".")[1]
@@ -939,6 +940,7 @@ def _parse_category_name(line):
     If the line defines a category, return this name.
     Return ``None`` otherwise.
     """
+    line = line.strip()
     if line[0] != "_":
         return None
     else:


### PR DESCRIPTION
Yasara Petworld model are written in a custom cif file, that put space in front of the catergories name. 
download models from http://download.yasara.org/petworld/index.html 