### PR TITLE
Adjust Python version to make it compatible with DSSP

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -124,9 +124,6 @@ jobs:
         with:
           mamba-version: "*"
           environment-file: environment.yml
-      # TODO: Re-enable DSSP tests as soon as issues with libboost in CI are resolved
-      - name: "TEMP: Remove DSSP from environment"
-        run: mamba remove dssp -y
       - name: Build distribution
         run: pip wheel --no-deps -w dist .
       - name: Install distribution

--- a/doc/switcher.py
+++ b/doc/switcher.py
@@ -70,11 +70,13 @@ def create_switcher_json(file_path, min_tag, n_versions):
         if version.patch != 0:
             # Documentation is not uploaded for patch versions
             continue
-        version_config.append({
-            "name": f"{version.major}.{version.minor}",
-            "version": str(version),
-            "url": f"{BIOTITE_URL}/{version}/",
-        })
+        version_config.append(
+            {
+                "name": f"{version.major}.{version.minor}",
+                "version": str(version),
+                "url": f"{BIOTITE_URL}/{version}/",
+            }
+        )
     current_version = _get_current_version()
     version_config.append(
         {

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
   - bioconda
 
 dependencies:
-  - python =3.12
+  - python =3.11
   # Package building
   - cython >=3.0
   - pip >=10.0

--- a/src/biotite/sequence/io/genbank/file.py
+++ b/src/biotite/sequence/io/genbank/file.py
@@ -80,7 +80,7 @@ class GenBankFile(TextFile):
     >>> print(content)
     ['One line', 'A second line']
     >>> print(subfields)
-    OrderedDict({'SUBFIELD1': ['Single Line'], 'SUBFIELD2': ['Two', 'lines']})
+    OrderedDict([('SUBFIELD1', ['Single Line']), ('SUBFIELD2', ['Two', 'lines'])])
 
     Adding an additional field:
 

--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -6,8 +6,8 @@ __name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
 __all__ = ["CIFFile", "CIFBlock", "CIFCategory", "CIFColumn", "CIFData"]
 
-import re
 import itertools
+import re
 from collections.abc import MutableMapping, Sequence
 import numpy as np
 from biotite.file import (

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -69,11 +69,11 @@ def test_escape(string, looped):
 @pytest.mark.parametrize(
     "cif_line, expected_fields",
     [
-        ["'' 'embed'quote' ", ['', "embed'quote"]],
-        ['2 "embed"quote" "\t\n"', ['2', 'embed"quote', '\t\n']],
-        [" 3 '' \"\" 'spac e' 'embed\"quote'", ['3', '', '', 'spac e', 'embed"quote']],
-        ["''' \"\"\" ''quoted''", ["'", '"', "'quoted'"]]
-    ]
+        ["'' 'embed'quote' ", ["", "embed'quote"]],
+        ['2 "embed"quote" "\t\n"', ["2", 'embed"quote', "\t\n"]],
+        [" 3 '' \"\" 'spac e' 'embed\"quote'", ["3", "", "", "spac e", 'embed"quote']],
+        ["''' \"\"\" ''quoted''", ["'", '"', "'quoted'"]],
+    ],
 )
 def test_split_one_line(cif_line, expected_fields):
     """


### PR DESCRIPTION
Currently the DSSP tests are disabled in `next-major-release` due to some incompatibility between *libboost* and *DSSP*. This PR aims to solve this, by temporarily decreasing the Python version in the environment again.

Having a compatible DSSP software can be tackled later, e.g. by publishing https://github.com/PDB-REDO/dssp in `conda-forge`, as *libboost* is only required for testing (https://github.com/PDB-REDO/dssp/issues/50#issuecomment-1422767236):

> The requirements are limited, only zlib development files are needed. And boost is only required for building unit-tests.

Having an updated version of DSSP available would also solve #622.