### PR TITLE
Allow more custom contact filtering in `lddt()`

### DIFF
--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -64,6 +64,9 @@ def get_chain_starts(array, add_exclusive_stop=False):
     --------
     get_residue_starts
     """
+    if array.array_length() == 0:
+        return np.array([], dtype=int)
+
     diff = np.diff(array.res_id)
     res_id_decrement = diff < 0
     # This mask is 'true' at indices where the value changes

--- a/src/biotite/structure/residues.py
+++ b/src/biotite/structure/residues.py
@@ -69,6 +69,9 @@ def get_residue_starts(array, add_exclusive_stop=False):
     [  0  16  35  56  75  92 116 135 157 169 176 183 197 208 219 226 250 264
      278 292 304]
     """
+    if array.array_length() == 0:
+        return np.array([], dtype=int)
+
     # These mask are 'true' at indices where the value changes
     chain_id_changes = array.chain_id[1:] != array.chain_id[:-1]
     res_id_changes = array.res_id[1:] != array.res_id[:-1]


### PR DESCRIPTION
This PR adds to parameters to `lddt()`:
- `exclude_same_chain`: Excludes contacts within the same chain
- `filter_function`: Allows passing a custom function to filter even more contacts