### PR TITLE
Add generic aromatic bond

### DIFF
--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -60,6 +60,7 @@ class BondType(IntEnum):
         - `AROMATIC_SINGLE` - Aromatic bond with a single formal bond
         - `AROMATIC_DOUBLE` - Aromatic bond with a double formal bond
         - `AROMATIC_TRIPLE` - Aromatic bond with a triple formal bond
+        - `AROMATIC` - Aromatic bond without specification of the formal bond
         - `COORDINATION` - Coordination complex involving a metal atom
     """
     ANY = 0
@@ -71,6 +72,7 @@ class BondType(IntEnum):
     AROMATIC_DOUBLE = 6
     AROMATIC_TRIPLE = 7
     COORDINATION = 8
+    AROMATIC = 9
 
 
     def without_aromaticity(self):
@@ -97,6 +99,8 @@ class BondType(IntEnum):
             return BondType.DOUBLE
         elif self == BondType.AROMATIC_TRIPLE:
             return BondType.TRIPLE
+        elif self == BondType.AROMATIC:
+            return BondType.ANY
         else:
             return self
 
@@ -517,7 +521,8 @@ class BondList(Copyable):
         for aromatic_type, non_aromatic_type in [
             (BondType.AROMATIC_SINGLE, BondType.SINGLE),
             (BondType.AROMATIC_DOUBLE, BondType.DOUBLE),
-            (BondType.AROMATIC_TRIPLE, BondType.TRIPLE)
+            (BondType.AROMATIC_TRIPLE, BondType.TRIPLE),
+            (BondType.AROMATIC, BondType.ANY),
         ]:
             bond_types[bond_types == aromatic_type] = non_aromatic_type
 

--- a/src/biotite/structure/io/mol/ctab.py
+++ b/src/biotite/structure/io/mol/ctab.py
@@ -24,19 +24,13 @@ BOND_TYPE_MAPPING = {
     1: BondType.SINGLE,
     2: BondType.DOUBLE,
     3: BondType.TRIPLE,
+    4: BondType.AROMATIC,
     5: BondType.ANY,
-    6: BondType.SINGLE,
-    7: BondType.DOUBLE,
+    6: BondType.AROMATIC_SINGLE,
+    7: BondType.AROMATIC_DOUBLE,
     8: BondType.ANY,
 }
-BOND_TYPE_MAPPING_REV = {
-    BondType.SINGLE: 1,
-    BondType.DOUBLE: 2,
-    BondType.TRIPLE: 3,
-    BondType.AROMATIC_SINGLE: 1,
-    BondType.AROMATIC_DOUBLE: 2,
-    BondType.ANY: 8,
-}
+BOND_TYPE_MAPPING_REV = {v: k for k, v in BOND_TYPE_MAPPING.items()}
 
 CHARGE_MAPPING = {0: 0, 1: 3, 2: 2, 3: 1, 5: -1, 6: -2, 7: -3}
 CHARGE_MAPPING_REV = {val: key for key, val in CHARGE_MAPPING.items()}

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -81,6 +81,7 @@ PDBX_BOND_TYPE_TO_ORDER = {
     BondType.AROMATIC_TRIPLE: "trip",
     # These are masked later, it is merely added here to avoid a KeyError
     BondType.ANY: "",
+    BondType.AROMATIC: "",
     BondType.COORDINATION: "",
 }
 # Map 'chem_comp_bond' bond orders and aromaticity to 'BondType'...
@@ -92,6 +93,7 @@ COMP_BOND_ORDER_TO_TYPE = {
     ("SING", "Y"): BondType.AROMATIC_SINGLE,
     ("DOUB", "Y"): BondType.AROMATIC_DOUBLE,
     ("TRIP", "Y"): BondType.AROMATIC_TRIPLE,
+    ("AROM", "Y"): BondType.AROMATIC,
 }
 # ...and vice versa
 COMP_BOND_TYPE_TO_ORDER = {


### PR DESCRIPTION
The kekulized form of aromatic bonds (i.e. their representations as single, double or triple bonds) is a visualization artifact: Chemically aromatic bonds have no bond order, but the pi-elections are delocalized in the entire pi-system.

For this reason I think it makes sense to lift the restriction to assign a bond to either of `AROMATIC_SINGLE`, `AROMATIC_DOUBLE` or `AROMATIC_TRIPLE`, but to allow a generic `AROMATIC` as well. Although, this might lead to some limitations in visualization, there are some advantages

- Models predicting aromatic bonds do not necessarily need to know the kekulized form.
- Some software does not internally represent aromatic bonds in kekulized form (e.g. RDKit).
- SDF and PDBx support generic aromatic bonds as well.