### PR TITLE
Micro-PR to add `alt_atom_id` to Biotite's internal CCD

### DIFF
--- a/setup_ccd.py
+++ b/setup_ccd.py
@@ -193,17 +193,19 @@ ATOM_COLUMNS = {
     ),
     "alt_atom_id": ColumnInfo(
         "U6",
-        [StringArrayEncoding(
-            # The unique strings in the column are sorted
-            # -> Indices do not follow distinct pattern
-            data_encoding=[ByteArrayEncoding(type=TypeCode.INT16)],
-            offset_encoding=[
-                DeltaEncoding(src_type=TypeCode.INT32),
-                RunLengthEncoding(),
-                IntegerPackingEncoding(byte_count=1, is_unsigned=True),
-                ByteArrayEncoding()
-            ]
-        )]
+        [
+            StringArrayEncoding(
+                # The unique strings in the column are sorted
+                # -> Indices do not follow distinct pattern
+                data_encoding=[ByteArrayEncoding(type=TypeCode.INT16)],
+                offset_encoding=[
+                    DeltaEncoding(src_type=TypeCode.INT32),
+                    RunLengthEncoding(),
+                    IntegerPackingEncoding(byte_count=1, is_unsigned=True),
+                    ByteArrayEncoding(),
+                ],
+            )
+        ],
     ),
 }
 

--- a/setup_ccd.py
+++ b/setup_ccd.py
@@ -191,6 +191,34 @@ ATOM_COLUMNS = {
         ],
         alternative="model_Cartn_z",
     ),
+    "alt_atom_id": ColumnInfo(
+        "U6",
+        [StringArrayEncoding(
+            # The unique strings in the column are sorted
+            # -> Indices do not follow distinct pattern
+            data_encoding=[ByteArrayEncoding(type=TypeCode.INT16)],
+            offset_encoding=[
+                DeltaEncoding(src_type=TypeCode.INT32),
+                RunLengthEncoding(),
+                IntegerPackingEncoding(byte_count=1, is_unsigned=True),
+                ByteArrayEncoding()
+            ]
+        )]
+    ),
+    "alt_atom_id": ColumnInfo(
+        "U6",
+        [StringArrayEncoding(
+            # The unique strings in the column are sorted
+            # -> Indices do not follow distinct pattern
+            data_encoding=[ByteArrayEncoding(type=TypeCode.INT16)],
+            offset_encoding=[
+                DeltaEncoding(src_type=TypeCode.INT32),
+                RunLengthEncoding(),
+                IntegerPackingEncoding(byte_count=1, is_unsigned=True),
+                ByteArrayEncoding()
+            ]
+        )]
+    ),
 }
 
 BOND_COLUMNS = {

--- a/setup_ccd.py
+++ b/setup_ccd.py
@@ -147,6 +147,22 @@ ATOM_COLUMNS = {
             )
         ],
     ),
+    "alt_atom_id": ColumnInfo(
+        "U6",
+        [
+            StringArrayEncoding(
+                # The unique strings in the column are sorted
+                # -> Indices do not follow distinct pattern
+                data_encoding=[ByteArrayEncoding(type=TypeCode.INT16)],
+                offset_encoding=[
+                    DeltaEncoding(src_type=TypeCode.INT32),
+                    RunLengthEncoding(),
+                    IntegerPackingEncoding(byte_count=1, is_unsigned=True),
+                    ByteArrayEncoding(),
+                ],
+            )
+        ],
+    ),
     "type_symbol": ColumnInfo(
         "U2",
         [
@@ -190,22 +206,6 @@ ATOM_COLUMNS = {
             ByteArrayEncoding(),
         ],
         alternative="model_Cartn_z",
-    ),
-    "alt_atom_id": ColumnInfo(
-        "U6",
-        [
-            StringArrayEncoding(
-                # The unique strings in the column are sorted
-                # -> Indices do not follow distinct pattern
-                data_encoding=[ByteArrayEncoding(type=TypeCode.INT16)],
-                offset_encoding=[
-                    DeltaEncoding(src_type=TypeCode.INT32),
-                    RunLengthEncoding(),
-                    IntegerPackingEncoding(byte_count=1, is_unsigned=True),
-                    ByteArrayEncoding(),
-                ],
-            )
-        ],
     ),
 }
 

--- a/setup_ccd.py
+++ b/setup_ccd.py
@@ -205,20 +205,6 @@ ATOM_COLUMNS = {
             ]
         )]
     ),
-    "alt_atom_id": ColumnInfo(
-        "U6",
-        [StringArrayEncoding(
-            # The unique strings in the column are sorted
-            # -> Indices do not follow distinct pattern
-            data_encoding=[ByteArrayEncoding(type=TypeCode.INT16)],
-            offset_encoding=[
-                DeltaEncoding(src_type=TypeCode.INT32),
-                RunLengthEncoding(),
-                IntegerPackingEncoding(byte_count=1, is_unsigned=True),
-                ByteArrayEncoding()
-            ]
-        )]
-    ),
 }
 
 BOND_COLUMNS = {


### PR DESCRIPTION
Micro-PR to add `alt_atom_id` to Biotite's internal CCD:

**Why?** This is useful for resolving atom names in PDB files that do not use the standard atom ids, but use the alternative atom ids instead. 