### PR TITLE
Integrate `openmm` into `biotite.interface.openmm`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -112,7 +112,10 @@ bibtex_default_style = "ieee"
 
 notfound_urls_prefix = "/latest/"
 
-intersphinx_mapping = {"rdkit": ("https://www.rdkit.org/docs/", None)}
+intersphinx_mapping = {
+    "rdkit": ("https://www.rdkit.org/docs/", None),
+    "openmm": ("http://docs.openmm.org/latest/api-python/", None),
+}
 intersphinx_timeout = 60
 
 

--- a/doc/extensions.rst
+++ b/doc/extensions.rst
@@ -49,10 +49,3 @@ Python packages that are developed independently.
         :class-img-top: extension-logo
 
         Investigation of molecular dynamics using elastic network models
-
-    .. grid-item-card:: Molmarbles
-        :link: https://github.com/biotite-dev/molmarbles
-        :img-top: https://raw.githubusercontent.com/biotite-dev/molmarbles/master/logo.svg
-        :class-img-top: extension-logo
-
-        An interface between Biotite and the *OpenMM* molecular dynamics simulation library

--- a/doc/tutorial/interface/index.rst
+++ b/doc/tutorial/interface/index.rst
@@ -37,3 +37,4 @@ The following chapters will give you an overview of the different interfaced pac
 
     rdkit
     pymol
+    openmm

--- a/doc/tutorial/interface/openmm.rst
+++ b/doc/tutorial/interface/openmm.rst
@@ -1,148 +1,249 @@
-# Molmarbles
+.. include:: /tutorial/preamble.rst
 
+Interface to OpenMM
+===================
 
