### PR TITLE
Add positional substitution matrices

### DIFF
--- a/doc/tutorial/sequence/index.rst
+++ b/doc/tutorial/sequence/index.rst
@@ -43,5 +43,5 @@ For an unambiguous DNA sequence, the alphabet comprises the four nucleobases.
     align_optimal
     align_heuristic
     align_multiple
-    annotations
     profiles
+    annotations

--- a/doc/tutorial/sequence/profiles.rst
+++ b/doc/tutorial/sequence/profiles.rst
@@ -1,0 +1,159 @@
+.. include:: /tutorial/preamble.rst
+
+Profiles and position-specific matrices
+=======================================
+Often sequences are not viewed in isolation:
+For example, if you investigate a protein family, you do not handle a single sequence,
+but an arbitrarily large collection of highly similar sequences.
+At some point handling those sequences as a mere collection of individual sequences
+becomes impractical for answering common questions, like which are the prevalent
+amino acids at a certain positions of the sequences.
+
+Sequence profiles
+-----------------
+
+.. currentmodule:: biotite.sequence
+
+This is where *sequence profiles* come into play:
+The condense the a collection of aligned sequences into a matrix that tracks the
+frequency of each symbol at each position of the alignment.
+Hence, asking the questions such as '*How frequent is an alanine at the n-th position?*'
+becomes a trivial indexing operation.
+
+As example for profiles, we will reuse the cyclotide sequence family from the
+:doc:`previous chapter <align_multiple>`.
+
+.. jupyter-execute::
+
+    from tempfile import NamedTemporaryFile
+    import biotite.sequence.io.fasta as fasta
+    import biotite.database.entrez as entrez
+
+    query = (
+        entrez.SimpleQuery("Cyclotide") &
+        entrez.SimpleQuery("cter") &
+        entrez.SimpleQuery("srcdb_swiss-prot", field="Properties") ^
+        entrez.SimpleQuery("Precursor")
+    )
+    uids = entrez.search(query, "protein")
+    temp_file = NamedTemporaryFile(suffix=".fasta", delete=False)
+    fasta_file = fasta.FastaFile.read(
+        entrez.fetch_single_file(uids, temp_file.name, "protein", "fasta")
+    )
+    sequences = {
+        # The cyclotide variant is the last character in the header
+        header[-1]: seq for header, seq in fasta.get_sequences(fasta_file).items()
+    }
+    # Extract cyclotide N as query sequence for later
+    query = sequences.pop("N")
+
+To create a profile, we first need to align the sequences, so corresponding symbols
+appear the same position.
+Then we can create a :class:`SequenceProfile` object from the :class:`.Alignment`, which
+simply counts for each alignment column (i.e. the sequence position) the number of
+occurrences for each symbol.
+
+.. jupyter-execute::
+
+    import biotite.sequence as seq
+    import biotite.sequence.align as align
+
+    alignment, _, _, _ = seq.align.align_multiple(
+        list(sequences.values()),
+        align.SubstitutionMatrix.std_protein_matrix(),
+        gap_penalty=-5,
+    )
+    profile = seq.SequenceProfile.from_alignment(alignment)
+    print(profile)
+
+Each row in the displayed count matrix
+(accessible via :attr:`SequenceProfile.symbols`) refers to a single position, i.e. a
+column in the input MSA, and each column refers to a symbol in the underlying alphabet
+(accessible via :attr:`SequenceProfile.alphabet`).
+For completeness it should be noted that :attr:`SequenceProfile.gaps` also tracks the
+gaps for each position in the alignment, but we will not further use them in this
+tutorial.
+
+Note that the information about the individual sequences is lost in the condensation
+process: There is no way to reconstruct the original sequences from the profile.
+However, we can still extract a consensus sequence from the profile, which is a
+sequence that represents the most frequent symbol at each position.
+
+.. jupyter-execute::
+
+    print(profile.to_consensus())
+
+Profile visualization as sequence logo
+--------------------------------------
+
+.. currentmodule:: biotite.sequence.align
+
+A common way to visualize a sequence profile is a sequence logo.
+It depicts each profile position as a stack of letters:
+The degree of conversation (more precisely the
+`Shannon entropy <https://en.wikipedia.org/wiki/Entropy_(information_theory)>`_)
+is the height of a stack and each letter's height in the stack is proportional to its
+frequency at the respective position.
+
+.. jupyter-execute::
+
+    import matplotlib.pyplot as plt
+    from biotite.sequence.graphics import plot_sequence_logo
+
+    fig, ax = plt.subplots(figsize=(8.0, 2.0), constrained_layout=True)
+    plot_sequence_logo(ax, profile)
+    ax.set_xlabel("Residue position")
+    ax.set_ylabel("Bits")
+
+Position-specific scoring matrices
+----------------------------------
+
+.. currentmodule:: biotite.sequence.align
+
+Sequence profiles can achieve even more:
+The substitution matrices we have seen so far assign a score to a pair of two symbols,
+regardless of their position in a sequence.
+However, as discussed above, the position is crucial information to determine how
+conserved a certain symbol is in a family of sequences.
+
+Hence, we extend the concept of substitution matrices to *position-specific* matrices,
+which assign a score to a symbol and a position (instead of another symbols).
+
+.. jupyter-execute::
+
+    # For a real analysis each amino acid background frequencies should be provided
+    log_odds = profile.log_odds_matrix(pseudocount=1)
+
+Now, we encounter a problem:
+To create a :class:`SubstitutionMatrix` object from the log-odds matrix, we require two
+:class:`.Alphabet` objects:
+One is taken from the query sequence to be aligned to the profile, but which alphabet
+do we use for the positional axis of the matrix?
+Likewise, the alignment functions (e.g. :func:`align_optimal()`) require a two sequences
+to be aligned, but we only have one query sequence.
+
+To solve this problem :mod:`biotite.sequence` provides the :class:`.PositionalSequence`
+which acts as a placeholder for the second sequence in the alignment.
+Its alphabet contains a unique symbol for each position, i.e. the alphabet has the
+sought length.
+
+.. jupyter-execute::
+
+    positional_seq = seq.PositionalSequence(profile.to_consensus())
+    matrix = align.SubstitutionMatrix(
+        positional_seq.alphabet,
+        profile.alphabet,
+        # Substitution matrices require integer scores
+        # Multiply by 10 to increase value range and convert to integer
+        (log_odds * 10).astype(int)
+    )
+    alignment = align.align_optimal(
+        positional_seq, query, matrix, gap_penalty=-5, max_number=1
+    )[0]
+    print(alignment)
+
+Only the length of the input sequence passed to :class:`.PositionalSequence` matters for
+the alignment to work.
+The consensus sequence of the profile was merely chosen for cosmetic reasons, i.e.
+to have a meaningful string representation of the positional sequence and thus the
+alignment.

