### PR TITLE
 Add `compress()` function to decrease the file size of BinaryCIF files 

### DIFF
--- a/benchmarks/structure/benchmark_pdbx.py
+++ b/benchmarks/structure/benchmark_pdbx.py
@@ -8,8 +8,12 @@ PDB_ID = "1aki"
 
 
 @pytest.fixture
-def deserialized_data():
-    pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / f"{PDB_ID}.bcif")
+def pdbx_file():
+    return pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / f"{PDB_ID}.bcif")
+
+
+@pytest.fixture
+def deserialized_data(pdbx_file):
     categories = {}
     for category_name, category in pdbx_file.block.items():
         columns = {}
@@ -98,3 +102,11 @@ def benchmark_set_structure(atoms, tmp_path, format, include_bonds):
     pdbx_file = File()
     pdbx.set_structure(pdbx_file, atoms, include_bonds=include_bonds)
     pdbx_file.write(tmp_path / f"{PDB_ID}.{format}")
+
+
+@pytest.mark.benchmark
+def benchmark_compress(pdbx_file):
+    """
+    Compress a CIF file.
+    """
+    pdbx.compress(pdbx_file)

--- a/doc/tutorial/structure/io.rst
+++ b/doc/tutorial/structure/io.rst
@@ -204,6 +204,21 @@ A well chosen encoding can reduce the file size significantly.
         ).serialize()
     )
 
+As finding good encodings manually can be tedious, :func:`compress()` does this
+automatically - from a single :class:`BinaryCIFData` to an entire
+:class:`BinaryCIFFile`.
+
+.. jupyter-execute::
+
+    uncompressed_data = pdbx.BinaryCIFData(np.arange(100))
+    print(f"Uncompressed size: {len(uncompressed_data.serialize()["data"])} bytes")
+    compressed_data = pdbx.compress(uncompressed_data)
+    print(f"Compressed size: {len(compressed_data.serialize()["data"])} bytes")
+
+
+Using structures from a PDBx file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 While this low-level API is useful for using the entire potential of
 the PDBx format, most applications require only reading/writing a
 structure.

--- a/src/biotite/database/rcsb/query.py
+++ b/src/biotite/database/rcsb/query.py
@@ -441,7 +441,7 @@ class StructureQuery(SingleQuery):
 
     >>> query = StructureQuery("1L2Y", chain="A")
     >>> print(sorted(search(query)))
