### PR TITLE
disambiguate assembly chains by appending assembly id

### DIFF
--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -57,14 +57,15 @@ The annotation arrays can be accessed either via the method
 The following annotation categories are optionally used by some
 functions:
 
-=========  ===========  =================   ============================
+=========  ===========  =================   =========================================
 Category   Type         Examples            Description
-=========  ===========  =================   ============================
+=========  ===========  =================   =========================================
 atom_id    int          1,2,3, ...          Atom serial number
 b_factor   float        0.9, 12.3, ...      Temperature factor
 occupancy  float        .1, .3, .9, ...     Occupancy
 charge     int          -2,-1,0,1,2, ...    Electric charge of the atom
-=========  ===========  =================   ============================
+sym_id     string       '1','2','3', ...    Symmetry ID for assemblies/symmetry mates
+=========  ===========  =================   =========================================
 
 For each type, the attributes can be accessed directly.
 Both :class:`AtomArray` and :class:`AtomArrayStack` support

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -218,6 +218,8 @@ def get_assembly(
     assembly : AtomArray or AtomArrayStack
         The assembly.
         The return type depends on the `model` parameter.
+        Contains the `sym_id` annotation, which enumerates the copies of the asymmetric
+        unit in the assembly.
 
     Examples
     --------

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -790,6 +790,8 @@ class PDBFile(TextFile):
         assembly : AtomArray or AtomArrayStack
             The assembly.
             The return type depends on the `model` parameter.
+            Contains the `sym_id` annotation, which enumerates the copies of the
+            asymmetric unit in the assembly.
 
         Examples
         --------

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -855,8 +855,12 @@ class PDBFile(TextFile):
             affected_chain_ids = []
             transform_start = None
             for j, line in enumerate(assembly_lines[start:stop]):
-                if line.startswith("APPLY THE FOLLOWING TO CHAINS:") or line.startswith(
-                    "                   AND CHAINS:"
+                if any(
+                    line.startswith(chain_signal_string)
+                    for chain_signal_string in [
+                        "APPLY THE FOLLOWING TO CHAINS:",
+                        "                   AND CHAINS:",
+                    ]
                 ):
                     affected_chain_ids += [
                         chain_id.strip() for chain_id in line[30:].split(",")
@@ -1150,7 +1154,11 @@ def _apply_transformations(structure, rotations, translations):
         coord += translation
         assembly_coord[i] = coord
 
-    return repeat(structure, assembly_coord)
+    assembly = repeat(structure, assembly_coord)
+    assembly.set_annotation(
+        "sym_id", np.repeat(np.arange(len(rotations)), structure.array_length())
+    )
+    return assembly
 
 
 def _check_pdb_compatibility(array, hybrid36):

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -1557,7 +1557,10 @@ def get_assembly(
     Returns
     -------
     assembly : AtomArray or AtomArrayStack
-        The assembly. The return type depends on the `model` parameter.
+        The assembly.
+        The return type depends on the `model` parameter.
+        Contains the `sym_id` annotation, which enumerates the copies of the asymmetric
+        unit in the assembly.
 
     Examples
     --------

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -1652,6 +1652,7 @@ def _apply_transformations(structure, transformation_dict, operations):
         coord = structure.coord
         # Execute for each transformation step
         # in the operation expression
+        coord.chain_id += "-" + "-".join(operation)
         for op_step in operation:
             rotation_matrix, translation_vector = transformation_dict[op_step]
             # Rotate

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -1649,7 +1649,6 @@ def _apply_transformations(structure, transformation_dict, operations):
     """
     # Additional first dimesion for 'structure.repeat()'
     assembly_coord = np.zeros((len(operations),) + structure.coord.shape)
-    sym_ids = []
     # Apply corresponding transformation for each copy in the assembly
     for i, operation in enumerate(operations):
         coord = structure.coord
@@ -1661,12 +1660,12 @@ def _apply_transformations(structure, transformation_dict, operations):
             coord = matrix_rotate(coord, rotation_matrix)
             # Translate
             coord += translation_vector
-
-        sym_ids.append("-".join(list(operation)))
         assembly_coord[i] = coord
 
     assembly = repeat(structure, assembly_coord)
-    assembly.set_annotation("sym_id", np.repeat(sym_ids, structure.array_length()))
+    assembly.set_annotation(
+        "sym_id", np.repeat(np.arange(len(operations)), structure.array_length())
+    )
     return assembly
 
 

--- a/tests/structure/io/test_pdb.py
+++ b/tests/structure/io/test_pdb.py
@@ -158,6 +158,9 @@ def test_pdbx_consistency_assembly(path, model):
     ref_assembly = pdbx.get_assembly(pdbx_file, model=model)
 
     for category in ref_assembly.get_annotation_categories():
+        if category == "sym_id":
+            # Symmetry ID annotation is currently not returned for PDB files
+            continue
         assert (
             test_assembly.get_annotation(category).tolist()
             == ref_assembly.get_annotation(category).tolist()

--- a/tests/structure/io/test_pdb.py
+++ b/tests/structure/io/test_pdb.py
@@ -158,9 +158,6 @@ def test_pdbx_consistency_assembly(path, model):
     ref_assembly = pdbx.get_assembly(pdbx_file, model=model)
 
     for category in ref_assembly.get_annotation_categories():
-        if category == "sym_id":
-            # Symmetry ID annotation is currently not returned for PDB files
-            continue
         assert (
             test_assembly.get_annotation(category).tolist()
             == ref_assembly.get_annotation(category).tolist()

--- a/tests/structure/io/test_pdbx.py
+++ b/tests/structure/io/test_pdbx.py
@@ -479,19 +479,19 @@ def test_assembly_chain_count(format, pdb_id, model):
 
 
 @pytest.mark.parametrize(
-    "pdb_id, assembly_id, ref_sym_ids",
+    "pdb_id, assembly_id, symmetric_unit_count",
     [
         # Single operation
-        ("5zng", "1", np.array([1]).astype(str)),
+        ("5zng", "1", 1),
         # Multiple operations with continuous operation IDs
-        ("1f2n", "1", np.arange(1, 60 + 1).astype(str)),
+        ("1f2n", "1", 60),
         # Multiple operations with discontinuous operation IDs
-        ("1f2n", "4", np.array([1, 2, 6, 10, 23, 24]).astype(str)),
+        ("1f2n", "4", 6),
         # Multiple combined operations
-        ("1f2n", "6", np.char.add(np.arange(1, 60 + 1).astype(str), "-X0")),
+        ("1f2n", "6", 60),
     ],
 )
-def test_assembly_sym_id(pdb_id, assembly_id, ref_sym_ids):
+def test_assembly_sym_id(pdb_id, assembly_id, symmetric_unit_count):
     """
     Check if the :func:`get_assembly()` function returns the correct
     symmetry ID annotation for a known example.
@@ -500,11 +500,11 @@ def test_assembly_sym_id(pdb_id, assembly_id, ref_sym_ids):
     assembly = pdbx.get_assembly(pdbx_file, assembly_id=assembly_id)
     # 'unique_indices' contains the FIRST occurence of each unique value
     unique_sym_ids, unique_indices = np.unique(assembly.sym_id, return_index=True)
-    # Sort by first occurrence instead of alphabetically
+    # Sort by first occurrence
     order = np.argsort(unique_indices)
     unique_sym_ids = unique_sym_ids[order]
     unique_indices = unique_indices[order]
-    assert unique_sym_ids.tolist() == ref_sym_ids.tolist()
+    assert unique_sym_ids.tolist() == list(range(symmetric_unit_count))
     # Every asymmetric unit should have the same length,
     # as each operation is applied to all atoms in the asymmetric unit
     asym_lengths = np.diff(np.append(unique_indices, assembly.array_length()))


### PR DESCRIPTION
Biotite doesn't currently distinguish between the chains produced by symmetry operations on a given asym unit in an assembly.

This can make certain selection operations slightly inconvenient (e.g. getting residue starts of a specific chain etc.) and is inconsistent with the chain naming convention employed by the PDB in assembly .cif files.

This PR follows the PDB convention of appending a '-<oper_id>' to the chain ids.

