### PR TITLE
Add `explicit_hydrogen` parameter

### DIFF
--- a/doc/tutorial/interface/rdkit.rst
+++ b/doc/tutorial/interface/rdkit.rst
@@ -27,15 +27,14 @@ For a proper structural formula, we need to compute proper 2D coordinates first.
 
     import biotite.interface.rdkit as rdkit_interface
     import biotite.structure.info as struc
+    import rdkit.Chem.AllChem as Chem
     from rdkit.Chem.Draw import MolToImage
-    from rdkit.Chem.rdDepictor import Compute2DCoords
-    from rdkit.Chem.rdmolops import RemoveHs
 
     penicillin = struc.residue("PNN")
     mol = rdkit_interface.to_mol(penicillin)
     # We do not want to include explicit hydrogen atoms in the structural formula
-    mol = RemoveHs(mol)
-    Compute2DCoords(mol)
+    mol = Chem.RemoveHs(mol)
+    Chem.Compute2DCoords(mol)
     image = MolToImage(mol, size=(600, 400))
     display(image)
 
@@ -49,18 +48,13 @@ One way to to obtain them as :class:`.AtomArray` is passing a *SMILES* string to
 
 .. jupyter-execute::
 
-    from rdkit.Chem import MolFromSmiles
-    from rdkit.Chem.rdDistGeom import EmbedMolecule
-    from rdkit.Chem.rdForceFieldHelpers import UFFOptimizeMolecule
-    from rdkit.Chem.rdmolops import AddHs
-
     ERTAPENEM_SMILES = "C[C@@H]1[C@@H]2[C@H](C(=O)N2C(=C1S[C@H]3C[C@H](NC3)C(=O)NC4=CC=CC(=C4)C(=O)O)C(=O)O)[C@@H](C)O"
 
-    mol = MolFromSmiles(ERTAPENEM_SMILES)
+    mol = Chem.MolFromSmiles(ERTAPENEM_SMILES)
     # RDKit uses implicit hydrogen atoms by default, but Biotite requires explicit ones
-    mol = AddHs(mol)
+    mol = Chem.AddHs(mol)
     # Create a 3D conformer
-    conformer_id = EmbedMolecule(mol)
-    UFFOptimizeMolecule(mol)
+    conformer_id = Chem.EmbedMolecule(mol)
+    Chem.UFFOptimizeMolecule(mol)
     ertapenem = rdkit_interface.from_mol(mol, conformer_id)
     print(ertapenem)

--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -290,14 +290,20 @@ def from_mol(mol, conformer_id=None, add_hydrogen=None):
         raise BadStructureError("Could not obtains atoms from Mol")
 
     if conformer_id is None:
-        conformers = [conf for conf in mol.GetConformers() if conf.Is3D()]
+        conformers = [conf for conf in mol.GetConformers()]
         atoms = AtomArrayStack(len(conformers), len(rdkit_atoms))
         for i, conformer in enumerate(conformers):
-            atoms.coord[i] = np.array(conformer.GetPositions())
+            if conformer.Is3D():
+                atoms.coord[i] = np.array(conformer.GetPositions())
+            else:
+                atoms.coord[i] = np.full((len(rdkit_atoms), 3), np.nan)
     else:
         conformer = mol.GetConformer(conformer_id)
         atoms = AtomArray(len(rdkit_atoms))
-        atoms.coord = np.array(conformer.GetPositions())
+        if conformer.Is3D():
+            atoms.coord = np.array(conformer.GetPositions())
+        else:
+            atoms.coord = np.full((len(rdkit_atoms), 3), np.nan)
 
     extra_annotations = defaultdict(
         # Use 'object' dtype first, as the maximum string length is unknown

--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -171,6 +171,7 @@ def to_mol(
     for i in range(atoms.array_length()):
         rdkit_atom = Chem.Atom(atoms.element[i].capitalize())
         if explicit_hydrogen:
+            # ... tell RDKit to not assume any implicit hydrogens
             rdkit_atom.SetNoImplicit(True)
         if "charge" in has_annot:
             rdkit_atom.SetFormalCharge(atoms.charge[i].item())

--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -114,12 +114,18 @@ def to_mol(
         If the input `atoms` is an :class:`AtomArrayStack`, all models are included
         as conformers with conformer IDs starting from ``0``.
 
-    Raised
+    Raises
     ------
     BadStructureError
         If the input `atoms` does not have an associated :class:`BondList`.
         Also raises a :class:`BadStructureError`, if `explicit_hydrogen` is set to
         ``False`` despite hydrogen atoms being present in `atoms`.
+
+    Notes
+    -----
+    The atoms in the return value are in the same order as the input `atoms`,
+    i.e. indices pointing to the :class:`rdkit.Chem.rdchem.Mol` can be used to point to
+    the same atoms in the :class:`.AtomArray`.
 
     Examples
     --------
@@ -272,6 +278,10 @@ def from_mol(mol, conformer_id=None, add_hydrogen=None):
 
     Notes
     -----
+    The atoms in the return value are in the same order as the input `mol`,
+    i.e. indices pointing to the :class:`rdkit.Chem.rdchem.Mol` can be used to point to
+    the same atoms in the :class:`.AtomArray`.
+
     All atom-level properties of `mol`
     (obtainable with :meth:`rdkit.Chem.rdchem.Mol.GetProp()`) are added as annotation
     array with the same name.

--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -3,7 +3,7 @@
 # information.
 
 __name__ = "biotite.interface.rdkit"
-__author__ = "Patrick Kunzmann"
+__author__ = "Patrick Kunzmann, Simon Mathis"
 __all__ = ["to_mol", "from_mol"]
 
 import warnings

--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -104,7 +104,7 @@ def to_mol(
         If set to true, the conversion process expects that all hydrogen atoms are
         explicit, i.e. each each hydrogen atom must be part of the :class:`AtomArray`.
         If set to false, the conversion process treats all hydrogen atoms as implicit.
-        By default, explicit hydrogen atoms are only assumed of any hydrogen atoms are
+        By default, explicit hydrogen atoms are only assumed if any hydrogen atoms are
         present in `atoms`.
 
     Returns

--- a/tests/interface/test_rdkit.py
+++ b/tests/interface/test_rdkit.py
@@ -20,11 +20,9 @@ def _load_smiles():
         return file.read().splitlines()
 
 
-@pytest.mark.filterwarnings(
-    "ignore:"
-    "The coordinates are missing for some atoms. "
-    "The fallback coordinates will be used instead"
-)
+@pytest.mark.filterwarnings("ignore:Missing coordinates.*")
+@pytest.mark.filterwarnings("ignore:.*coordinates are missing.*")
+@pytest.mark.filterwarnings("ignore::biotite.interface.LossyConversionWarning")
 @pytest.mark.parametrize(
     "res_name", np.random.default_rng(0).choice(info.all_residues(), size=200).tolist()
 )
@@ -46,7 +44,7 @@ def test_conversion_from_biotite(res_name):
     # Some compounds in the CCD have missing coordinates
     assert np.allclose(test_atoms.coord, ref_atoms.coord, equal_nan=True)
 
-    # There should be now undefined bonds
+    # There should be no undefined bonds
     assert (test_atoms.bonds.as_array()[:, 2] != struc.BondType.ANY).all()
     # Kekulization returns one of multiple resonance structures, so the returned one
     # might not be the same as the input


### PR DESCRIPTION
This parameter in `interface.rdkit.to_mol()` defines whether hydrogen should be explicitly or implicitly included in the created `Mol`