--- a/src/biotite/application/util.py
+++ b/src/biotite/application/util.py
@@ -50,7 +50,7 @@ def map_matrix(matrix):
     # All trailing symbols are filled with zeros
     old_length = len(matrix.get_alphabet1())
     new_length = len(ProteinSequence.alphabet)
-    new_score_matrix = np.zeros((new_length, new_length))
+    new_score_matrix = np.zeros((new_length, new_length), dtype=np.int32)
     new_score_matrix[:old_length, :old_length] = matrix.score_matrix()
     return SubstitutionMatrix(
         ProteinSequence.alphabet, ProteinSequence.alphabet, new_score_matrix

--- a/src/biotite/database/uniprot/check.py
+++ b/src/biotite/database/uniprot/check.py
@@ -10,7 +10,7 @@ from biotite.database.error import RequestError
 
 
 # Taken from https://www.uniprot.org/help/api_retrieve_entries
-def assert_valid_response(response_status_code):
+def assert_valid_response(response):
     """
     Checks whether the response is valid.
 
@@ -19,17 +19,22 @@ def assert_valid_response(response_status_code):
     response_status_code: int
         Status code of request.get.
     """
-    if response_status_code == 400:
-        raise RequestError("Bad request. There is a problem with your input.")
-    elif response_status_code == 404:
-        raise RequestError("Not found. The resource you requested doesn't exist.")
-    elif response_status_code == 410:
-        raise RequestError("Gone. The resource you requested was removed.")
-    elif response_status_code == 500:
-        raise RequestError(
-            "Internal server error. Most likely a temporary problem, but if the problem persists please contact UniProt team."
-        )
-    elif response_status_code == 503:
-        raise RequestError(
-            "Service not available. The server is being updated, try again later."
-        )
+    if len(response.content) == 0:
+        raise RequestError("No content returned")
+    match response.status_code:
+        case 400:
+            raise RequestError("Bad request. There is a problem with your input.")
+        case 404:
+            raise RequestError("Not found. The resource you requested doesn't exist.")
+        case 410:
+            raise RequestError("Gone. The resource you requested was removed.")
+        case 500:
+            raise RequestError(
+                "Internal server error. "
+                "Most likely a temporary problem, "
+                "but if the problem persists please contact UniProt team."
+            )
+        case 503:
+            raise RequestError(
+                "Service not available. The server is being updated, try again later."
+            )

--- a/src/biotite/database/uniprot/download.py
+++ b/src/biotite/database/uniprot/download.py
@@ -111,7 +111,7 @@ def fetch(ids, format, target_path=None, overwrite=False, verbose=False):
             if format in ["fasta", "gff", "txt", "xml", "rdf", "tab"]:
                 r = requests.get(_fetch_url + db_name + "/" + id + "." + format)
                 content = r.text
-                assert_valid_response(r.status_code)
+                assert_valid_response(r)
             else:
                 raise ValueError(f"Format '{format}' is not supported")
             if file is None:

--- a/src/biotite/database/uniprot/query.py
+++ b/src/biotite/database/uniprot/query.py
@@ -289,5 +289,5 @@ def search(query, number=500):
     params = {"query": str(query), "format": "list", "size": str(number)}
     r = requests.get(_base_url, params=params)
     content = r.text
-    assert_valid_response(r.status_code)
+    assert_valid_response(r)
     return content.split("\n")[:-1]

--- a/src/biotite/sequence/align/alignment.py
+++ b/src/biotite/sequence/align/alignment.py
@@ -9,7 +9,6 @@ import numbers
 import textwrap
 from collections.abc import Sequence
 import numpy as np
-from biotite.sequence.alphabet import LetterAlphabet
 
 __all__ = [
     "Alignment",
@@ -111,7 +110,7 @@ class Alignment(object):
         for i in range(len(self.trace)):
             j = self.trace[i][seq_index]
             if j != -1:
-                seq_str += self.sequences[seq_index][j]
+                seq_str += str(self.sequences[seq_index][j])
             else:
                 seq_str += "-"
         return seq_str
@@ -133,7 +132,7 @@ class Alignment(object):
         # has an non-single letter alphabet
         all_single_letter = True
         for seq in self.sequences:
-            if not isinstance(seq.get_alphabet(), LetterAlphabet):
+            if not _is_single_letter(seq.alphabet):
                 all_single_letter = False
         if all_single_letter:
             # First dimension: sequence number,
@@ -665,3 +664,17 @@ def remove_terminal_gaps(alignment):
             "no overlap and the resulting alignment would be empty"
         )
     return alignment[start:stop]
+
+
+def _is_single_letter(alphabet):
+    """
+    More relaxed version of :func:`biotite.sequence.alphabet.is_letter_alphabet()`:
+    It is sufficient that only only the string representation of each symbol is only
+    a single character.
+    """
+    if alphabet.is_letter_alphabet():
+        return True
+    for symbol in alphabet:
+        if len(str(symbol)) != 1:
+            return False
+    return True

--- a/src/biotite/sequence/align/kmeralphabet.pyx
+++ b/src/biotite/sequence/align/kmeralphabet.pyx
@@ -568,6 +568,23 @@ class KmerAlphabet(Alphabet):
         return int(len(self._base_alph) ** self._k)
 
 
+    def __iter__(self):
+        # Creating all symbols is expensive
+        # -> Use a generator instead
+        if isinstance(self._base_alph, LetterAlphabet):
+            return ("".join(self.decode(code)) for code in range(len(self)))
+        else:
+            return (list(self.decode(code)) for code in range(len(self)))
+
+
+    def __contains__(self, symbol):
+        try:
+            self.fuse(self._base_alph.encode_multiple(symbol))
+            return True
+        except AlphabetError:
+            return False
+
+
 def _to_array_form(model_string):
     """
     Convert the the common string representation of a *k-mer* spacing

--- a/src/biotite/sequence/align/matrix.py
+++ b/src/biotite/sequence/align/matrix.py
@@ -9,7 +9,11 @@ __author__ = "Patrick Kunzmann"
 import functools
 from pathlib import Path
 import numpy as np
-from biotite.sequence.seqtypes import NucleotideSequence, ProteinSequence
+from biotite.sequence.seqtypes import (
+    NucleotideSequence,
+    PositionalSequence,
+    ProteinSequence,
+)
 
 # Directory of matrix files
 _DB_DIR = Path(__file__).parent / "matrix_data"
@@ -86,6 +90,11 @@ class SubstitutionMatrix(object):
         or a dictionary mapping the symbol pairing to scores,
         or a string referencing a matrix in the internal database.
 
+    Attributes
+    ----------
+    shape : tuple
+        The shape of the substitution matrix.
+
     Raises
     ------
     KeyError
@@ -156,34 +165,18 @@ class SubstitutionMatrix(object):
         # score matrix -> make the score matrix read-only
         self._matrix.setflags(write=False)
 
-    def __repr__(self):
-        """Represent SubstitutionMatrix as a string for debugging."""
-        return (
-            f"SubstitutionMatrix({self._alph1.__repr__()}, {self._alph2.__repr__()}, "
-            f"np.{np.array_repr(self._matrix)})"
-        )
+    @property
+    def shape(self):
+        """
+        Get the shape (i.e. the length of both alphabets)
+        of the substitution matrix.
 
-    def __eq__(self, item):
-        if not isinstance(item, SubstitutionMatrix):
-            return False
-        if self._alph1 != item.get_alphabet1():
-            return False
-        if self._alph2 != item.get_alphabet2():
-            return False
-        if not np.array_equal(self.score_matrix(), item.score_matrix()):
-            return False
-        return True
-
-    def __ne__(self, item):
-        return not self == item
-
-    def _fill_with_matrix_dict(self, matrix_dict):
-        self._matrix = np.zeros((len(self._alph1), len(self._alph2)), dtype=np.int32)
-        for i in range(len(self._alph1)):
-            for j in range(len(self._alph2)):
-                sym1 = self._alph1.decode(i)
-                sym2 = self._alph2.decode(j)
-                self._matrix[i, j] = int(matrix_dict[sym1, sym2])
+        Returns
+        -------
+        shape : tuple
+            Matrix shape.
+        """
+        return (len(self._alph1), len(self._alph2))
 
     def get_alphabet1(self):
         """
@@ -285,26 +278,155 @@ class SubstitutionMatrix(object):
         code2 = self._alph2.encode(symbol2)
         return self._matrix[code1, code2]
 
-    def shape(self):
+    def as_positional(self, sequence1, sequence2):
         """
-        Get the shape (i.e. the length of both alphabets)
-        of the subsitution matrix.
+        Transform this substitution matrix and two sequences into positional
+        equivalents.
+
+        This means the new substitution matrix is position-specific: It has the lengths
+        of the sequences instead of the lengths of their alphabets.
+        Its scores represent the same scores as the original matrix, but now mapped
+        onto the positions of the sequences.
+
+        Parameters
+        ----------
+        sequence1, sequence2 : seq.Sequence, length=n
+            The sequences to create the positional equivalents from.
 
         Returns
         -------
-        shape : tuple
-            Matrix shape.
+        pos_matrix : align.SubstitutionMatrix, shape=(n, n)
+            The position-specific substitution matrix.
+        pos_sequence1, pos_sequence2 : PositionalSequence, length=n
+            The positional sequences.
+
+        Notes
+        -----
+        After the transformation the substitution scores remain the same, i.e.
+        `substitution_matrix.get_score(sequence1[i], sequence2[j])` is equal to
+        `pos_matrix.get_score(pos_sequence1[i], pos_sequence2[j])`.
+
+        Examples
+        --------
+
+        Run an alignment with the usual substitution matrix:
+
+        >>> seq1 = ProteinSequence("BIQTITE")
+        >>> seq2 = ProteinSequence("IQLITE")
+        >>> matrix = SubstitutionMatrix.std_protein_matrix()
+        >>> print(matrix)
+            A   C   D   E   F   G   H   I   K   L   M   N   P   Q   R   S   T   V   W   Y   B   Z   X   *
+        A   4   0  -2  -1  -2   0  -2  -1  -1  -1  -1  -2  -1  -1  -1   1   0   0  -3  -2  -2  -1   0  -4
+        C   0   9  -3  -4  -2  -3  -3  -1  -3  -1  -1  -3  -3  -3  -3  -1  -1  -1  -2  -2  -3  -3  -2  -4
+        D  -2  -3   6   2  -3  -1  -1  -3  -1  -4  -3   1  -1   0  -2   0  -1  -3  -4  -3   4   1  -1  -4
+        E  -1  -4   2   5  -3  -2   0  -3   1  -3  -2   0  -1   2   0   0  -1  -2  -3  -2   1   4  -1  -4
+        F  -2  -2  -3  -3   6  -3  -1   0  -3   0   0  -3  -4  -3  -3  -2  -2  -1   1   3  -3  -3  -1  -4
+        G   0  -3  -1  -2  -3   6  -2  -4  -2  -4  -3   0  -2  -2  -2   0  -2  -3  -2  -3  -1  -2  -1  -4
+        H  -2  -3  -1   0  -1  -2   8  -3  -1  -3  -2   1  -2   0   0  -1  -2  -3  -2   2   0   0  -1  -4
+        I  -1  -1  -3  -3   0  -4  -3   4  -3   2   1  -3  -3  -3  -3  -2  -1   3  -3  -1  -3  -3  -1  -4
+        K  -1  -3  -1   1  -3  -2  -1  -3   5  -2  -1   0  -1   1   2   0  -1  -2  -3  -2   0   1  -1  -4
+        L  -1  -1  -4  -3   0  -4  -3   2  -2   4   2  -3  -3  -2  -2  -2  -1   1  -2  -1  -4  -3  -1  -4
+        M  -1  -1  -3  -2   0  -3  -2   1  -1   2   5  -2  -2   0  -1  -1  -1   1  -1  -1  -3  -1  -1  -4
+        N  -2  -3   1   0  -3   0   1  -3   0  -3  -2   6  -2   0   0   1   0  -3  -4  -2   3   0  -1  -4
+        P  -1  -3  -1  -1  -4  -2  -2  -3  -1  -3  -2  -2   7  -1  -2  -1  -1  -2  -4  -3  -2  -1  -2  -4
+        Q  -1  -3   0   2  -3  -2   0  -3   1  -2   0   0  -1   5   1   0  -1  -2  -2  -1   0   3  -1  -4
+        R  -1  -3  -2   0  -3  -2   0  -3   2  -2  -1   0  -2   1   5  -1  -1  -3  -3  -2  -1   0  -1  -4
+        S   1  -1   0   0  -2   0  -1  -2   0  -2  -1   1  -1   0  -1   4   1  -2  -3  -2   0   0   0  -4
+        T   0  -1  -1  -1  -2  -2  -2  -1  -1  -1  -1   0  -1  -1  -1   1   5   0  -2  -2  -1  -1   0  -4
+        V   0  -1  -3  -2  -1  -3  -3   3  -2   1   1  -3  -2  -2  -3  -2   0   4  -3  -1  -3  -2  -1  -4
+        W  -3  -2  -4  -3   1  -2  -2  -3  -3  -2  -1  -4  -4  -2  -3  -3  -2  -3  11   2  -4  -3  -2  -4
+        Y  -2  -2  -3  -2   3  -3   2  -1  -2  -1  -1  -2  -3  -1  -2  -2  -2  -1   2   7  -3  -2  -1  -4
+        B  -2  -3   4   1  -3  -1   0  -3   0  -4  -3   3  -2   0  -1   0  -1  -3  -4  -3   4   1  -1  -4
+        Z  -1  -3   1   4  -3  -2   0  -3   1  -3  -1   0  -1   3   0   0  -1  -2  -3  -2   1   4  -1  -4
+        X   0  -2  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -2  -1  -1   0   0  -1  -2  -1  -1  -1  -1  -4
+        *  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4   1
+        >>> alignment = align_optimal(seq1, seq2, matrix, gap_penalty=-10)[0]
+        >>> print(alignment)
+        BIQTITE
+        -IQLITE
+
+        Running the alignment with positional equivalents gives the same result:
+
+        >>> pos_matrix, pos_seq1, pos_seq2 = matrix.as_positional(seq1, seq2)
+        >>> print(pos_matrix)
+            I   Q   L   I   T   E
+        B  -3   0  -4  -3  -1   1
+        I   4  -3   2   4  -1  -3
+        Q  -3   5  -2  -3  -1   2
+        T  -1  -1  -1  -1   5  -1
+        I   4  -3   2   4  -1  -3
+        T  -1  -1  -1  -1   5  -1
+        E  -3   2  -3  -3  -1   5
+        >>> pos_alignment = align_optimal(pos_seq1, pos_seq2, pos_matrix, gap_penalty=-10)[0]
+        >>> print(pos_alignment)
+        BIQTITE
+        -IQLITE
+
+        Increase the substitution score for the first symbols in both sequences to align
+        to each other:
+
+        >>> score_matrix = pos_matrix.score_matrix().copy()
+        >>> score_matrix[0, 0] = 100
+        >>> biased_matrix = SubstitutionMatrix(
+        ...     pos_matrix.get_alphabet1(), pos_matrix.get_alphabet2(), score_matrix
+        ... )
+        >>> print(biased_matrix)
+            I   Q   L   I   T   E
+        B 100   0  -4  -3  -1   1
+        I   4  -3   2   4  -1  -3
+        Q  -3   5  -2  -3  -1   2
+        T  -1  -1  -1  -1   5  -1
+        I   4  -3   2   4  -1  -3
+        T  -1  -1  -1  -1   5  -1
+        E  -3   2  -3  -3  -1   5
+        >>> biased_alignment = align_optimal(pos_seq1, pos_seq2, biased_matrix, gap_penalty=-10)[0]
+        >>> print(biased_alignment)
+        BIQTITE
+        I-QLITE
         """
-        return (len(self._alph1), len(self._alph2))
+        pos_sequence1 = PositionalSequence(sequence1)
+        pos_sequence2 = PositionalSequence(sequence2)
+
+        pos_score_matrix = self._matrix[
+            tuple(_cartesian_product(sequence1.code, sequence2.code).T)
+        ].reshape(len(sequence1), len(sequence2))
+        pos_matrix = SubstitutionMatrix(
+            pos_sequence1.get_alphabet(),
+            pos_sequence2.get_alphabet(),
+            pos_score_matrix,
+        )
+
+        return pos_matrix, pos_sequence1, pos_sequence2
+
+    def __repr__(self):
+        """Represent SubstitutionMatrix as a string for debugging."""
+        return (
+            f"SubstitutionMatrix({self._alph1.__repr__()}, {self._alph2.__repr__()}, "
+            f"np.{np.array_repr(self._matrix)})"
+        )
+
+    def __eq__(self, item):
+        if not isinstance(item, SubstitutionMatrix):
+            return False
+        if self._alph1 != item.get_alphabet1():
+            return False
+        if self._alph2 != item.get_alphabet2():
+            return False
+        if not np.array_equal(self.score_matrix(), item.score_matrix()):
+            return False
+        return True
+
+    def __ne__(self, item):
+        return not self == item
 
     def __str__(self):
         # Create matrix in NCBI format
         string = " "
         for symbol in self._alph2:
-            string += f" {symbol:>3}"
+            string += f" {str(symbol):>3}"
         string += "\n"
         for i, symbol in enumerate(self._alph1):
-            string += f"{symbol:>1}"
+            string += f"{str(symbol):>1}"
             for j in range(len(self._alph2)):
                 string += f" {int(self._matrix[i,j]):>3d}"
             string += "\n"
@@ -464,3 +586,23 @@ class SubstitutionMatrix(object):
             alphabet,
             matrix_dict,
         )
