### PR TITLE
Omit 'standard' bonds when writing `struct_conn` category

### DIFF
--- a/src/biotite/structure/io/pdbx/compress.py
+++ b/src/biotite/structure/io/pdbx/compress.py
@@ -49,14 +49,14 @@ def compress(data, float_tolerance=1e-6):
     >>> pdbx_file.write(uncompressed_file)
     >>> _ = uncompressed_file.seek(0)
     >>> print(f"{len(uncompressed_file.read()) // 1000} KB")
-    931 KB
+    927 KB
     >>> # Write compressed file
     >>> pdbx_file = compress(pdbx_file)
     >>> compressed_file = BytesIO()
     >>> pdbx_file.write(compressed_file)
     >>> _ = compressed_file.seek(0)
     >>> print(f"{len(compressed_file.read()) // 1000} KB")
-    113 KB
+    111 KB
     """
     match type(data):
         case bcif.BinaryCIFFile:


### PR DESCRIPTION
This PR increases the speed in which PDBx files with structure + bonds written by Biotite can be read:

Currently, `pdbx.set_structure(include_bonds=True)` writes **all** inter-residue bonds, to be sure that all required bonds are written, because the [PDBx dictionary](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Categories/struct_conn.html) describes the bonds that are stored in this category rather vaguely:

> Nonstandard residue linkage. The LINK records specify connectivity between residues that is not implied by the primary structure.

This means that the `struct_conn` category can become much larger than in the original from the PDB.

For parsing the `struct_conn` category again, each of its rows is matched against each row in `atom_site`. While this can be done in a fast vectorized manner using `(n_atoms x n_bonds)` boolean matrices, this does not scale well when `struct_conn` is 'verbose' as described above: Now these matrices effectively have approximately the shape `(n_atoms x n_residues)`, because there is one bond for each residue linkage. As `n_residues` is approximately proportional to `n_atoms`, the shape of the boolean matrices and thus the time complexity becomes `O(n^2)`. Therefore, the time for parsing inter-residue bonds explodes for larger structures.

The solution of this PR is to write less inter-residue bonds to `struct_conn`: While the specification of the category is no very precise, backbone bonds between adjacent canonical amino acids/nucleotides can be definetely excluded from the category. Filtering these out, renders the size of `struct_conn` much smaller and, more importantly, it does not scale with the number of atoms anymore.