### PR TITLE
Avoid deserialization of PDBx data in `__contains__()`

### DIFF
--- a/src/biotite/structure/io/pdbx/bcif.py
+++ b/src/biotite/structure/io/pdbx/bcif.py
@@ -510,6 +510,9 @@ class BinaryCIFBlock(_HierarchicalContainer):
     def __iter__(self):
         return (key.lstrip("_") for key in super().__iter__())
 
+    def __contains__(self, key):
+        return super().__contains__("_" + key)
+
 
 class BinaryCIFFile(File, _HierarchicalContainer):
     """

--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -416,6 +416,9 @@ class CIFCategory(_Component, MutableMapping):
             raise ValueError("At least one column must remain")
         del self._columns[key]
 
+    def __contains__(self, key):
+        return key in self._columns
+
     def __iter__(self):
         return iter(self._columns)
 
@@ -708,6 +711,9 @@ class CIFBlock(_Component, MutableMapping):
     def __delitem__(self, key):
         del self._categories[key]
 
+    def __contains__(self, key):
+        return key in self._categories
+
     def __iter__(self):
         return iter(self._categories)
 
@@ -912,6 +918,9 @@ class CIFFile(_Component, File, MutableMapping):
 
     def __delitem__(self, key):
         del self._blocks[key]
+
+    def __contains__(self, key):
+        return key in self._blocks
 
     def __iter__(self):
         return iter(self._blocks)

--- a/src/biotite/structure/io/pdbx/component.py
+++ b/src/biotite/structure/io/pdbx/component.py
@@ -223,6 +223,11 @@ class _HierarchicalContainer(_Component, MutableMapping, metaclass=ABCMeta):
     def __delitem__(self, key):
         del self._elements[key]
 
+    # Implement `__contains__()` explicitly,
+    # because the mixin method unnecessarily deserializes the value, if available
+    def __contains__(self, key):
+        return key in self._elements
+
     def __iter__(self):
         return iter(self._elements)
 


### PR DESCRIPTION
Currently the CIF and BinaryCIF container classes use the default *mixin* implementation of `__contains__()`. However, this default implementation uses

```python
try:
    self[key]:
except KeyError:
    return False
return True
```

Hence, calling `__contains__()` actually gets the value, e.g. checking if a category name is in a CIF/BCIF block would automatically deserialize the category data. This counteracts the lazy deserialization behavior.

This PR explicitly implements `__contains__()` for all the mentioned container classes, checking only if a key is present and thus avoid the automatic deserialization. 