### PR TITLE
Add support for space group information when reading and writing pdb files

### DIFF
--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -571,8 +571,8 @@ class PDBFile(TextFile):
                     z_val = int(line[_z])
                 except ValueError:
                     # File contains invalid 'CRYST1' record
-                    warnings.warn(
-                        "File contains invalid 'CRYST1' record, using defaults"
+                    raise InvalidFileError(
+                        "File does not contain assembly information (REMARK 300)"
                     )
                     # Set default values
                     space_group = "P 1"
@@ -753,13 +753,12 @@ class PDBFile(TextFile):
 
                     # Replace the existing CRYST1 record
                     self.lines[i] = line[:55] + space_group_str + z_val_str + line[70:]
-                except (ValueError, AttributeError):
-                    # File contains invalid 'CRYST1' record
-                    warnings.warn(
-                        "File contains invalid 'CRYST1' record; defaulting to 'P 1'"
-                        "space group and '1' Z value"
+                except (ValueError, AttributeError) as e:
+                    # Raise an exception with context
+                    raise AttributeError(
+                        f"Failed to update CRYST1 record. "
+                        f"Line: {line.strip()} | Error: {e}"
                     )
-                    break
                 break
 
     def list_assemblies(self):

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -572,7 +572,7 @@ class PDBFile(TextFile):
                 except ValueError:
                     # File contains invalid 'CRYST1' record
                     raise InvalidFileError(
-                        "File does not contain assembly information (REMARK 300)"
+                        "File does not contain valid space group and/or Z values"
                     )
                     # Set default values
                     space_group = "P 1"

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -740,8 +740,8 @@ class PDBFile(TextFile):
 
         Parameters
         ----------
-            add_info : namedtuple or similar
-                Containes 'space_group' (str) and 'z_val' (int) attributes
+        info : tuple(str, int) or SpaceGroupInfo
+            Contains the space group and Z-value.
         """
         for i, line in enumerate(self.lines):
             if line.startswith("CRYST1"):

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -734,7 +734,7 @@ class PDBFile(TextFile):
 
         self._index_models_and_atoms()
 
-    def set_space_group(self, add_info):
+    def set_space_group(self, info):
         """
         Update the CRYST1 record with the provided space group and Z value.
 

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -554,9 +554,10 @@ class PDBFile(TextFile):
 
         Returns
         -------
-        SpaceGroupInfo : A namedtuple
-            space_group (str): The extracted space group, or "P 1" if not found.
-            z_val (int): The extracted Z value, or 1 if not found.
+        space_group : str
+            The extracted space group.
+        z_val : int
+            The extracted Z value.
         """
         # Initialize the namedtuple
         SpaceGroupInfo = namedtuple("SpaceGroupInfo", ["space_group", "z_val"])

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -748,8 +748,8 @@ class PDBFile(TextFile):
             if line.startswith("CRYST1"):
                 try:
                     # Format the replacement string
-                    space_group_str = add_info.space_group.ljust(11)
-                    z_val_str = str(add_info.z_val).rjust(4)
+                    space_group_str = info.space_group.ljust(11)
+                    z_val_str = str(info.z_val).rjust(4)
 
                     # Replace the existing CRYST1 record
                     self.lines[i] = line[:55] + space_group_str + z_val_str + line[70:]

--- a/tests/structure/io/test_pdb.py
+++ b/tests/structure/io/test_pdb.py
@@ -76,18 +76,16 @@ def test_array_conversion(path, model, hybrid36, include_bonds):
         )
     assert array1.coord.tolist() == array2.coord.tolist()
 
+
 @pytest.mark.parametrize(
     "path, model",
-    itertools.product(
-        glob.glob(join(data_dir("structure"), "*.pdb")), 
-        [None, 1, -1]
-    ),
+    itertools.product(glob.glob(join(data_dir("structure"), "*.pdb")), [None, 1, -1]),
 )
 def test_space_group(path, model):
     """
-    Test the preservation of space group information and structure 
+    Test the preservation of space group information and structure
     when reading and writing a PDB file.
-    
+
     Parameters
     ----------
     path : str
@@ -122,6 +120,7 @@ def test_space_group(path, model):
     # Assertions to check if the original and new data match
     assert stack1 == stack2, "Structure mismatch after writing and reading."
     assert cryst1 == cryst2, "Space group mismatch after writing and reading."
+
 
 @pytest.mark.parametrize(
     "path, model",

--- a/tests/structure/io/test_pdb.py
+++ b/tests/structure/io/test_pdb.py
@@ -110,8 +110,8 @@ def test_space_group(path, model):
 
     # Write the structure and space group back to a new PDB file
     pdb_file = pdb.PDBFile()
-    pdb.set_structure(pdb_file, stack1)
-    pdb.PDBFile.set_space_group(pdb_file, cryst1)
+    pdb_file.set_structure(stack1)
+    pdb_file.set_space_group(cryst1)
 
     # Re-read the structure and space group
     stack2 = pdb_file.get_structure(model=model)

--- a/tests/structure/io/test_pdb.py
+++ b/tests/structure/io/test_pdb.py
@@ -78,10 +78,10 @@ def test_array_conversion(path, model, hybrid36, include_bonds):
 
 
 @pytest.mark.parametrize(
-    "path, model",
-    itertools.product(glob.glob(join(data_dir("structure"), "*.pdb")), [None, 1, -1]),
+    "path",
+    glob.glob(join(data_dir("structure"), "*.pdb")),
 )
-def test_space_group(path, model):
+def test_space_group(path):
     """
     Test the preservation of space group information and structure
     when reading and writing a PDB file.
@@ -90,23 +90,17 @@ def test_space_group(path, model):
     ----------
     path : str
         Path to the PDB file.
-    model : int or None
-        Model index for multi-model PDB files, or None to include all models.
     """
     # Read the PDB file
     pdb_file = pdb.PDBFile.read(path)
-    print(f"Testing file: {path}, model: {model}")
+    print(f"Testing file: {path}")
 
     try:
         # Extract structure and space group
-        stack1 = pdb_file.get_structure(model=model)  # Removed duplicate argument
+        stack1 = pdb_file.get_structure(model=1)
         cryst1 = pdb_file.get_space_group()
     except biotite.InvalidFileError:
-        # If parsing fails for model=None due to mismatched atom counts, skip the test
-        if model is None:
-            pytest.skip("Skipping test due to incompatible atom counts across models.")
-        else:
-            raise  # Re-raise the error for other cases
+        raise
 
     # Write the structure and space group back to a new PDB file
     pdb_file = pdb.PDBFile()
@@ -114,7 +108,7 @@ def test_space_group(path, model):
     pdb_file.set_space_group(cryst1)
 
     # Re-read the structure and space group
-    stack2 = pdb_file.get_structure(model=model)
+    stack2 = pdb_file.get_structure(model=1)
     cryst2 = pdb_file.get_space_group()
 
     # Assertions to check if the original and new data match


### PR DESCRIPTION
Added `get_space_group()` and `set_space_group()` methods as discussed in #689 to support space group and Z value reading/writing for (deprecated) PDB files.