### PR TITLE
Enable CCD update from installed package

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -72,14 +72,14 @@ jobs:
         id: cache-ccd
         with:
           path: ./src/biotite/structure/info/components.bcif
-          key: cache-${{ hashFiles('setup_ccd.py') }}-${{ hashFiles('components.cif.gz') }}
+          key: cache-${{ hashFiles('src/biotite/setup_ccd.py') }}-${{ hashFiles('components.cif.gz') }}
       - name: Remove CCD used for hashing
         run: rm components.cif.gz
       - name: Build internal CCD
         if: steps.cache-ccd.outputs.cache-hit != 'true'
         run: |
-          pip install .
-          python setup_ccd.py
+          pip install -e .
+          python -m biotite.setup_ccd
       - name: Install build backend
         run: pip install build
       - name: Build distribution

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,9 @@ Some functions require some extra packages:
 
    $ pip install biotite
 
+After install, biotite's Chemical Component Dictionary (CCD) can be updated via
+
+   $ biotite-setup-ccd
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -71,9 +71,6 @@ Some functions require some extra packages:
 
    $ pip install biotite
 
-After install, biotite's Chemical Component Dictionary (CCD) can be updated via
-
-   $ biotite-setup-ccd
 
 Usage
 -----

--- a/doc/contribution/deployment.rst
+++ b/doc/contribution/deployment.rst
@@ -4,14 +4,6 @@ This section describes how create and deploy a release build of the *Biotite*
 package and documentation.
 Therefore, this section primarily addresses the maintainers of the project.
 
-CCD update
-----------
-:mod:`biotite.structure.info` bundles selected information from the
-`Chemical Component Dictionary <https://www.wwpdb.org/data/ccd>`_ (CCD).
-From time to time, this dataset needs an update to include new components
-added to the CCD.
-This is achieved by running ``setup_ccd.py``.
-
 Creating a new release
 ----------------------
 When a new *GitHub* release is created, the CI jobs building the distributions
@@ -20,6 +12,7 @@ After the successful completion of these jobs, the artifacts are added to the
 release.
 The distributions for different platforms and Python versions are automatically
 uploaded to *PyPI*.
+The documentation is also uploaded to this website via the CI.
 
 Conda release
 -------------
@@ -28,35 +21,3 @@ an automatic pull request for the new release of the
 `Conda package <https://github.com/conda-forge/biotite-feedstock>`_.
 If no dependencies changed, this pull request can usually be merged without
 further effort.
-
-Documentation website
----------------------
-The final step of the deployment is putting the directory containing the built
-documentation onto the server hosting the website.
-
-The document root of the website should look like this:
-
-.. code-block::
-
-   ├─ .htaccess
-   ├─ latest -> x.y.z/
-   ├─ x.y.z/
-   │  ├─ index.html
-   │  ├─ ...
-   ├─ a.b.c/
-      ├─ index.html
-      ├─ ...
-
-``x.y.z/`` and ``a.b.c/`` represent the documentation directories for two
-different *Biotite* release versions.
-
-``.htaccess`` should have the following content:
-
-.. code-block:: apache
-
-   RewriteBase /
-   RewriteEngine On
-   # Redirect if page name does not start with 'latest' or version identifier
-   RewriteRule ^(?!latest|\d+\.\d+\.\d+|robots.txt)(.*) latest/$1 [R=301,L]
-
-   ErrorDocument 404 /latest/404.html

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -57,10 +57,10 @@ You can also install *Biotite* from the
 `project repository <https://github.com/biotite-dev/biotite>`_.
 However, in addition to building and installing the package, the internal
 `Chemical Component Dictionary (CCD) <https://www.wwpdb.org/data/ccd>`_. for
-:mod:`biotite.structure.info` needs to be built with the ``setup_ccd.py`` script.
+:mod:`biotite.structure.info` needs to be built with the ``setup_ccd`` module.
 The script in turn requires *Biotite*.
 The solution to this chicken-and-egg problem is to first install Biotite without the
-CCD, then build the CCD and finally install Biotite again.
+CCD and build the CCD afterwards.
 After cloning the repository, navigate to its top-level directory (the one
 ``setup.py`` is in) and type the following:
 