-    ['1L2Y', '1RIJ', '2JOF', '2LDJ', '2M7D', '7MQS']
+    ['1L2Y', '1RIJ', '2JOF', '2LDJ', '2M7D', '7MQS', '9DPF']
     """
 
     def __init__(self, pdb_id, chain=None, assembly=None, strict=True):

--- a/src/biotite/structure/io/pdbx/__init__.py
+++ b/src/biotite/structure/io/pdbx/__init__.py
@@ -18,5 +18,6 @@ __author__ = "Patrick Kunzmann"
 from .bcif import *
 from .cif import *
 from .component import *
+from .compress import *
 from .convert import *
 from .encoding import *

--- a/src/biotite/structure/io/pdbx/bcif.py
+++ b/src/biotite/structure/io/pdbx/bcif.py
@@ -38,8 +38,9 @@ class BinaryCIFData(_Component):
     array : array_like or int or float or str
         The data array to be stored.
         If a single item is given, it is converted into an array.
-    encoding : list of Encoding
+    encoding : list of Encoding , optional
         The encoding steps that are successively applied to the data.
+        By default, the data is stored uncompressed directly as bytes.
 
     Attributes
     ----------

--- a/src/biotite/structure/io/pdbx/compress.py
+++ b/src/biotite/structure/io/pdbx/compress.py
@@ -1,0 +1,249 @@
+__all__ = ["compress"]
+__name__ = "biotite.structure.io.pdbx"
+__author__ = "Patrick Kunzmann"
+
+import itertools
+import msgpack
+import numpy as np
+import biotite.structure.io.pdbx.bcif as bcif
+from biotite.structure.io.pdbx.bcif import _encode_numpy as encode_numpy
+from biotite.structure.io.pdbx.encoding import (
+    ByteArrayEncoding,
+    DeltaEncoding,
+    FixedPointEncoding,
+    IntegerPackingEncoding,
+    RunLengthEncoding,
+    StringArrayEncoding,
+)
+
+
+def compress(data, float_tolerance=1e-6):
+    """
+    Try to reduce the size of a *BinaryCIF* file (or block, category, etc.) by testing
+    different data encodings for each data array and selecting the one, which results in
+    the smallest size.
+
+    Parameters
+    ----------
+    data : BinaryCIFFile or BinaryCIFBlock or BinaryCIFCategory or BinaryCIFColumn or BinaryCIFData
+        The data to compress.
+
+    Returns
+    -------
+    compressed_file : BinaryCIFFile or BinaryCIFBlock or BinaryCIFCategory or BinaryCIFColumn or BinaryCIFData
+        The compressed data with the same type as the input data.
+        If no improved compression is found for a :class:`BinaryCIFData` array,
+        the input data is kept.
+        Hence, the return value is no deep copy of the input data.
+    float_tolerance : float, optional
+        The relative error that is accepted when compressing floating point numbers.
+    """
+    match type(data):
+        case bcif.BinaryCIFFile:
+            return _compress_file(data, float_tolerance)
+        case bcif.BinaryCIFBlock:
+            return _compress_block(data, float_tolerance)
+        case bcif.BinaryCIFCategory:
+            return _compress_category(data, float_tolerance)
+        case bcif.BinaryCIFColumn:
+            return _compress_column(data, float_tolerance)
+        case bcif.BinaryCIFData:
+            return _compress_data(data, float_tolerance)
+        case _:
+            raise TypeError(f"Unsupported type {type(data).__name__}")
+
+
+def _compress_file(bcif_file, float_tolerance):
+    compressed_file = bcif.BinaryCIFFile()
+    for block_name, bcif_block in bcif_file.items():
+        compressed_block = _compress_block(bcif_block, float_tolerance)
+        compressed_file[block_name] = compressed_block
+    return compressed_file
+
+
+def _compress_block(bcif_block, float_tolerance):
+    compressed_block = bcif.BinaryCIFBlock()
+    for category_name, bcif_category in bcif_block.items():
+        compressed_category = _compress_category(bcif_category, float_tolerance)
+        compressed_block[category_name] = compressed_category
+    return compressed_block
+
+
+def _compress_category(bcif_category, float_tolerance):
+    compressed_category = bcif.BinaryCIFCategory()
+    for column_name, bcif_column in bcif_category.items():
+        compressed_column = _compress_column(bcif_column, float_tolerance)
+        compressed_category[column_name] = compressed_column
+    return compressed_category
+
+
+def _compress_column(bcif_column, float_tolerance):
+    data = _compress_data(bcif_column.data, float_tolerance)
+    if bcif_column.mask is not None:
+        mask = _compress_data(bcif_column.mask, float_tolerance)
+    else:
+        mask = None
+    return bcif.BinaryCIFColumn(data, mask)
+
+
+def _compress_data(bcif_data, float_tolerance):
+    array = bcif_data.array
+    if len(array) == 1:
+        # No need to compress a single value -> Use default uncompressed encoding
+        return bcif.BinaryCIFData(array)
+
+    if np.issubdtype(array.dtype, np.str_):
+        # Leave encoding empty for now, as it is explicitly set later
+        encoding = StringArrayEncoding(data_encoding=[], offset_encoding=[])
+        # Run encode to initialize the data and offset arrays
+        indices = encoding.encode(array)
+        offsets = np.cumsum([0] + [len(s) for s in encoding.strings])
+        encoding.data_encoding, _ = _find_best_integer_compression(indices)
+        encoding.offset_encoding, _ = _find_best_integer_compression(offsets)
+        return bcif.BinaryCIFData(array, [encoding])
+
+    elif np.issubdtype(array.dtype, np.floating):
+        to_integer_encoding = FixedPointEncoding(
+            10 ** _get_decimal_places(array, float_tolerance)
+        )
+        integer_array = to_integer_encoding.encode(array)
+        best_encoding, size_compressed = _find_best_integer_compression(integer_array)
+        if size_compressed < _data_size_in_file(bcif.BinaryCIFData(array)):
+            return bcif.BinaryCIFData(array, [to_integer_encoding] + best_encoding)
+        else:
+            # The float array is smaller -> encode it directly as bytes
+            return bcif.BinaryCIFData(array, [ByteArrayEncoding()])
+
+    elif np.issubdtype(array.dtype, np.integer):
+        array = _to_smallest_integer_type(array)
+        encodings, _ = _find_best_integer_compression(array)
+        return bcif.BinaryCIFData(array, encodings)
+
+    else:
+        raise TypeError(f"Unsupported data type {array.dtype}")
+
+
+def _find_best_integer_compression(array):
+    """
+    Try different data encodings on an integer array and return the one that results in
+    the smallest size.
+    """
+    # Default is no compression at all
+    best_encoding_sequence = [ByteArrayEncoding()]
+    smallest_size = _data_size_in_file(
+        bcif.BinaryCIFData(array, best_encoding_sequence)
+    )
+    for (
+        use_delta,
+        use_run_length,
+        packed_byte_count,
+    ) in itertools.product([False, True], [False, True], [None, 1, 2]):
+        encoding_sequence = []
+        if use_delta:
+            encoding_sequence.append(DeltaEncoding())
+        if use_run_length:
+            encoding_sequence.append(RunLengthEncoding())
+        if packed_byte_count is not None:
+            encoding_sequence.append(IntegerPackingEncoding(packed_byte_count))
+        encoding_sequence.append(ByteArrayEncoding())
+        size = _data_size_in_file(bcif.BinaryCIFData(array, encoding_sequence))
+        if size < smallest_size:
+            best_encoding_sequence = encoding_sequence
+            smallest_size = size
+    return best_encoding_sequence, smallest_size
+
+
+def _to_smallest_integer_type(array):
+    """
+    Convert an integer array to the smallest possible integer type, that is still able
+    to represent all values in the array.
+
+    Parameters
+    ----------
+    array : numpy.ndarray
+        The array to convert.
+
+    Returns
+    -------
+    array : numpy.ndarray
+        The converted array.
+    """
+    if array.min() >= 0:
+        for dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
+            if np.all(array <= np.iinfo(dtype).max):
+                return array.astype(dtype)
+    for dtype in [np.int8, np.int16, np.int32, np.int64]:
+        if np.all(array >= np.iinfo(dtype).min) and np.all(
+            array <= np.iinfo(dtype).max
+        ):
+            return array.astype(dtype)
+    raise ValueError("Array is out of bounds for all integer types")
+
+
+def _data_size_in_file(data):
+    """
+    Get the size of a :class:`BinaryCIFData` object, it would have when written into a
+    file.
+
+    Parameters
+    ----------
+    data : BinaryCIFData
+        The data array whose size is measured.
+
+    Returns
+    -------
+    size : int
+        The size of the data array in the file in bytes.
+    """
+    bytes_in_file = msgpack.packb(
+        data.serialize(), use_bin_type=True, default=encode_numpy
+    )
+    return len(bytes_in_file)
+
+
+def _get_decimal_places(array, tol):
+    """
+    Get the number of decimal places in a floating point array.
+
+    Parameters
+    ----------
+    array : numpy.ndarray
+        The array to analyze.
+    tol : float, optional
+        The relative tolerance allowed when the values are cut off after the returned
+        number of decimal places.
+
+    Returns
+    -------
+    decimals : int
+        The number of decimal places.
+    """
+    # Decimals of NaN or infinite values do not make sense
+    # and 0 would give NaN when rounding on decimals
+    array = array[np.isfinite(array) & (array != 0)]
+    for decimals in itertools.count(start=-_order_magnitude(array)):
+        error = np.abs(np.round(array, decimals) - array)
+        if np.all(error < tol * np.abs(array)):
+            return decimals
+
+
+def _order_magnitude(array):
+    """
+    Get the order of magnitude of floating point values.
+
+    Parameters
+    ----------
+    array : ndarray, dtype=float
+        The value to analyze.
+
+    Returns
+    -------
+    magnitude : int
+        The order of magnitude, i.e. the maximum exponent a number in the array would
+        have in scientific notation, if only one digit is left of the decimal point.
+    """
+    array = array[array != 0]
+    if len(array) == 0:
+        # No non-zero values -> define order of magnitude as 0
+        return 0
+    return int(np.max(np.floor(np.log10(np.abs(array)))).item())

--- a/src/biotite/structure/io/pdbx/compress.py
+++ b/src/biotite/structure/io/pdbx/compress.py
@@ -37,6 +37,26 @@ def compress(data, float_tolerance=1e-6):
         Hence, the return value is no deep copy of the input data.
     float_tolerance : float, optional
         The relative error that is accepted when compressing floating point numbers.
+
+    Examples
+    --------
+
+    >>> from io import BytesIO
+    >>> pdbx_file = BinaryCIFFile()
+    >>> set_structure(pdbx_file, atom_array_stack)
+    >>> # Write uncompressed file
+    >>> uncompressed_file = BytesIO()
+    >>> pdbx_file.write(uncompressed_file)
+    >>> _ = uncompressed_file.seek(0)
+    >>> print(f"{len(uncompressed_file.read()) // 1000} KB")
+    931 KB
+    >>> # Write compressed file
+    >>> pdbx_file = compress(pdbx_file)
+    >>> compressed_file = BytesIO()
+    >>> pdbx_file.write(compressed_file)
+    >>> _ = compressed_file.seek(0)
+    >>> print(f"{len(compressed_file.read()) // 1000} KB")
+    113 KB
     """
     match type(data):
         case bcif.BinaryCIFFile:

