### PR TITLE
Allow coordinate ndarrays in Fortran order

### DIFF
--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -142,7 +142,10 @@ def to_mol(
         coord = coord[None, :, :]
     for model_coord in coord:
         conformer = Conformer(mol.GetNumAtoms())
-        conformer.SetPositions(model_coord.astype(np.float64))
+        # RDKit silently expects the data to be in C-contiguous order
+        # Otherwise the coordinates would be completely misassigned
+        # (https://github.com/rdkit/rdkit/issues/8221)
+        conformer.SetPositions(np.ascontiguousarray(model_coord, dtype=np.float64))
         conformer.Set3D(True)
         mol.AddConformer(conformer)
 

--- a/tests/interface/test_rdkit.py
+++ b/tests/interface/test_rdkit.py
@@ -158,3 +158,21 @@ def test_unmappable_bond_type():
 
     with pytest.warns(LossyConversionWarning):
         rdkit_interface.from_mol(mol)
+
+
+def test_fortran_ordered_coord():
+    """
+    Check if :func:`to_mol()` also works with ``ndarray`` objects in *Fortran*
+    contiguous order.
+
+    Currently *RDKit* cannot handle *Fortran*-ordered arrays directly as described
+    in https://github.com/rdkit/rdkit/issues/8221.
+    """
+    ref_atoms = info.residue("ALA", allow_missing_coord=True)
+    # Bring coordinates to Fortran order
+    ref_atoms.coord = np.asfortranarray(ref_atoms.coord)
+
+    mol = rdkit_interface.to_mol(ref_atoms)
+    test_atoms = rdkit_interface.from_mol(mol, add_hydrogen=False)
+
+    assert np.allclose(test_atoms.coord, ref_atoms.coord)


### PR DESCRIPTION
This PR basically fixes https://github.com/rdkit/rdkit/issues/8221 on the Biotite side.