### PR TITLE
Temporarily revert DSSP version in environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
   - anaconda
   - conda-forge
   - bioconda
+  - salilab
 
 dependencies:
   - python =3.12
@@ -30,7 +31,7 @@ dependencies:
   # Interfaced software in biotite.application (can also be installed separately)
   - autodock-vina
   - clustalo
-  - dssp =4
+  - dssp =3
   - mafft
   - muscle =3
   - sra-tools


### PR DESCRIPTION
Due to the current issues in the Conda DSSP build (https://github.com/conda-forge/dssp-feedstock/pull/4), this PR uses the `dssp` build from `salilab` again.