### PR TITLE
Do not try integer packing for huge values

### DIFF
--- a/src/biotite/application/viennarna/rnaplot.py
+++ b/src/biotite/application/viennarna/rnaplot.py
@@ -99,8 +99,12 @@ class RNAplotApp(LocalApp):
         self._in_file.write(self._dot_bracket)
         self._in_file.flush()
         self.set_arguments(
-            ["-i", self._in_file.name, "-o", "xrna", "-t", self._layout_type]
-        )
+            [
+                "-i", self._in_file.name,
+                "--output-format", "xrna",
+                "-t", self._layout_type,
+            ]
+        )  # fmt: skip
         super().run()
 
     def evaluate(self):

--- a/src/biotite/structure/io/pdbx/encoding.pyx
+++ b/src/biotite/structure/io/pdbx/encoding.pyx
@@ -696,7 +696,7 @@ class IntegerPackingEncoding(Encoding):
         # Get length of output array
         # by summing up required length of each element
         cdef int number
-        cdef int length = 0
+        cdef long length = 0
         for i in range(data.shape[0]):
             number = data[i]
             if number < 0:


### PR DESCRIPTION
Currently, `pdbx.compress()` will always try integer packing on an integer array. However, this may explode, if the input array has large input values, as the number of bytes per element is `(value // 256) + 1` (for `byte_count=1` and `is_unsigned=True`).
This PR fixes this by estimating the integer packing output size before trying it.