+
+    def _fill_with_matrix_dict(self, matrix_dict):
+        self._matrix = np.zeros((len(self._alph1), len(self._alph2)), dtype=np.int32)
+        for i in range(len(self._alph1)):
+            for j in range(len(self._alph2)):
+                sym1 = self._alph1.decode(i)
+                sym2 = self._alph2.decode(j)
+                self._matrix[i, j] = int(matrix_dict[sym1, sym2])
+
+
+def _cartesian_product(array1, array2):
+    """
+    Create all combinations of elements from two arrays.
+    """
+    return np.transpose(
+        [
+            np.repeat(array1, len(array2)),
+            np.tile(array2, len(array1)),
+        ]
+    )

--- a/src/biotite/sequence/alphabet.py
+++ b/src/biotite/sequence/alphabet.py
@@ -410,6 +410,9 @@ class LetterAlphabet(Alphabet):
             symbols = symbols.astype("U1")
         return symbols
 
+    def is_letter_alphabet(self):
+        return True
+
     def __contains__(self, symbol):
         if not isinstance(symbol, (str, bytes)):
             return False

--- a/src/biotite/sequence/profile.py
+++ b/src/biotite/sequence/profile.py
@@ -156,8 +156,23 @@ class SequenceProfile(object):
             )
         self._gaps = new_gaps
 
