### PR TITLE
fix: allow matching `nan` values in annotations (e.g. when b_factors are set to `nan`)

### DIFF
--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -255,7 +255,9 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         if not self.equal_annotation_categories(item):
             return False
         for name in self._annot:
-            if not np.array_equal(self._annot[name], item._annot[name], equal_nan=equal_nan):
+            if not np.array_equal(
+                self._annot[name], item._annot[name], equal_nan=equal_nan
+            ):
                 return False
         return True
 

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -233,7 +233,7 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         else:
             raise TypeError(f"Index must be integer, not '{type(index).__name__}'")
 
-    def equal_annotations(self, item):
+    def equal_annotations(self, item, equal_nan: bool = True):
         """
         Check, if this object shares equal annotation arrays with the
         given :class:`AtomArray` or :class:`AtomArrayStack`.
@@ -242,6 +242,8 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         ----------
         item : AtomArray or AtomArrayStack
             The object to compare the annotation arrays with.
+        equal_nan: bool
+            Whether to count `nan` values as equal. Default: True.
 
         Returns
         -------
@@ -253,7 +255,7 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         if not self.equal_annotation_categories(item):
             return False
         for name in self._annot:
-            if not np.array_equal(self._annot[name], item._annot[name]):
+            if not np.array_equal(self._annot[name], item._annot[name], equal_nan=equal_nan):
                 return False
         return True
 

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -233,7 +233,7 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         else:
             raise TypeError(f"Index must be integer, not '{type(index).__name__}'")
 
-    def equal_annotations(self, item, equal_nan: bool = True):
+    def equal_annotations(self, item, equal_nan=True):
         """
         Check, if this object shares equal annotation arrays with the
         given :class:`AtomArray` or :class:`AtomArrayStack`.
@@ -255,8 +255,13 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         if not self.equal_annotation_categories(item):
             return False
         for name in self._annot:
-            # ... allowing `nan` values causes type-casting, which is only possible for floating-point arrays
-            allow_nan = equal_nan if np.issubdtype(self._annot[name].dtype, np.floating) else False
+            # ... allowing `nan` values causes type-casting, which is
+            #     only possible for floating-point arrays
+            allow_nan = (
+                equal_nan
+                if np.issubdtype(self._annot[name].dtype, np.floating)
+                else False
+            )
             if not np.array_equal(
                 self._annot[name],
                 item._annot[name],

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -255,8 +255,12 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         if not self.equal_annotation_categories(item):
             return False
         for name in self._annot:
+            # ... allowing `nan` values causes type-casting, which is only possible for floating-point arrays
+            allow_nan = equal_nan if np.issubdtype(self._annot[name].dtype, np.floating) else False
             if not np.array_equal(
-                self._annot[name], item._annot[name], equal_nan=equal_nan
+                self._annot[name],
+                item._annot[name],
+                equal_nan=allow_nan,
             ):
                 return False
         return True


### PR DESCRIPTION
A tiny fix, to allow counting `nan` values as equal in annotations. This makes sense in cases where annotations are flagged as not available (e.g. b_factor = `nan`).