### PR TITLE
Add proper RDKit version constraints

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,4 +56,4 @@ dependencies:
   - scipy >=1.8.0
   - pip:
     # Conda provides no recent version of RDKit (required for biotite.interface)
-    - rdkit
+    - rdkit >=2024.09.1

--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -47,7 +47,8 @@ _RDKIT_TO_BIOTITE_BOND_TYPE = {
 }
 
 
-@requires_version("rdkit", ">=2020")
+# `Conformer.SetPositions()` was added in RDKit 2024.09.1
+@requires_version("rdkit", ">=2024.09.1")
 def to_mol(
     atoms, kekulize=False, use_dative_bonds=False, include_annotations=("atom_name",)
 ):


### PR DESCRIPTION
This PR reflects that `Conformer.SetPositions()` was added in RDKit `2024.09.1`.