### PR TITLE
Docstrings for 'set_annotation': Remove 'None' as input type for 'array'.

### DIFF
--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -157,7 +157,7 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         ----------
         category : str
             The annotation category to be set.
-        array : ndarray or None
+        array : ndarray
             The new value of the annotation category. The size of the
             array must be the same as the array length.
 


### PR DESCRIPTION
Mini-PR to correct Docstrings for the `set_annotation` method under `_AtomArrayBase`.