+    def __str__(self):
+        # Add an additional row and column for the position and symbol indicators
+        print_matrix = np.full(
+            (self.symbols.shape[0] + 1, self.symbols.shape[1] + 1), "", dtype=object
+        )
+        print_matrix[1:, 1:] = self.symbols.astype(str)
+        print_matrix[0, 1:] = [str(sym) for sym in self.alphabet]
+        print_matrix[1:, 0] = [str(i) for i in range(self.symbols.shape[0])]
+        max_len = len(max(print_matrix.flatten(), key=len))
+        return "\n".join(
+            [
+                " ".join([str(cell).rjust(max_len) for cell in row])
+                for row in print_matrix
+            ]
+        )
+
     def __repr__(self):
-        """Represent SequenceProfile as a string for debugging."""
         return (
             f"SequenceProfile(np.{np.array_repr(self.symbols)}, "
             f"np.{np.array_repr(self.gaps)}, Alphabet({self.alphabet}))"

--- a/tests/application/test_msa.py
+++ b/tests/application/test_msa.py
@@ -46,7 +46,7 @@ def sequences():
             "TITANITE\n"
             "BI-SMITE\n"
             "-I-QLITE",
-            [0, 3, 1, 2]
+            [1, 3, 0, 2]
         ),
         (
             MafftApp,

--- a/tests/application/test_msa.py
+++ b/tests/application/test_msa.py
@@ -145,7 +145,7 @@ def test_custom_substitution_matrix(sequences, app_cls):
 
     alph = seq.ProteinSequence.alphabet
     # Strong identity matrix
-    score_matrix = np.identity(len(alph)) * 1000
+    score_matrix = np.identity(len(alph), dtype=int) * 1000
     matrix = align.SubstitutionMatrix(alph, alph, score_matrix)
     exp_ali = (
         "BI-QTITE\n"
@@ -187,7 +187,7 @@ def test_custom_sequence_type(app_cls):
         [6, 6],
     ]
     # Strong identity matrix
-    score_matrix = np.identity(len(alph))
+    score_matrix = np.identity(len(alph), dtype=int)
     score_matrix[score_matrix == 0] = -1000
     score_matrix[score_matrix == 1] = 1000
     matrix = align.SubstitutionMatrix(alph, alph, score_matrix)

--- a/tests/sequence/align/test_matrix.py
+++ b/tests/sequence/align/test_matrix.py
@@ -71,3 +71,32 @@ def test_matrix_str():
          "b   3   4   5",
          "c   6   7   8"]
     )  # fmt: skip
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_as_positional(seed):
+    """
+    Check if the score from a positional substitution matrix for symbols from
+    positional sequences is equal to the score from the original matrix for the
+    corresponding symbols from the original sequences.
+    """
+    MAX_SEQ_LENGTH = 10
+
+    np.random.seed(seed)
+    matrix = align.SubstitutionMatrix.std_protein_matrix()
+    sequences = []
+    for _ in range(2):
+        seq_length = np.random.randint(1, MAX_SEQ_LENGTH)
+        sequence = seq.ProteinSequence()
+        sequence.code = np.random.randint(0, len(sequence.alphabet), size=seq_length)
+        sequences.append(sequence)
+    pos_matrix, *pos_sequences = matrix.as_positional(*sequences)
+
+    # Sanity check if the positional sequences do correspond to the original sequences
+    for i in range(2):
+        assert str(pos_sequences[i]) == str(sequences[i])
+    for i in range(len(sequences[0])):
+        for j in range(len(sequences[1])):
+            ref_score = matrix.get_score(sequences[0][i], sequences[1][j])
+            test_score = pos_matrix.get_score(pos_sequences[0][i], pos_sequences[1][j])
+            assert test_score == ref_score