--- a/src/biotite/structure/io/pdbx/encoding.pyx
+++ b/src/biotite/structure/io/pdbx/encoding.pyx
@@ -750,7 +750,7 @@ class StringArrayEncoding(Encoding):
         If omitted, the unique strings are determined from the data the
         first time :meth:`encode()` is called.
     data_encoding : list of Encoding, optional
-        The encodings that are applied to the indiy array.
+        The encodings that are applied to the index array.
         If omitted, the array is directly encoded into bytes without
         further compression.
     offset_encoding : list of Encoding, optional
@@ -888,6 +888,19 @@ _encoding_classes_kinds = {
 
 
 def deserialize_encoding(content):
+    """
+    Create a :class:`Encoding` by deserializing the given *BinaryCIF* content.
+
+    Parameters
+    ----------
+    content : dict
+        The encoding represenet as *BinaryCIF* dictionary.
+
+    Returns
+    -------
+    encoding : Encoding
+        The deserialized encoding.
+    """
     try:
         encoding_class = _encoding_classes[content["kind"]]
     except KeyError:
@@ -898,21 +911,62 @@ def deserialize_encoding(content):
 
 
 def create_uncompressed_encoding(array):
-    dtype = array.dtype
+    """
+    Create a simple encoding for the given array that does not compress the data.
 
-    if np.issubdtype(dtype, np.str_):
+    Parameters
+    ----------
+    array : ndarray
+        The array to to create the encoding for.
+
+    Returns
+    -------
+    encoding : list of Encoding
+        The encoding for the data.
+    """
+    if np.issubdtype(array.dtype, np.str_):
         return [StringArrayEncoding()]
     else:
         return [ByteArrayEncoding()]
 
 
 def encode_stepwise(data, encoding):
+    """
+    Apply a list of encodings stepwise to the given data.
+
+    Parameters
+    ----------
+    data : ndarray
+        The data to be encoded.
+    encoding : list of Encoding
+        The encodings to be applied.
+
+    Returns
+    -------
+    encoded_data : ndarray or bytes
+        The encoded data.
+    """
     for encoding in encoding:
         data = encoding.encode(data)
     return data
 
 
 def decode_stepwise(data, encoding):
+    """
+    Apply a list of encodings stepwise to the given data.
+
+    Parameters
+    ----------
+    data : ndarray or bytes
+        The data to be decoded.
+    encoding : list of Encoding
+        The encodings to be applied.
+
+    Returns
+    -------
+    decoded_data : ndarray
+        The decoded data.
+    """
     for enc in reversed(encoding):
         data = enc.decode(data)
     return data

--- a/src/biotite/structure/io/pdbx/encoding.pyx
+++ b/src/biotite/structure/io/pdbx/encoding.pyx
@@ -550,8 +550,11 @@ class DeltaEncoding(Encoding):
     --------
 
     >>> data = np.array([1, 1, 2, 3, 5, 8])
-    >>> print(DeltaEncoding().encode(data))
-    [1 0 1 1 2 3]
+    >>> encoding = DeltaEncoding()
+    >>> print(encoding.encode(data))
+    [0 0 1 1 2 3]
+    >>> print(encoding.origin)
+    1
     """
     src_type: ... = None
     origin: ... = None


### PR DESCRIPTION
When data is set in `BinaryCIFFile` objects (e.g via `set_structure()`), a simple default encoding is used which does not compress the data. Although this is fast, the resulting files can be significantly larger. This PR introduces the `compress()` function, which takes an existing `BinaryCIF...` object and creates `BinaryCIF...` object with size-optimized encoding.

The resulting files are significantly smaller than the uncompressed ones and even quite a bit smaller than the ones originating from the PDB. The following example shows the size for `1L2Y`:

```
Original file from PDB:   199893 bytes
Uncompressed file:       1299713 bytes
File after `compress()`:  169448 bytes
```