### PR TITLE
Improve error message in `align_structural_homologs()`

### DIFF
--- a/src/biotite/structure/tm.py
+++ b/src/biotite/structure/tm.py
@@ -490,7 +490,7 @@ def _mask_by_d0_threshold(fixed_ca_coord, mobile_ca_coord, reference_length):
     """
     mask = distance(fixed_ca_coord, mobile_ca_coord) < _d0(reference_length)
     if not np.any(mask):
-        raise ValueError("No anchors found")
+        raise ValueError("No anchors found, the structures are too dissimilar")
     return mask
 
 


### PR DESCRIPTION
The previous error message is a bit vague, as it requires knowledge of the algorithm itself. The new message elucidates the cause better.