--- a/tests/sequence/test_seqtypes.py
+++ b/tests/sequence/test_seqtypes.py
@@ -2,6 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+import numpy as np
 import pytest
 import biotite.sequence as seq
 
@@ -90,3 +91,23 @@ def test_get_molecular_weight(monoisotopic, expected_mol_weight_protein):
     protein = seq.ProteinSequence("ACDEFGHIKLMNPQRSTVW")
     mol_weight_protein = protein.get_molecular_weight(monoisotopic=monoisotopic)
     assert mol_weight_protein == pytest.approx(expected_mol_weight_protein, abs=1e-2)
+
+
+def test_positional_sequence():
+    """
+    Check whether the original sequence symbols can be reconstructed from a
+    :class:`PositionalSequence`.
+    """
+    SEQ_LENGTH = 100
+
+    np.random.seed(0)
+    orig_sequence = seq.ProteinSequence()
+    orig_sequence.code = np.random.randint(
+        0, len(orig_sequence.alphabet), size=SEQ_LENGTH
+    )
+    positional_sequence = seq.PositionalSequence(orig_sequence)
+
+    assert str(positional_sequence) == str(orig_sequence)
+    reconstructed_sequence = positional_sequence.reconstruct()
+    assert np.all(reconstructed_sequence.code == orig_sequence.code)
+    assert reconstructed_sequence.alphabet == orig_sequence.alphabet

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -15,7 +15,9 @@ from biotite.sequence import (
     LetterAlphabet,
     Location,
     NucleotideSequence,
+    PositionalSequence,
     ProteinSequence,
+    PurePositionalSequence,
     SequenceProfile,
 )
 from biotite.sequence.align import Alignment, SubstitutionMatrix
@@ -31,6 +33,8 @@ __author__ = "Maximilian Greil"
         NucleotideSequence("AACTGCTA"),
         NucleotideSequence("AACTGCTA", ambiguous=True),
         ProteinSequence("BIQTITE"),
+        PositionalSequence(NucleotideSequence("AACTGCTA")),
+        PurePositionalSequence(123),
         Alphabet(["X", "Y", "Z"]),
         GeneralSequence(Alphabet(["X", 42, False]), ["X", 42, "X"]),
         I3DSequence("ACDE"),


### PR DESCRIPTION
This PR adds functionality for creating positional substitution matrices, i.e. matrices that have a score for each position in a sequence. This allows position-specific sequence alignments, such as algorithms like TM-align or sequence profile alignments using a `SequenceProfile`.