@@ -68,10 +68,9 @@ After cloning the repository, navigate to its top-level directory (the one
 
    $ pip install .
    $ python -m biotite.setup_ccd
-   $ pip install .
 
-The `setup_ccd.py` script can also be used to update the internal CCD to the current
-upstream version from the PDB.
+``setup_ccd.py`` can also be used to update the internal CCD to the current upstream
+version from the PDB.
 
 Having the *Biotite* installation always pointing to your repository clone is
 also possible.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -67,7 +67,7 @@ After cloning the repository, navigate to its top-level directory (the one
 .. code-block:: console
 
    $ pip install .
-   $ python setup_ccd.py
+   $ python -m biotite.setup_ccd
    $ pip install .
 
 The `setup_ccd.py` script can also be used to update the internal CCD to the current
@@ -80,7 +80,7 @@ Substitute the installation with the following commands instead:
 .. code-block:: console
 
    $ pip install -e .
-   $ python setup_ccd.py
+   $ python -m biotite.setup_ccd
 
 Common issues and solutions
 ---------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,3 +147,6 @@ requires = [
     "cython >= 3.0",
 ]
 build-backend = "hatchling.build"
+
+[project.scripts]
+biotite-setup-ccd = "biotite.setup_ccd:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # Due to `* import` of BCIF encoding
-"setup_ccd.py" = ["F405", "F403"]
+"src/biotite/setup_ccd.py" = ["F405", "F403"]
 # Due to imports after the PATH has been adjusted
 "doc/conf.py" = ["E402"]
 # Due to `from .module import *` imports in `__init__.py` modules
@@ -109,7 +109,6 @@ exclude = [
   "benchmarks",
   "doc",
   "environment.yml",
-  "setup_ccd.py",
   # .github, .gitignore, .gitattributes
   ".git*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,3 @@ requires = [
     "cython >= 3.0",
 ]
 build-backend = "hatchling.build"
-
-[project.scripts]
-biotite-setup-ccd = "biotite.setup_ccd:main"

--- a/src/biotite/setup_ccd.py
+++ b/src/biotite/setup_ccd.py
@@ -1,3 +1,6 @@
+__author__ = "Patrick Kunzmann"
+__all__ = []
+
 import gzip
 import logging
 from collections import defaultdict

--- a/src/biotite/setup_ccd.py
+++ b/src/biotite/setup_ccd.py
@@ -8,7 +8,7 @@ import requests
 from biotite.structure.io.pdbx import *
 
 OUTPUT_CCD = (
-    Path(__file__).parent / "src" / "biotite" / "structure" / "info" / "components.bcif"
+    Path(__file__).parent / "structure" / "info" / "components.bcif"
 )
 CCD_URL = "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
 
@@ -184,9 +184,13 @@ def _into_fitting_type(string_array, mask):
     return array
 
 
-if __name__ == "__main__":
+def main():
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
     OUTPUT_CCD.parent.mkdir(parents=True, exist_ok=True)
 
     compressed_ccd = concatenate_ccd(["chem_comp", "chem_comp_atom", "chem_comp_bond"])
     compressed_ccd.write(OUTPUT_CCD)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/biotite/setup_ccd.py
+++ b/src/biotite/setup_ccd.py
@@ -7,9 +7,7 @@ import numpy as np
 import requests
 from biotite.structure.io.pdbx import *
 
-OUTPUT_CCD = (
-    Path(__file__).parent / "structure" / "info" / "components.bcif"
-)
+OUTPUT_CCD = Path(__file__).parent / "structure" / "info" / "components.bcif"
 CCD_URL = "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
 
 

--- a/src/biotite/structure/info/ccd.py
+++ b/src/biotite/structure/info/ccd.py
@@ -53,7 +53,7 @@ def get_ccd():
         return BinaryCIFFile.read(_CCD_FILE).block
     except FileNotFoundError:
         raise RuntimeError(
-            "Internal CCD not found. Please run 'setup_ccd.py' and reinstall Biotite."
+            "Internal CCD not found. Please run 'python -m biotite.setup_ccd'."
         )
 
 
@@ -68,7 +68,7 @@ def set_ccd_path(ccd_path):
     ----------
     ccd_path : path-like
         The path to the custom CCD in BinaryCIF format, prepared with the
-        ``setup_ccd.py`` script.
+        ``setup_ccd.py`` module.
 
     Notes
     -----

--- a/tests/test_modname.py
+++ b/tests/test_modname.py
@@ -16,6 +16,9 @@ def find_all_modules(package_name, src_dir):
     """
     module_names = []
     for _, module_name, is_package in pkgutil.iter_modules([src_dir]):
+        if module_name == "setup_ccd":
+            # This module is not intended to be imported
+            continue
         full_module_name = f"{package_name}.{module_name}"
         if is_package:
             module_names.extend(


### PR DESCRIPTION
currently the setup_ccd.py script has to be run from a clone of the repo. this creates a command-line utility to run the ccd update directly from the pip installed package itself. i think this simplifies dependency management for downstream projects quite a bit