### PR TITLE
fix: fix link to contribution guide in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,5 +123,5 @@ Contribution
 
 Interested in improving *Biotite*?
 Have a look at the
-`contribution guidelines <https://www.biotite-python.org/contribute.html>`_.
+`contribution guidelines <https://www.biotite-python.org/latest/contribution/index.html>`_.
 Feel free to join our community chat on `Discord <https://discord.gg/cUjDguF>`_.


### PR DESCRIPTION
Fixed link to contributions guidelines in README (was missing `index.html`)