### PR TITLE
Update _split_one_line and remove whitespace parameter

### DIFF
--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -7,7 +7,6 @@ __author__ = "Patrick Kunzmann"
 __all__ = ["CIFFile", "CIFBlock", "CIFCategory", "CIFColumn", "CIFData"]
 
 import itertools
-import re
 from collections.abc import MutableMapping, Sequence
 import numpy as np
 from biotite.file import (
@@ -1062,6 +1061,7 @@ def _split_one_line(line):
                 word, _, line = striped_line[1:].partition(separator)
 
             yield word
+
 
 def _arrayfy(data):
     if not isinstance(data, (Sequence, np.ndarray)) or isinstance(data, str):

--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -1045,9 +1045,9 @@ def _split_one_line(line):
         # Loop over the line
         while line:
             # Strip leading whitespace(s)
-            striped_line = line.lstrip()
+            stripped_line = line.lstrip()
             # Split the line on whitespace
-            word, _, line = striped_line.partition(" ")
+            word, _, line = stripped_line.partition(" ")
             # Handle the case where the word start with a quote
             if word.startswith(("'", '"')):
                 # Set the separator to the quote found
@@ -1058,7 +1058,7 @@ def _split_one_line(line):
                     yield word[1:-1]
                     continue
                 # split the word on the separator
-                word, _, line = striped_line[1:].partition(separator)
+                word, _, line = stripped_line[1:].partition(separator)
 
             yield word
 

--- a/tests/database/test_rcsb.py
+++ b/tests/database/test_rcsb.py
@@ -31,7 +31,7 @@ def test_fetch(format, as_file_like):
     if format == "pdb":
         file = pdb.PDBFile.read(file_path_or_obj)
         pdb.get_structure(file)
-    elif format == "pdbx":
+    elif format == "cif":
         file = pdbx.CIFFile.read(file_path_or_obj)
         pdbx.get_structure(file)
     elif format == "bcif":

--- a/tests/structure/io/test_pdbx.py
+++ b/tests/structure/io/test_pdbx.py
@@ -85,7 +85,7 @@ def test_split_one_line(cif_line, expected_fields):
     """
     Test whether values that have an embedded quote are properly escaped.
     """
-    assert pdbx.cif._split_one_line(cif_line) == expected_fields
+    assert list(pdbx.cif._split_one_line(cif_line)) == expected_fields
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is an attempt to update _split_one_line function to avoid usage of 'whitespace' parameter and approximation made for '_atom_site' CIF block.

Performance have to be approved with a CI run.