### PR TITLE
feat: allow setting the `label_entity_id` from the AtomArray, if annotated

### DIFF
--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -836,7 +836,11 @@ def set_structure(
     )
     atom_site["label_comp_id"] = np.copy(array.res_name)
     atom_site["label_asym_id"] = np.copy(array.chain_id)
-    atom_site["label_entity_id"] = _determine_entity_id(array.chain_id)
+    atom_site["label_entity_id"] = (
+        np.copy(array.label_entity_id)
+        if "label_entity_id" in array.get_annotation_categories()
+        else _determine_entity_id(array.chain_id)
+    )
     atom_site["label_seq_id"] = np.copy(array.res_id)
     atom_site["pdbx_PDB_ins_code"] = Column(
         np.copy(array.ins_code),


### PR DESCRIPTION
The [`label_entity_id`](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_atom_site.label_entity_id.html) is a standard category in cif files that relates the asym_id to the entity_id in entity_poly. 

Currently, when writing out an AtomArray as cif file, entity_id's are always determined anew, giving new chains new entity id's even when they are actually the same entity (try e.g. `5ocm`). This tiny PR allows to pass on the `label_entity_id` to writing out the structure. This category can already be loaded in AtomArrays via the `extra_fields` keyword argument.