### PR TITLE
Make dtype of mandatory annotation arrays dynamic

### DIFF
--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -450,7 +450,7 @@ def _fill_annotations(array, atom_site, extra_fields, use_author_fields):
         "chain_id",
         _get_or_fallback(
             atom_site, f"{prefix}_asym_id", f"{alt_prefix}_asym_id"
-        ).as_array("U4"),
+        ).as_array(str),
     )
     array.set_annotation(
         "res_id",
@@ -458,21 +458,21 @@ def _fill_annotations(array, atom_site, extra_fields, use_author_fields):
             atom_site, f"{prefix}_seq_id", f"{alt_prefix}_seq_id"
         ).as_array(int, -1),
     )
-    array.set_annotation("ins_code", atom_site["pdbx_PDB_ins_code"].as_array("U1", ""))
+    array.set_annotation("ins_code", atom_site["pdbx_PDB_ins_code"].as_array(str, ""))
     array.set_annotation(
         "res_name",
         _get_or_fallback(
             atom_site, f"{prefix}_comp_id", f"{alt_prefix}_comp_id"
-        ).as_array("U5"),
+        ).as_array(str),
     )
     array.set_annotation("hetero", atom_site["group_PDB"].as_array(str) == "HETATM")
     array.set_annotation(
         "atom_name",
         _get_or_fallback(
             atom_site, f"{prefix}_atom_id", f"{alt_prefix}_atom_id"
-        ).as_array("U6"),
+        ).as_array(str),
     )
-    array.set_annotation("element", atom_site["type_symbol"].as_array("U2"))
+    array.set_annotation("element", atom_site["type_symbol"].as_array(str))
 
     if "atom_id" in extra_fields:
         array.set_annotation("atom_id", atom_site["id"].as_array(int))
@@ -577,7 +577,7 @@ def _parse_inter_residue_bonds(atom_site, struct_conn):
     atoms_indices_2 = atoms_indices_2[mapping_exists_mask]
 
     # Interpret missing values as ANY bonds
-    bond_order = struct_conn["pdbx_value_order"].as_array("U4", "")
+    bond_order = struct_conn["pdbx_value_order"].as_array(str, "")
     # Consecutively apply the same masks as applied to the atom indices
     # Logical combination does not work here,
     # as the second mask was created based on already filtered data
@@ -1135,12 +1135,11 @@ def get_component(pdbx_file, data_block=None, use_ideal_coord=True, res_name=Non
 
     array = AtomArray(atom_category.row_count)
 
-    array.hetero[:] = True
-    array.res_name = atom_category["comp_id"].as_array("U5")
-    array.atom_name = atom_category["atom_id"].as_array("U6")
-    array.element = atom_category["type_symbol"].as_array("U2")
-    array.add_annotation("charge", int)
-    array.charge = atom_category["charge"].as_array(int, 0)
+    array.set_annotation("hetero", np.full(len(atom_category["comp_id"]), True))
+    array.set_annotation("res_name", atom_category["comp_id"].as_array(str))
+    array.set_annotation("atom_name", atom_category["atom_id"].as_array(str))
+    array.set_annotation("element", atom_category["type_symbol"].as_array(str))
+    array.set_annotation("charge", atom_category["charge"].as_array(int, 0))
 
     coord_fields = [f"pdbx_model_Cartn_{dim}_ideal" for dim in ("x", "y", "z")]
     alt_coord_fields = [f"model_Cartn_{dim}" for dim in ("x", "y", "z")]

--- a/tests/structure/test_atoms.py
+++ b/tests/structure/test_atoms.py
@@ -75,6 +75,19 @@ def test_access(array):
         array.set_annotation("test2", np.array([0, 1, 2, 3]))
 
 
+def test_finding_compatible_dtype(array):
+    """
+    Check if a compatible dtype is selected, if the existing one is incompatible with
+    the new annotation array.
+    """
+    # Has more than the default 4 characters
+    CHAIN_ID = "LONG_ID"
+
+    array.set_annotation("chain_id", np.array([CHAIN_ID] * array.array_length()))
+    # Without a compatible dtype, the string would be truncated
+    assert (array.chain_id[:] == CHAIN_ID).all()
+
+
 def test_modification(atom, array, stack):
     new_atom = atom
     new_atom.chain_id = "C"

--- a/tests/structure/test_pdbx.py
+++ b/tests/structure/test_pdbx.py
@@ -213,6 +213,24 @@ def test_extra_fields(tmpdir, format):
     assert test_atoms == ref_atoms
 
 
+def test_dynamic_dtype():
+    """
+    Check if the dtype of an annotation array is automatically adjusted if the
+    column in the `atom_site` category contains longer strings than supported by the
+    default dtype.
+    """
+    CHAIN_ID = "LONG_ID"
+
+    path = join(data_dir("structure"), "1l2y.bcif")
+    pdbx_file = pdbx.BinaryCIFFile.read(path)
+    category = pdbx_file.block["atom_site"]
+    category["label_asym_id"] = np.full(len(category["label_asym_id"]), CHAIN_ID)
+    atoms = pdbx.get_structure(pdbx_file, model=1, use_author_fields=False)
+
+    # Without a dynamically chosen compatible dtype, the string would be truncated
+    assert (atoms.chain_id == CHAIN_ID).all()
+
+
 def test_intra_bond_residue_parsing():
     """
     Check if intra-residue bonds can be parsed from a NextGen CIF file


### PR DESCRIPTION
Currently the `AtomArray` annotation arrays are locked to their initial dtype. Usually this is no problem. However the PDBx format does not set a limit to string lengths, e.g. in `atom_site.comp_id` or `atom_site.label_atom_id`. Hence such potentially longer strings would be truncated to the dtype of the mandatory column, e.g. the chain ID `FOO_BAR` would become `FOO_` as the `chain_id` `dtype` is `U4`.

This PR changes this behavior: When `set_annotation()` is called a compatible dtype is searched. 