-![Molmarbles](https://raw.githubusercontent.com/biotite-dev/molmarbles/master/logo.svg)
+.. currentmodule:: biotite.interface.openmm
 
-This small package allows conversion between structures objects from
-[Biotite](https://www.biotite-python.org/)
-(`AtomArray` and `AtomArrayStack`) and `System`, `Topology`,
-`Context` or `State` objects from [OpenMM](https://openmm.org/).
-This allows for data preparation, MD simulation and trajectory analysis from
-the same script without intermediate files.
+This subpackage provides an interface to the `OpenMM <https://openmm.org/>`_
+molecular simulation toolkit, expanding the structure capabilities of
+*Biotite* into the realm of molecular dynamics.
 
-> **Note**
-> The development of this package is work in progress.
-> The API will probably change in the future.
+Like other :mod:`biotite.interface` subpackages, *OpenMM* objects are created with
+``to_<x>()`` functions (:func:`to_topology()`, :func:`to_system()`) and converted back
+to an :class:`.AtomArray` with ``from_<x>()`` functions
+(:func:`from_topology()`, :func:`from_system()`, :func:`from_states()`, etc.).
+Like in the :doc:`RDKit interface tutorial <rdkit>`, explaining all the functionalities
+of *OpenMM* would exceed the scope of this tutorial.
+Please refer to the `OpenMM documentation <http://docs.openmm.org/latest/api-python/>`_
+for further information.
+This tutorial will only give a few examples of how *OpenMM* and *Biotite* work in
+tandem.
 
+First example: MD simulation of lysozyme
+----------------------------------------
+Here the aim is to run the prominent
+`'Lysozyme in water' <http://www.mdtutorials.com/gmx/lysozyme/>`_ example in *OpenMM*.
+For structure preparation before and analysis afterwards, we will use *Biotite*.
 
-## Installation
+.. jupyter-execute::
 
-*Molmarbles* can be installed via *pip*, either from PyPI...
+    import numpy as np
+    import openmm
+    import openmm.app as app
+    from openmm.unit import angstrom, kelvin, nanometer, picosecond
+    import biotite.database.rcsb as rcsb
+    import biotite.interface.openmm as openmm_interface
+    import biotite.interface.pymol as pymol_interface
+    import biotite.structure.io.pdbx as pdbx
+    import biotite.structure as struc
 
-```shell
-$ pip install molmarbles
-```
+    BUFFER = 10
 
-or a local repository clone.
+    atoms = pdbx.get_structure(
+        pdbx.BinaryCIFFile.read(rcsb.fetch("1aki", "bcif")), model=1, include_bonds=True
+    )
+    # Remove solvent, as proper solvent addition is handled by OpenMM
+    molecule = atoms[struc.filter_amino_acids(atoms)]
+    # Create a box with some buffer around the protein
+    # This box will be used as starting simulation box
+    box_dim = np.max(molecule.coord, axis=0) - np.min(molecule.coord, axis=0)
+    molecule.box = np.diag(box_dim + BUFFER)
 
-```shell
-$ pip install .
-```
+The :class:`.AtomArray` is converted to an :class:`openmm.topology.Topology` simply
+by calling :func:`to_topology()`.
 
-Note that *OpenMM* must also be installed for *Molmarbles* to work.
-*OpenMM* is not distributed via *PyPI* and must installed via *Conda*.
+.. jupyter-execute::
 
-```shell
-$ conda install -c conda-forge openmm
-```
+    # Create an OpenMM Topology from the AtomArray
+    topology = openmm_interface.to_topology(molecule)
 
+The lysozyme structure we use does not have hydrogen atoms, but we require them for the
+MD simulation.
+Hence, we use functionality from *OpenMM* to model the missing hydrogen atoms.
 
-## Usage
+.. jupyter-execute::
 
-`AtomArray` and `AtomArrayStack` objects can be converted to the respective
-*OpenMM* objects with
+    force_field = openmm.app.ForceField("amber14-all.xml", "amber14/tip3pfb.xml")
+    # Add hydrogen atoms and water
+    modeller = app.Modeller(topology, molecule.coord * angstrom)
+    modeller.addHydrogens(force_field)
+    modeller.addSolvent(force_field)
+    topology = modeller.topology
 
-- `to_system()`
-- `to_topology()`
+The last prerequisite for the MD simulation is the energy minimization to get a
+proper starting conformation.
+After that, we can finally run the simulation for the given number of steps.
+After a certain number of steps, we record the current state (i.e. conformation) of the
+system for later analysis.
 
-and vice versa with
+.. jupyter-execute::
 
-- `from_topology()`
-- `from_context()`
-- `from_states()`
-- `from_state()`
+    TIME_STEP = 0.004
+    FRAME_STEP = 2.0
+    N_FRAMES = 60
 
-Detailed description of parameters and return values is provided by the
-respective
-[docstring](https://github.com/biotite-dev/molmarbles/blob/master/molmarbles/__init__.py).
+    system = force_field.createSystem(
+        topology,
+        nonbondedMethod=app.PME,
+        nonbondedCutoff=1 * nanometer,
+        constraints=app.HBonds,
+    )
+    integrator = openmm.LangevinMiddleIntegrator(
+        300 * kelvin, 1 / picosecond, TIME_STEP * picosecond
+    )
+    simulation = app.Simulation(topology, system, integrator)
+    simulation.context.setPositions(modeller.positions)
+    simulation.minimizeEnergy()
 
+    # Run simulation and record the current state (the coordinates)
+    # every FRAME_STEP picoseconds
+    states = []
+    for i in range(N_FRAMES):
+        simulation.step(FRAME_STEP // TIME_STEP)
+        states.append(simulation.context.getState(getPositions=True))
 
-## Example
+While each state contains information about the current atom coordinates, box dimensions
+etc., it misses the topology of the system, i.e. residues, atoms and bonds.
+Hence, to get the trajectory as :class:`.AtomArrayStack` via :func:`from_states()`,
+we need to provide an :class:`.AtomArray` as template.
+However, we cannot use the original input lysozyme structure from above, as hydrogen
+atoms were added meanwhile and thus the topology has changed.
+To solve this problem we obtain an updated template first using :func:`from_topology()`.
 
-A short MD simulation of lysozyme
+.. jupyter-execute::
 
-```python
-import os
-from os.path import isdir, join
-import numpy as np
-import matplotlib.pyplot as plt
-import biotite.database.rcsb as rcsb
-import biotite.structure as struc
-import biotite.structure.io.mmtf as mmtf
-import molmarbles
-import openmm
-import openmm.app as app
-from openmm.unit import nanometer, angstrom, kelvin, picosecond
+    template = openmm_interface.from_topology(topology)
+    trajectory = openmm_interface.from_states(template, states)
+    # Center protein in box
+    trajectory.coord -= struc.centroid(
+        trajectory.coord[:, struc.filter_amino_acids(trajectory)]
+    )[:, np.newaxis, :]
+    trajectory.coord += np.sum(trajectory.box / 2, axis=-2)[:, np.newaxis, :]
+    # Remove segmentation over periodic boundary
+    trajectory = struc.remove_pbc(trajectory)
 
+Now we could analyze the trajectory using functionality from :mod:`biotite.structure`,
+as exemplified in the :doc:`trajectory tutorial <../structure/trajectories>`, or use
+some custom analysis.
+For this tutorial we will simply visualize the trajectory using
+:mod:`biotite.interface.pymol`.
 
-BUFFER = 10
-TIME_STEP = 0.004
-FRAME_STEP = 0.1
-N_FRAMES = 100
+.. jupyter-execute::
 
+    pymol_object = pymol_interface.PyMOLObject.from_structure(trajectory)
+    pymol_object.color("biotite_lightorange", struc.filter_amino_acids(trajectory))
+    # Draw simulation box
+    # As the box does not extend much during the simulation, simply draw the mean size
+    box = pymol_interface.draw_box(
+        np.mean(trajectory.box, axis=0), color=(0, 0, 0), width=1
+    )
 
-molecule = mmtf.get_structure(
-    mmtf.MMTFFile.read(rcsb.fetch("1aki", "mmtf")),
-    model=1,
-    include_bonds=True
-)
-# Remove solvent, as proper solvent addition is handled by OpenMM
-molecule = molecule[struc.filter_amino_acids(molecule)]
-# Create a box with some buffer around the protein
-# This box represents the
-box_dim = np.max(molecule.coord, axis=0) - np.min(molecule.coord, axis=0)
-molecule.box = np.diag(box_dim + BUFFER)
+    # Create an isometric view
+    pymol_interface.cmd.turn("y", 45)
+    pymol_interface.cmd.turn("x", 45)
+    pymol_object.zoom(buffer=15)
+    pymol_interface.cmd.set("orthoscopic", 1)
 
-# Create an OpenMM Topology from the AtomArray
-topology = molmarbles.to_topology(molecule)
+    pymol_interface.cmd.mset()
+    pymol_interface.play(
+        (1400, 1400), format="mp4", html_attributes="loop autoplay width=700"
+    )
 
+Second example: Simulating water in vacuum
+------------------------------------------
+Although simulating a single molecule of water is a frankly boring application,
+it demonstrates the usage of custom forces in *OpenMM*:
+Instead of creating a :class:`openmm.openmm.System` from a
+:class:`openmm.app.topology.Topology`, we could alternatively creating it manually,
+allowing us to customize the forces. And because ``Force`` objects use atom indices to
+define interacting atoms and :func:`to_system()` creates a system with the same
+atom ordering as the input :class:`.AtomArray`, we can directly use atom indices
+obtained in *Biotite* to create forces in *OpenMM*.
 
-force_field = openmm.app.ForceField('amber14-all.xml', 'amber14/tip3pfb.xml')
-# Add hydrogen atoms and water
-modeller = app.Modeller(topology, molecule.coord * angstrom)
-modeller.addHydrogens(force_field)
-modeller.addSolvent(force_field)
-topology = modeller.topology
+We begin by constructing the molecule from the *Chemical Component Dictionary*.
 
-system = force_field.createSystem(
-    topology, nonbondedMethod=app.PME,
-    nonbondedCutoff=1*nanometer, constraints=app.HBonds
-)
-integrator = openmm.LangevinMiddleIntegrator(300*kelvin, 1/picosecond, TIME_STEP*picosecond)
-simulation = app.Simulation(topology, system, integrator)
-simulation.context.setPositions(modeller.positions)
-simulation.minimizeEnergy()
+.. jupyter-execute::
 
-# Run simulation and record the current state (the coordinates)
-# every FRAME_STEP picoseconds
-states = []
-states.append(simulation.context.getState(getPositions=True))
-for i in range(N_FRAMES):
-    simulation.step(FRAME_STEP // TIME_STEP)
-    states.append(simulation.context.getState(getPositions=True))
+    import biotite.structure.info as info
 
+    TIME_STEP = 0.001
+    FRAME_STEP = 0.1
+    N_FRAMES = 120
 
-# Transfer the trajectory back to Biotite
-# The topology was changed in the process of adding hydrogen and solvent
-# -> Update the structure
-template = molmarbles.from_topology(topology)
-trajectory = molmarbles.from_states(template, states)
-# Center protein in box
-trajectory.coord -= struc.centroid(
-    trajectory.coord[:, struc.filter_amino_acids(trajectory)]
-)[:, np.newaxis, :]
-trajectory.coord += np.sum(trajectory.box / 2, axis=-2)[:, np.newaxis, :]
-# Remove segmentation over periodic boundary
-trajectory = struc.remove_pbc(trajectory)
-```
+    water = info.residue("HOH")
+    system = openmm_interface.to_system(water)
 
-Visualization with [Ammolite](https://ammolite.biotite-python.org/) and
-[PyMOL](https://pymol.org/)
+For the sake of brevity the force field will only contain bonded forces for bond
+length and angle stretching. This is also the reason a box was not set in the system:
+For bonded forces, periodic boundaries simply do not matter.
 
+.. jupyter-execute::
 
-https://user-images.githubusercontent.com/28051833/220104497-ecf2cdb2-5e1d-4c22-ae27-ae4ca59ebb8e.mp4
+    # Adopted from TIP3P
+    # (https://github.com/openmm/openmmforcefields/blob/main/amber/files/tip3p.xml)
+    BOND_LENGTH_IDEAL = 0.09572
+    BOND_LENGTH_STIFFNESS = 462750.4
+    BOND_ANGLE_IDEAL = 1.82421813418
+    BOND_ANGLE_STIFFNESS = 836.8
 
+    length_force = openmm.HarmonicBondForce()
+    for i, j, _ in water.bonds.as_array():
+        length_force.addBond(i, j, BOND_LENGTH_IDEAL, BOND_LENGTH_STIFFNESS)
+    system.addForce(length_force)
 
-## Testing
+    angle_force = openmm.HarmonicAngleForce()
+    angle_force.addAngle(
+        np.where(water.atom_name == "H1")[0][0],
+        np.where(water.atom_name == "O")[0][0],
+        np.where(water.atom_name == "H2")[0][0],
+        BOND_ANGLE_IDEAL,
+        BOND_ANGLE_STIFFNESS,
+    )
+    _ = system.addForce(angle_force)
 
-*Molmarbles* uses *pytest* for running its tests.
+Now we are prepared to run the simulation.
+Here we cannot use a ``Simulation`` object as convenient wrapper, as we have bypassed
+the creation of a ``Topology`` this time.
+Hence, we use the ``Context`` and ``Integrator`` directly.
+
+.. jupyter-execute::
+
+    integrator = openmm.LangevinMiddleIntegrator(
+        300 * kelvin, 1 / picosecond, TIME_STEP * picosecond
+    )
+    context = openmm.Context(system, integrator)
+    context.setPositions(water.coord * angstrom)
+
+    states = []
+    for i in range(N_FRAMES):
+        integrator.step(FRAME_STEP // TIME_STEP)
+        states.append(context.getState(getPositions=True))
+
+Finally we can obtain the trajectory as :class:`.AtomArrayStack` and visualize the
+trajectory, analogous to the snippets shown above.
+
+.. jupyter-execute::
+
+    # In this case we can reuse the input structure as template,
+    # as not atoms have been added or removed
+    trajectory = openmm_interface.from_states(water, states)
+    # Superimpose the frames
+    trajectory, _ = struc.superimpose(trajectory[0], trajectory)
+
+    # Remove the box from the previous visualization
+    del box
+    pymol_object = pymol_interface.PyMOLObject.from_structure(trajectory)
+    # Visualize as stick model
+    pymol_interface.cmd.set("stick_radius", 0.15)
+    pymol_interface.cmd.set("sphere_scale", 0.25)
+    pymol_interface.cmd.set("sphere_quality", 4)
+    # Visualize docked model
+    pymol_object.show("spheres")
+    pymol_object.show("sticks")
+    pymol_object.set("stick_color", "black")
+    pymol_object.orient()
+
+    pymol_interface.cmd.mset()
+    # Play as looping GIF
+    pymol_interface.play((300, 300))

--- a/doc/tutorial/interface/openmm.rst
+++ b/doc/tutorial/interface/openmm.rst
@@ -1,0 +1,148 @@
+# Molmarbles
+
+
+![Molmarbles](https://raw.githubusercontent.com/biotite-dev/molmarbles/master/logo.svg)
+
+This small package allows conversion between structures objects from
+[Biotite](https://www.biotite-python.org/)
+(`AtomArray` and `AtomArrayStack`) and `System`, `Topology`,
+`Context` or `State` objects from [OpenMM](https://openmm.org/).
+This allows for data preparation, MD simulation and trajectory analysis from
+the same script without intermediate files.
+
+> **Note**
+> The development of this package is work in progress.
+> The API will probably change in the future.
+
+
+## Installation
+
+*Molmarbles* can be installed via *pip*, either from PyPI...
+
+```shell
+$ pip install molmarbles
+```
+
+or a local repository clone.
+
+```shell
+$ pip install .
+```
+
+Note that *OpenMM* must also be installed for *Molmarbles* to work.
+*OpenMM* is not distributed via *PyPI* and must installed via *Conda*.
+
+```shell
+$ conda install -c conda-forge openmm
+```
+
+
+## Usage
+
+`AtomArray` and `AtomArrayStack` objects can be converted to the respective
+*OpenMM* objects with
+
+- `to_system()`
+- `to_topology()`
+
+and vice versa with
+
+- `from_topology()`
+- `from_context()`
+- `from_states()`
+- `from_state()`
+
+Detailed description of parameters and return values is provided by the
+respective
+[docstring](https://github.com/biotite-dev/molmarbles/blob/master/molmarbles/__init__.py).
+
+
+## Example
+
+A short MD simulation of lysozyme
+
+```python
+import os
+from os.path import isdir, join
+import numpy as np
+import matplotlib.pyplot as plt
+import biotite.database.rcsb as rcsb
+import biotite.structure as struc
+import biotite.structure.io.mmtf as mmtf
+import molmarbles
+import openmm
+import openmm.app as app
+from openmm.unit import nanometer, angstrom, kelvin, picosecond
+
+
+BUFFER = 10
+TIME_STEP = 0.004
+FRAME_STEP = 0.1
+N_FRAMES = 100
+
+
+molecule = mmtf.get_structure(
+    mmtf.MMTFFile.read(rcsb.fetch("1aki", "mmtf")),
+    model=1,
+    include_bonds=True
+)
+# Remove solvent, as proper solvent addition is handled by OpenMM
+molecule = molecule[struc.filter_amino_acids(molecule)]
+# Create a box with some buffer around the protein
+# This box represents the
+box_dim = np.max(molecule.coord, axis=0) - np.min(molecule.coord, axis=0)
+molecule.box = np.diag(box_dim + BUFFER)
+
+# Create an OpenMM Topology from the AtomArray
+topology = molmarbles.to_topology(molecule)
+
+
+force_field = openmm.app.ForceField('amber14-all.xml', 'amber14/tip3pfb.xml')
+# Add hydrogen atoms and water
+modeller = app.Modeller(topology, molecule.coord * angstrom)
+modeller.addHydrogens(force_field)
+modeller.addSolvent(force_field)
+topology = modeller.topology
+
+system = force_field.createSystem(
+    topology, nonbondedMethod=app.PME,
+    nonbondedCutoff=1*nanometer, constraints=app.HBonds
+)
+integrator = openmm.LangevinMiddleIntegrator(300*kelvin, 1/picosecond, TIME_STEP*picosecond)
+simulation = app.Simulation(topology, system, integrator)
+simulation.context.setPositions(modeller.positions)
+simulation.minimizeEnergy()
+
+# Run simulation and record the current state (the coordinates)
+# every FRAME_STEP picoseconds
+states = []
+states.append(simulation.context.getState(getPositions=True))
+for i in range(N_FRAMES):
+    simulation.step(FRAME_STEP // TIME_STEP)
+    states.append(simulation.context.getState(getPositions=True))
+
+
+# Transfer the trajectory back to Biotite
+# The topology was changed in the process of adding hydrogen and solvent
+# -> Update the structure
+template = molmarbles.from_topology(topology)
+trajectory = molmarbles.from_states(template, states)
+# Center protein in box
+trajectory.coord -= struc.centroid(
+    trajectory.coord[:, struc.filter_amino_acids(trajectory)]
+)[:, np.newaxis, :]
+trajectory.coord += np.sum(trajectory.box / 2, axis=-2)[:, np.newaxis, :]
+# Remove segmentation over periodic boundary
+trajectory = struc.remove_pbc(trajectory)
+```
+
+Visualization with [Ammolite](https://ammolite.biotite-python.org/) and
+[PyMOL](https://pymol.org/)
+
+
+https://user-images.githubusercontent.com/28051833/220104497-ecf2cdb2-5e1d-4c22-ae27-ae4ca59ebb8e.mp4
+
+
+## Testing
+
+*Molmarbles* uses *pytest* for running its tests.

--- a/doc/tutorial/structure/index.rst
+++ b/doc/tutorial/structure/index.rst
@@ -52,6 +52,7 @@ contains functions for structure analysis and manipulation.
     bonds
     editing
     measurement
+    trajectories
     segments
     nucleotide
     alphabet

--- a/doc/tutorial/structure/trajectories.rst
+++ b/doc/tutorial/structure/trajectories.rst
@@ -5,10 +5,9 @@ Working with molecular trajectories
 As :mod:`biotite.structure` provides efficient tools for analyzing multi-model
 structures, the package is predestined for handling trajectories from
 *molecular dynamics* (MD) simulations.
-If you like, you can even use the
-`Molmarbles <https://github.com/biotite-dev/molmarbles>`_ extension package for
-seamless interaction between *Biotite* and the
-`OpenMM <https://openmm.org/>`_ MD simulation toolkit.
+If you like, you can even use the :mod:`biotite.interface.openmm` subpackage with the
+`OpenMM <https://openmm.org/>`_ molecular simulation toolkit to integrate MD
+simulations.
 
 Reading trajectory files
 ------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -42,6 +42,7 @@ dependencies:
   - pymol-open-source >=2
   - ffmpeg  # Required for video rendering in PyMOL
   - imagemagick  # Required for video rendering in PyMOL
+  - openmm >=8
   # Documentation building
   - pydata-sphinx-theme =0.15
   - matplotlib >=3.3

--- a/src/biotite/interface/openmm/__init__.py
+++ b/src/biotite/interface/openmm/__init__.py
@@ -1,0 +1,16 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+"""
+This subpackage provides an interface to the `OpenMM <https://openmm.org/>`_
+molecular simulation toolkit.
+It allows conversion between :class:`.AtomArray`/:class:`.AtomArrayStack` and
+structure-related objects from *OpenMM*.
+"""
+
+__name__ = "biotite.interface.openmm"
+__author__ = "Patrick Kunzmann"
+
+from .state import *
+from .system import *

--- a/src/biotite/interface/openmm/state.py
+++ b/src/biotite/interface/openmm/state.py
@@ -1,0 +1,93 @@
+__name__ = "biotite.interface.openmm"
+__author__ = "Patrick Kunzmann"
+__all__ = ["from_context", "from_state", "from_states"]
+
+import numpy as np
+import openmm
+import biotite.structure as struc
+
+
+def from_context(template, context):
+    """
+    Parse the coordinates and box of the current state of an
+    :class:`openmm.openmm.Context` into an :class:`AtomArray`.
+
+    Parameters
+    ----------
+    template : AtomArray
+        This structure is used as template.
+        The output :class:`AtomArray` is equal to this template with the
+        exception of the coordinates and the box vectors.
+    context : Context
+        The coordinates are parsed from the current state of this
+        :class:`openmm.openmm.Context`.
+
+    Returns
+    -------
+    atoms : AtomArray
+        The created :class:`AtomArray`.
+    """
+    state = context.getState(getPositions=True)
+    return from_state(template, state)
+
+
+def from_state(template, state):
+    """
+    Parse the coordinates and box of the given :class:`openmm.openmm.State`
+    into an :class:`AtomArray`.
+
+    Parameters
+    ----------
+    template : AtomArray
+        This structure is used as template.
+        The output :class:`AtomArray` is equal to this template with the
+        exception of the coordinates and the box vectors.
+    state : State
+        The coordinates are parsed from this state.
+        Must be created with ``getPositions=True``.
+
+    Returns
+    -------
+    atoms : AtomArray
+        The created :class:`AtomArray`.
+    """
+    coord, box = _parse_state(state)
+    atoms = template.copy()
+    atoms.coord = coord
+    atoms.box = box
+    return atoms
+
+
+def from_states(template, states):
+    """
+    Parse the coordinates and box vectors of multiple :class:`openmm.openmm.State`
+    objects into an :class:`AtomArrayStack`.
+
+    Parameters
+    ----------
+    template : AtomArray
+        This structure is used as template.
+        The output :class:`AtomArray` is equal to this template with the
+        exception of the coordinates and the box vectors.
+    state : iterable of State
+        The coordinates are parsed from these states.
+        Must be created with ``getPositions=True``.
+
+    Returns
+    -------
+    atoms : AtomArrayStack
+        The created :class:`AtomArrayStack`.
+    """
+    coords = []
+    boxes = []
+    for state in states:
+        coord, box = _parse_state(state)
+        coords.append(coord)
+        boxes.append(box)
+    return struc.from_template(template, np.stack(coords), np.stack(boxes))
+
+
+def _parse_state(state):
+    coord = state.getPositions(asNumpy=True).value_in_unit(openmm.unit.angstrom)
+    box = state.getPeriodicBoxVectors(asNumpy=True).value_in_unit(openmm.unit.angstrom)
+    return coord, box

--- a/src/biotite/interface/openmm/system.py
+++ b/src/biotite/interface/openmm/system.py
@@ -1,0 +1,227 @@
+__name__ = "biotite.interface.openmm"
+__author__ = "Patrick Kunzmann"
+__all__ = ["to_system", "to_topology", "from_topology"]
+
+import numpy as np
+import openmm
+import openmm.app as app
+import openmm.unit as unit
+import biotite.structure as struc
+import biotite.structure.info as info
+
+_BOND_TYPE_TO_ORDER = {
+    struc.BondType.SINGLE: 1,
+    struc.BondType.DOUBLE: 2,
+    struc.BondType.TRIPLE: 3,
+    struc.BondType.QUADRUPLE: 4,
+    struc.BondType.AROMATIC_SINGLE: 1,
+    struc.BondType.AROMATIC_DOUBLE: 2,
+    struc.BondType.AROMATIC_TRIPLE: 3,
+}
+
+
+def to_system(atoms):
+    """
+    Create a :class:`openmm.openmm.System` from an :class:`AtomArray` or
+    :class:`AtomArrayStack`.
+
+    Parameters
+    ----------
+    atoms : AtomArray or AtomArrayStack
+        The structure to be converted.
+        The box vectors are set from the ``box`` attribute.
+        If multiple models are given the box of the first model is selected.
+
+    Returns
+    -------
+    system : System
+        The created :class:`openmm.openmm.System`.
+    """
+    system = openmm.System()
+
+    for element in atoms.element:
+        system.addParticle(info.mass(element))
+
+    if atoms.box is not None:
+        if atoms.box.ndim == 3:
+            # If an `AtomArrayStack`, the first box is chosen
+            box = atoms.box[0]
+        else:
+            box = atoms.box
+        if not _check_box_requirements(box):
+            raise struc.BadStructureError(
+                "Box does not fulfill OpenMM's requirements for periodic boxes"
+            )
+        system.setDefaultPeriodicBoxVectors(*(box * unit.angstrom))
+
+    return system
+
+
+def to_topology(atoms):
+    """
+    Create a :class:`openmm.app.topology.Topology` from an :class:`AtomArray` or
+    :class:`AtomArrayStack`.
+
+    Parameters
+    ----------
+    atoms : AtomArray or AtomArrayStack
+        The structure to be converted.
+        An associated :class:`BondList` is required.
+
+    Returns
+    -------
+    topology : Topology
+        The created :class:`openmm.app.topology.Topology`.
+    """
+    if "atom_id" in atoms.get_annotation_categories():
+        atom_id = atoms.atom_id
+    else:
+        atom_id = np.arange(atoms.array_length()) + 1
+
+    chain_starts = struc.get_chain_starts(atoms)
+    res_starts = struc.get_residue_starts(atoms)
+
+    # Lists of chain, residue and atom objects that will be filled later
+    chain_list = []
+    residue_list = []
+    atom_list = []
+    # Each atom's index in the chain and residue list
+    chain_idx = _generate_idx(chain_starts, atoms.array_length())
+    res_idx = _generate_idx(res_starts, atoms.array_length())
+
+    topology = app.Topology()
+
+    ## Add atoms
+    for start_i in chain_starts:
+        chain_list.append(topology.addChain(id=atoms.chain_id[start_i]))
+    for start_i in res_starts:
+        residue_list.append(
+            topology.addResidue(
+                name=atoms.res_name[start_i],
+                chain=chain_list[chain_idx[start_i]],
+                insertionCode=atoms.ins_code[start_i],
+                id=str(atoms.res_id[start_i]),
+            )
+        )
+    for i in np.arange(atoms.array_length()):
+        atom_list.append(
+            topology.addAtom(
+                name=atoms.atom_name[i],
+                element=app.Element.getBySymbol(atoms.element[i]),
+                residue=residue_list[res_idx[i]],
+                id=str(atom_id[start_i]),
+            )
+        )
+
+    ## Add bonds
+    if atoms.bonds is None:
+        raise struc.BadStructureError("Input structure misses an associated BondList")
+    for atom_i, atom_j, bond_type in atoms.bonds.as_array():
+        topology.addBond(
+            atom_list[atom_i],
+            atom_list[atom_j],
+            order=_BOND_TYPE_TO_ORDER.get(bond_type),
+        )
+
+    ## Add box
+    if atoms.box is not None:
+        if atoms.box.ndim == 3:
+            # If an `AtomArrayStack`, the first box is chosen
+            box = atoms.box[0]
+        else:
+            box = atoms.box
+        if not _check_box_requirements(box):
+            raise struc.BadStructureError(
+                "Box does not fulfill OpenMM's requirements for periodic boxes"
+            )
+        topology.setPeriodicBoxVectors(box * unit.angstrom)
+
+    return topology
+
+
+def from_topology(topology):
+    """
+    Create a :class:`AtomArray` from a :class:`openmm.app.topology.Topology`.
+
+    Parameters
+    ----------
+    topology : Topology
+        The topology to be converted.
+
+    Returns
+    -------
+    atoms : AtomArray
+        The created :class:`AtomArray`.
+        As the :class:`openmm.app.topology.Topology` does not contain atom
+        coordinates, the values of the :class:`AtomArray` ``coord``
+        are set to `*NaN*.
+
+    Notes
+    -----
+    This function is especially useful for obtaining an updated
+    template, if the original topology was modified
+    (e.g. via :class:`openmm.app.modeller.Modeller`).
+    """
+    atoms = struc.AtomArray(topology.getNumAtoms())
+
+    chain_ids = []
+    res_ids = []
+    ins_codes = []
+    res_names = []
+    atom_names = []
+    elements = []
+    for chain in topology.chains():
+        chain_id = chain.id
+        for residue in chain.residues():
+            res_name = residue.name
+            res_id = int(residue.id)
+            ins_code = residue.insertionCode
+            for atom in residue.atoms():
+                chain_ids.append(chain_id)
+                res_ids.append(res_id)
+                ins_codes.append(ins_code)
+                res_names.append(res_name)
+                atom_names.append(atom.name.upper())
+                elements.append(atom.element.symbol.upper())
+    atoms.chain_id = chain_ids
+    atoms.res_id = res_ids
+    atoms.ins_code = ins_codes
+    atoms.res_name = res_names
+    atoms.atom_name = atom_names
+    atoms.element = elements
+    atoms.hetero = ~(struc.filter_amino_acids(atoms) | struc.filter_nucleotides(atoms))
+
+    bonds = []
+    atom_to_index = {atom: i for i, atom in enumerate(topology.atoms())}
+    for bond in topology.bonds():
+        order = bond.order if bond.order is not None else struc.BondType.ANY
+        bonds.append([atom_to_index[bond.atom1], atom_to_index[bond.atom2], order])
+    atoms.bonds = struc.BondList(atoms.array_length(), np.array(bonds))
+
+    box = topology.getPeriodicBoxVectors()
+    if box is None:
+        atoms.box = None
+    else:
+        atoms.box = np.asarray(box.value_in_unit(openmm.unit.angstrom))
+
+    return atoms
+
+
+def _generate_idx(starts, length):
+    # An array that is 1, at start positions and 0 everywhere else
+    start_counter = np.zeros(length, dtype=int)
+    start_counter[starts] = 1
+    # The first index should be zero -> the first start is not counted
+    start_counter[0] = 0
+    return np.cumsum(start_counter)
+
+
+def _check_box_requirements(box):
+    """
+    Return True, if the given box fulfills *OpenMM*'s requirements for
+    boxes, else otherwise.
+
+    The first vector must be on the x-axis
+    and the second vector must be on the xy-plane.
+    """
+    return np.all(np.triu(box, k=1) == 0)

--- a/tests/interface/test_openmm.py
+++ b/tests/interface/test_openmm.py
@@ -1,0 +1,160 @@
+from os.path import join
+import numpy as np
+import openmm
+import openmm.app as app
+import openmm.unit as unit
+import pytest
+import biotite.interface.openmm as openmm_interface
+import biotite.structure as struc
+import biotite.structure.io.pdbx as pdbx
+from tests.util import data_dir
+
+
+@pytest.fixture
+def test_path():
+    # Use a structure with hydrogen atoms
+    return join(data_dir("structure"), "1l2y.cif")
+
+
+@pytest.mark.parametrize("multi_state", [False, True])
+def test_state_conversion(test_path, multi_state):
+    """
+    Test whether the :class:`AtomArray` obtained from a :class:`State`
+    matches the original template atom array with newly generated
+    positions.
+    """
+    pdbx_file = pdbx.CIFFile.read(test_path)
+    template = pdbx.get_structure(pdbx_file, model=1)
+    system = openmm_interface.to_system(template)
+    # Create an arbitrary integrator
+    integrator = openmm.VerletIntegrator(1)
+    context = openmm.Context(system, integrator)
+
+    # Generate arbitrary coordinates and box vectors
+    coord = np.arange(template.array_length() * 3).reshape(-1, 3)
+    box = np.array(
+        [
+            [1, 0, 0],
+            [0, 2, 0],
+            [0, 0, 3],
+        ]
+    )
+    context.setPositions(coord * unit.angstrom)
+    context.setPeriodicBoxVectors(*(box * unit.angstrom))
+
+    if multi_state:
+        ref_atoms = struc.from_template(
+            template, np.stack([coord] * 2), np.stack([box] * 2)
+        )
+    else:
+        ref_atoms = template.copy()
+        ref_atoms.coord = coord
+        ref_atoms.box = box
+
+    if multi_state:
+        states = [context.getState(getPositions=True) for _ in range(2)]
+        test_atoms = openmm_interface.from_states(template, states)
+    else:
+        state = context.getState(getPositions=True)
+        test_atoms = openmm_interface.from_state(template, state)
+
+    assert np.allclose(test_atoms.coord, ref_atoms.coord)
+    assert np.allclose(test_atoms.box, ref_atoms.box)
+
+
+def test_system_consistency(test_path):
+    """
+    Test whether a :class:`System` converted from a :class:`AtomArray` is equal to a
+    :class:`System` directly read via OpenMM.
+    Forces and constraints are not tested, as they are not set by :func:`to_system()`.
+    """
+    topology = app.PDBxFile(test_path).topology
+    force_field = app.ForceField("amber14-all.xml")
+    ref_system = force_field.createSystem(topology)
+
+    atoms = pdbx.get_structure(pdbx.CIFFile.read(test_path), model=1)
+    test_system = openmm_interface.to_system(atoms)
+
+    assert test_system.getNumParticles() == ref_system.getNumParticles()
+    test_masses = [
+        test_system.getParticleMass(i).value_in_unit(unit.dalton)
+        for i in range(test_system.getNumParticles())
+    ]
+    ref_masses = [
+        ref_system.getParticleMass(i).value_in_unit(unit.dalton)
+        for i in range(ref_system.getNumParticles())
+    ]
+    assert test_masses == pytest.approx(ref_masses, abs=1e-2)
+    assert (
+        test_system.getDefaultPeriodicBoxVectors()
+        == ref_system.getDefaultPeriodicBoxVectors()
+    )
+
+
+@pytest.mark.parametrize("include_box", [False, True])
+def test_topology_conversion(test_path, include_box):
+    """
+    Converting an :class:`AtomArray` into a :class:`Topology` and back
+    again should not change the :class:`AtomArray`.
+    """
+    ref_atoms = pdbx.get_structure(pdbx.CIFFile.read(test_path), model=1)
+    ref_atoms.bonds = struc.connect_via_residue_names(ref_atoms)
+    if not include_box:
+        ref_atoms.box = None
+
+    topology = openmm_interface.to_topology(ref_atoms)
+    test_atoms = openmm_interface.from_topology(topology)
+
+    # The Topology cannot properly handle the aromatic bond types of Biotite
+    ref_atoms.bonds.remove_aromaticity()
+    _assert_equal_atom_arrays(test_atoms, ref_atoms)
+
+
+def test_topology_consistency(test_path):
+    """
+    Test whether an :class:`AtomArray` converted from a
+    :class:`Topology` read via OpenMM is equal to :class:`AtomArray`
+    directly read via Biotite.
+    """
+    ref_atoms = pdbx.get_structure(
+        pdbx.CIFFile.read(test_path), model=1, extra_fields=["label_asym_id"]
+    )
+    # OpenMM uses author fields, except for the chain ID,
+    # where it uses the label field
+    ref_atoms.chain_id = ref_atoms.label_asym_id
+    ref_atoms.del_annotation("label_asym_id")
+    ref_atoms.bonds = struc.connect_via_residue_names(ref_atoms)
+
+    topology = app.PDBxFile(test_path).topology
+    test_atoms = openmm_interface.from_topology(topology)
+
+    # OpenMM does not parse the bond type from CIF files
+    ref_atoms.bonds.remove_bond_order()
+    # Biotite does not parse disulfide bridges
+    # -> Remove them from the bonds parsed by OpenMM
+    for i, j, _ in test_atoms.bonds.as_array():
+        if test_atoms.element[i] == "S" and test_atoms.element[j] == "S":
+            test_atoms.bonds.remove_bond(i, j)
+    # The first residue has 'loose' hydrogen atoms which are automatically fixed by
+    # OpenMM, resulting in a new name for the hydrogen atom and a new bond
+    # For easy comparison, simply remove the first residue
+    ref_atoms = ref_atoms[ref_atoms.res_id >= 2]
+    test_atoms = test_atoms[test_atoms.res_id >= 2]
+
+    _assert_equal_atom_arrays(test_atoms, ref_atoms)
+
+
+def _assert_equal_atom_arrays(test_atoms, ref_atoms):
+    for category in ref_atoms.get_annotation_categories():
+        assert np.array_equal(
+            test_atoms.get_annotation(category), ref_atoms.get_annotation(category)
+        )
+
+    if ref_atoms.box is not None:
+        assert np.allclose(test_atoms.box, ref_atoms.box)
+    else:
+        assert test_atoms.box is None
+
+    # Do not compare array from 'BondList.as_array()',
+    # as the comparison would not allow different order of bonds
+    assert test_atoms.bonds == ref_atoms.bonds


### PR DESCRIPTION
As described in #709, this PR adds an interface to the *OpenMM* molecular simulation toolkit.
The code is taken and adapted from [`biotite-dev/molmarbles`](https://github.com/biotite-dev/molmarbles/). Afther this PR is merged, [`biotite-dev/molmarbles`](https://github.com/biotite-dev/molmarbles/) will be archived.