### PR TITLE
Add functionalities related to aromatic rings

### DIFF
--- a/doc/apidoc.json
+++ b/doc/apidoc.json
@@ -347,6 +347,11 @@
             "dot_bracket",
             "dot_bracket_from_structure",
             "base_pairs_from_dot_bracket"
+        ],
+        "Aromatic rings": [
+            "find_aromatic_rings",
+            "find_stacking_interactions",
+            "PiStacking"
         ]
     },
     "biotite.structure.info" : {

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -103,6 +103,20 @@
   doi = {10.1021/j100785a001}
 }
 
+@article{Bouysset2021,
+  title = {{{ProLIF}}: A Library to Encode Molecular Interactions as Fingerprints},
+  shorttitle = {{{ProLIF}}},
+  author = {Bouysset, Cédric and Fiorucci, Sébastien},
+  year = {2021},
+  month = sep,
+  journal = {Journal of Cheminformatics},
+  volume = {13},
+  number = {1},
+  pages = {72},
+  issn = {1758-2946},
+  doi = {10.1186/s13321-021-00548-6}
+}
+
 @article{Brevern2000,
   title = {Bayesian Probabilistic Approach for Predicting Backbone Structures in Terms of Protein Blocks},
   author = {de Brevern, A. G. and Etchebest, C. and Hazout, S.},
@@ -543,16 +557,17 @@
 }
 
 @article{Mantina2009,
+  title = {Consistent van Der {{Waals Radii}} for the {{Whole Main Group}}},
   author = {Mantina, Manjeera and Chamberlin, Adam C. and Valero, Rosendo and Cramer, Christopher J. and Truhlar, Donald G.},
-  title = {Consistent van der Waals Radii for the Whole Main Group},
+  year = {2009},
+  month = may,
   journal = {The Journal of Physical Chemistry A},
   volume = {113},
   number = {19},
-  pages = {5806-5812},
-  year = {2009},
-  doi = {10.1021/jp8111556},
-  note = {PMID: 19382751},
-  url = {https://doi.org/10.1021/jp8111556}
+  pages = {5806--5812},
+  publisher = {American Chemical Society},
+  issn = {1089-5639},
+  doi = {10.1021/jp8111556}
 }
 
 @article{Mariani2013,
@@ -665,49 +680,12 @@
 }
 
 @article{RDKit,
-  author       = {Greg Landrum and
-                  Paolo Tosco and
-                  Brian Kelley and
-                  Ricardo Rodriguez and
-                  David Cosgrove and
-                  Riccardo Vianello and
-                  sriniker and
-                  Peter Gedeck and
-                  Gareth Jones and
-                  NadineSchneider and
-                  Eisuke Kawashima and
-                  Dan Nealschneider and
-                  Andrew Dalke and
-                  Matt Swain and
-                  Brian Cole and
-                  Samo Turk and
-                  Aleksandr Savelev and
-                  tadhurst-cdd and
-                  Alain Vaucher and
-                  Maciej Wójcikowski and
-                  Ichiru Take and
-                  Vincent F. Scalfani and
-                  Rachel Walker and
-                  Kazuya Ujihara and
-                  Daniel Probst and
-                  Juuso Lehtivarjo and
-                  Hussein Faara and
-                  guillaume godin and
-                  Axel Pahl and
-                  Jeremy Monat},
-  title        = {rdkit/rdkit: 2024\_09\_5 (Q3 2024) Release},
-  month        = jan,
-  year         = 2025,
-  publisher    = {Zenodo},
-  version      = {Release\_2024\_09\_5},
-  doi          = {10.5281/zenodo.14779836},
-  url          = {https://doi.org/10.5281/zenodo.14779836},
-  swhid        = {swh:1:dir:7f64ae1b0334f6273f3daedab96bf3e0229e530a
-                   ;origin=https://doi.org/10.5281/zenodo.591637;visi
-                   t=swh:1:snp:17d9293d284e1a05de2a78abb47df1ef544a3c
-                   cd;anchor=swh:1:rel:eaf5c3e1f69b9714806a37d25966b6
-                   4cc04f19b8;path=rdkit-rdkit-7ea9d81
-                  },
+  title = {Rdkit/Rdkit: 2024\_09\_5 ({{Q3}} 2024) {{Release}}},
+  shorttitle = {Rdkit/Rdkit},
+  author = {Landrum, Greg and Tosco, Paolo and Kelley, Brian and Rodriguez, Ricardo and Cosgrove, David and Vianello, Riccardo and {sriniker} and Gedeck, Peter and Jones, Gareth and NadineSchneider and Kawashima, Eisuke and Nealschneider, Dan and Dalke, Andrew and Swain, Matt and Cole, Brian and Turk, Samo and Savelev, Aleksandr and {tadhurst-cdd} and Vaucher, Alain and Wójcikowski, Maciej and Take, Ichiru and Scalfani, Vincent F. and Walker, Rachel and Ujihara, Kazuya and Probst, Daniel and Lehtivarjo, Juuso and Faara, Hussein and {godin}, guillaume and Pahl, Axel and Monat, Jeremy},
+  year = {2025},
+  month = jan,
+  doi = {10.5281/zenodo.14779836}
 }
 
 @article{Roberts2004,
@@ -953,6 +931,20 @@
   doi = {10.1093/bioinformatics/btu789},
   pmcid = {PMC4393513},
   pmid = {25540181}
+}
+
+@article{Wojcikowski2015,
+  title = {Open {{Drug Discovery Toolkit}} ({{ODDT}}): A New Open-Source Player in the Drug Discovery Field},
+  shorttitle = {Open {{Drug Discovery Toolkit}} ({{ODDT}})},
+  author = {Wójcikowski, Maciej and Zielenkiewicz, Piotr and Siedlecki, Pawel},
+  year = {2015},
+  month = jun,
+  journal = {Journal of Cheminformatics},
+  volume = {7},
+  number = {1},
+  pages = {26},
+  issn = {1758-2946},
+  doi = {10.1186/s13321-015-0078-2}
 }
 
 @article{Xia2021,

--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -125,6 +125,7 @@ from .pseudoknots import *
 from .rdf import *
 from .repair import *
 from .residues import *
+from .rings import *
 from .sasa import *
 from .sequence import *
 from .sse import *

--- a/src/biotite/structure/rings.py
+++ b/src/biotite/structure/rings.py
@@ -1,0 +1,335 @@
+# This source code is part of the Biotite package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+"""
+This module provides functions related to aromatic rings.
+"""
+
+__name__ = "biotite.structure"
+__author__ = "Patrick Kunzmann"
+__all__ = ["find_aromatic_rings", "find_stacking_interactions", "PiStacking"]
+
+
+from enum import IntEnum
+import networkx as nx
+import numpy as np
+from biotite.structure.bonds import BondType
+from biotite.structure.error import BadStructureError
+from biotite.structure.geometry import displacement
+from biotite.structure.util import norm_vector, vector_dot
+
+
+class PiStacking(IntEnum):
+    """
+    The type of pi-stacking interaction.
+
+    - ``PARALLEL``: parallel pi-stacking (also called *staggered* or *Sandwich*)
+    - ``PERPENDICULAR``: perpendicular pi-stacking (also called *T-shaped*)
+    """
+
+    PARALLEL = 0
+    PERPENDICULAR = 1
+
+
+def find_aromatic_rings(atoms):
+    """
+    Find (anti-)aromatic rings in a structure.
+
+    Parameters
+    ----------
+    atoms : AtomArray or AtomArrayStack
+        The atoms to be searched for aromatic rings.
+        Requires an associated :class:`BondList`.
+
+    Returns
+    -------
+    rings : list of ndarray
+        The indices of the atoms that form aromatic rings.
+        Each ring is represented by a list of indices.
+        Only rings with minimum size are returned, i.e. two connected rings
+        (e.g. in tryptophan) are reported as separate rings.
+
+    Notes
+    -----
+    This function does not distinguish between aromatic and antiaromatic rings.
+    All cycles containing atoms that are completely connected by aromatic bonds
+    are considered aromatic rings.
+
+    The PDB *Chemical Component Dictionary* (CCD) does not identify aromatic rings in
+    all compounds as such.
+    Prominent examples are the nucleobases, where the 6-membered rings are not
+    flagged as aromatic.
+
+    Examples
+    --------
+
+    >>> nad = residue("NAD")
+    >>> rings = find_aromatic_rings(nad)
+    >>> print(rings)
+    [array([41, 37, 36, 35, 43, 42]), array([19, 18, 16, 15, 21, 20]), array([12, 13, 14, 15, 21])]
+    >>> for atom_indices in rings:
+    ...     print(np.sort(nad.atom_name[atom_indices]))
+    ['C2N' 'C3N' 'C4N' 'C5N' 'C6N' 'N1N']
+    ['C2A' 'C4A' 'C5A' 'C6A' 'N1A' 'N3A']
+    ['C4A' 'C5A' 'C8A' 'N7A' 'N9A']
+    """
+    if atoms.bonds is None:
+        raise BadStructureError("Structure must have an associated BondList")
+    bond_array = atoms.bonds.as_array()
+    # To detect aromatic rings, only keep bonds that are aromatic
+    aromatic_bond_array = bond_array[
+        np.isin(
+            bond_array[:, 2],
+            [
+                BondType.AROMATIC,
+                BondType.AROMATIC_SINGLE,
+                BondType.AROMATIC_DOUBLE,
+                BondType.AROMATIC_TRIPLE,
+            ],
+        ),
+        # We can omit the bond type now
+        :2,
+    ]
+    aromatic_bond_graph = nx.from_edgelist(aromatic_bond_array.tolist())
+    # Find the cycles with minimum size -> cycle basis
+    rings = nx.cycle_basis(aromatic_bond_graph)
+    return [np.array(ring, dtype=int) for ring in rings]
+
+
+def find_stacking_interactions(
+    atoms,
+    centroid_cutoff=6.5,
+    plane_angle_tol=np.deg2rad(30.0),
+    shift_angle_tol=np.deg2rad(30.0),
+):
+    """
+    Find pi-stacking interactions between aromatic rings.
+
+    Parameters
+    ----------
+    atoms : AtomArray
+        The atoms to be searched for aromatic rings.
+        Requires an associated :class:`BondList`.
+    centroid_cutoff : float
+        The cutoff distance for ring centroids.
+    plane_angle_tol : float
+        The tolerance for the angle between ring planes that must be either
+        parallel or perpendicular.
+        Given in radians.
+    shift_angle_tol : float
+        The tolerance for the angle between the ring plane normals and the
+        centroid difference vector.
+        Given in radians.
+
+    Returns
+    -------
+    interactions : list of tuple(ndarray, ndarray, PiStacking)
+        The stacking interactions between aromatic rings.
+        Each element in the list represents one stacking interaction.
+        The first two elements of each tuple represent atom indices of the stacked
+        rings.
+        The third element of each tuple is the type of stacking interaction.
+
+    See Also
+    --------
+    find_aromatic_rings : Used for finding the aromatic rings in this function.
+
+    Notes
+    -----
+    This function does not distinguish between aromatic and antiaromatic rings.
+    Furthermore, it does not distinguish between repulsive and attractive stacking:
+    Usually, stacking two rings directly above each other is repulsive, as the pi
+    orbitals above the rings repel each other, so a slight horizontal shift is
+    usually required to make the interaction attractive.
+    However, in details this is strongly dependent on heteroatoms and the exact
+    orientation of the rings.
+    Hence, this function aggregates all stacking interactions to simplify the
+    conditions for pi-stacking.
+
+    The conditions for pi-stacking are :footcite:`Wojcikowski2015`:
+
+        - The ring centroids must be within cutoff distance (default: 6.5 Å).
+          While :footcite:`Wojcikowski2015` uses a cutoff of 5.0 Å, 6.5 Å was
+          adopted from :footcite:`Bouysset2021`to better identify perpendicular
+          stacking interactions.
+        - The planes must be parallel or perpendicular to each other within a default
+          tolerance of 30°.
+        - The angle between the plane normals and the centroid difference vector must be
+          be either 0° or 90° within a default tolerance of 30°, to check for lateral
+          shifts.
+
+    References
+    ----------
+
+    .. footbibliography::
+
+    Examples
+    --------
+
+    Detect base stacking interactions in a DNA helix
+
+    >>> from os.path import join
+    >>> dna_helix = load_structure(
+    ...     join(path_to_structures, "base_pairs", "1qxb.cif"), include_bonds=True
+    ... )
+    >>> interactions = find_stacking_interactions(dna_helix)
+    >>> for ring_atom_indices_1, ring_atom_indices_2, stacking_type in interactions:
+    ...     print(
+    ...         dna_helix.res_id[ring_atom_indices_1[0]],
+    ...         dna_helix.res_id[ring_atom_indices_2[0]],
+    ...         PiStacking(stacking_type).name
+    ...     )
+    17 18 PARALLEL
+    17 18 PARALLEL
+    5 6 PARALLEL
+    5 6 PARALLEL
+    5 6 PARALLEL
+    """
+    rings = find_aromatic_rings(atoms)
+    if len(rings) == 0:
+        return []
+
+    ring_centroids = np.array(
+        [atoms.coord[atom_indices].mean(axis=0) for atom_indices in rings]
+    )
+    ring_normals = np.array(
+        [_get_ring_normal(atoms.coord[atom_indices]) for atom_indices in rings]
+    )
+
+    # Create an index array that contains the Cartesian product of all rings
+    indices = np.stack(
+        [
+            np.repeat(np.arange(len(rings)), len(rings)),
+            np.tile(np.arange(len(rings)), len(rings)),
+        ],
+        axis=-1,
+    )
+    # Do not include duplicate pairs
+    indices = indices[indices[:, 0] > indices[:, 1]]
+
+    ## Condition 1: Ring centroids are close enough to each other
+    diff = displacement(ring_centroids[indices[:, 0]], ring_centroids[indices[:, 1]])
+    # Use squared distance to avoid time consuming sqrt computation
+    sq_distance = vector_dot(diff, diff)
+    is_interacting = sq_distance < centroid_cutoff**2
+    indices = indices[is_interacting]
+
+    ## Condition 2: Ring planes are parallel or perpendicular
+    plane_angles = _minimum_angle(
+        ring_normals[indices[:, 0]], ring_normals[indices[:, 1]]
+    )
+    is_parallel = _is_within_tolerance(plane_angles, 0, plane_angle_tol)
+    is_perpendicular = _is_within_tolerance(plane_angles, np.pi / 2, plane_angle_tol)
+    is_interacting = is_parallel | is_perpendicular
+    indices = indices[is_interacting]
+    # Keep in sync with the shape of the filtered indices,
+    # i.e. after filtering, `is_parallel==False` means a perpendicular interaction
+    is_parallel = is_parallel[is_interacting]
+
+    ## Condition 3: The ring centroids are not shifted too much
+    ## (in terms of normal-centroid angle)
+    diff = displacement(ring_centroids[indices[:, 0]], ring_centroids[indices[:, 1]])
+    norm_vector(diff)
+    angles = np.stack(
+        [_minimum_angle(ring_normals[indices[:, i]], diff) for i in range(2)]
+    )
+    is_interacting = (
+        # For parallel stacking, the lateral shift may not exceed the tolerance
+        (is_parallel & np.any(_is_within_tolerance(angles, 0, shift_angle_tol), axis=0))
+        # For perpendicular stacking, one ring must be above the other,
+        # but from the perspective of the other ring, the first ring is approximately
+        # in the same plane
+        | (
+            ~is_parallel
+            & (
+                (
+                    _is_within_tolerance(angles[0], 0, shift_angle_tol)
+                    & _is_within_tolerance(angles[1], np.pi / 2, shift_angle_tol)
+                )
+                | (
+                    _is_within_tolerance(angles[0], np.pi / 2, shift_angle_tol)
+                    & _is_within_tolerance(angles[1], 0, shift_angle_tol)
+                )
+            )
+        )
+    )
+    indices = indices[is_interacting]
+    is_parallel = is_parallel[is_interacting]
+
+    # Only return pairs of rings where all conditions were fulfilled
+    return [
+        (
+            rings[ring_i],
+            rings[ring_j],
+            PiStacking.PARALLEL if is_parallel[i] else PiStacking.PERPENDICULAR,
+        )
+        for i, (ring_i, ring_j) in enumerate(indices)
+    ]
+
+
+def _get_ring_normal(ring_coord):
+    """
+    Get the normal vector perpendicular to the ring plane.
+
+    Parameters
+    ----------
+    ring_coord : ndarray
+        The coordinates of the atoms in the ring.
+
+    Returns
+    -------
+    normal : ndarray
+        The normal vector of the ring plane.
+    """
+    # Simply use any three atoms in the ring to calculate the normal vector
+    # We can also safely assume that there are at least three atoms in the ring,
+    # as otherwise it would not be a ring
+    normal = np.cross(ring_coord[1] - ring_coord[0], ring_coord[2] - ring_coord[0])
+    norm_vector(normal)
+    return normal
+
+
+def _minimum_angle(v1, v2):
+    """
+    Get the minimum angle between two vectors, i.e. the possible angle range is
+    ``[0, pi/2]``.
+
+    Parameters
+    ----------
+    v1, v2 : ndarray, shape=(n,3), dtype=float
+        The vectors to measure the angle between.
+
+    Returns
+    -------
+    angle : ndarray, shape=(n,), dtype=float
+        The minimum angle between the two vectors.
+
+    Notes
+    -----
+    This restriction is added here as the normal vectors of the ring planes
+    have no 'preferred side'.
+    """
+    # Do not distinguish between the 'sides' of the rings -> take absolute of cosine
+    return np.arccos(np.abs(vector_dot(v1, v2)))
+
+
+def _is_within_tolerance(angles, expected_angle, tolerance):
+    """
+    Check if the angles are within a certain tolerance.
+
+    Parameters
+    ----------
+    angles : ndarray, shape=x, dtype=float
+        The angles to check.
+    expected_angle : float
+        The expected angle.
+    tolerance : float
+        The tolerance.
+
+    Returns
+    -------
+    is_within_tolerance : ndarray, shape=x, dtype=bool
+        True if the angles are within the tolerance, False otherwise.
+    """
+    return np.abs(angles - expected_angle) < tolerance

--- a/tests/structure/test_rings.py
+++ b/tests/structure/test_rings.py
@@ -1,0 +1,190 @@
+import itertools
+from enum import IntEnum
+from pathlib import Path
+import numpy as np
+import pytest
+import biotite.structure as struc
+import biotite.structure.info as info
+import biotite.structure.io.pdbx as pdbx
+from tests.util import data_dir
+
+
+@pytest.fixture
+def riboswitch_structure():
+    """
+    Get a nucleotide structure with a complex fold, to include a variety of aromatic
+    ring interactions.
+    """
+    pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / "4gxy.bcif")
+    atoms = pdbx.get_structure(pdbx_file, model=1, include_bonds=True)
+    atoms = atoms[struc.filter_nucleotides(atoms)]
+
+    # The CCD does not flag the 6-cycles in nucleobases as aromatic -> correct this
+    aromatic_atom_names = [
+        element + str(number)
+        for element, number in itertools.product(["C", "N"], range(1, 10))
+    ]
+    bond_array = atoms.bonds.as_array()
+    # Convert single and double bonds between those atoms into aromatic bonds
+    aromatic_atom_mask = np.isin(
+        atoms.atom_name[bond_array[:, 0]], aromatic_atom_names
+    ) & np.isin(atoms.atom_name[bond_array[:, 1]], aromatic_atom_names)
+    bond_array[aromatic_atom_mask, 2] = struc.BondType.AROMATIC
+    atoms.bonds = struc.BondList(atoms.array_length(), bond_array)
+
+    return atoms
+
+
+@pytest.mark.parametrize(
+    "res_name, ref_ring_members",
+    [
+        # No aromatic rings at all
+        ("ALA", []),
+        # Rings, but no aromatic ones
+        ("GLC", []),
+        # One aromatic ring
+        (
+            "TYR",
+            [
+                ("CG", "CD1", "CD2", "CE1", "CE2", "CZ"),
+            ],
+        ),
+        # Aromatic ring with heteroatoms
+        (
+            "HIS",
+            [
+                ("CG", "CD2", "NE2", "CE1", "ND1"),
+            ],
+        ),
+        # Two fused aromatic rings
+        (
+            "TRP",
+            [
+                ("CG", "CD1", "CD2", "CE2", "NE1"),
+                ("CD2", "CE2", "CZ2", "CH2", "CZ3", "CE3"),
+            ],
+        ),
+        # Disconnected aromatic rings
+        (
+            "BP5",
+            [
+                ("N1", "C1", "C2", "C3", "C4", "C5"),
+                ("N2", "C6", "C7", "C8", "C9", "C11"),
+            ],
+        ),
+    ],
+    # Keep only the residue name as ID
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_find_known_aromatic_rings(res_name, ref_ring_members):
+    """
+    Check if aromatic rings are correctly identified by :func:`find_aromatic_rings()` in
+    known molecules.
+    """
+    molecule = info.residue(res_name)
+    rings = struc.find_aromatic_rings(molecule)
+    test_ring_members = set(
+        [frozenset(molecule.atom_name[atom_indices].tolist()) for atom_indices in rings]
+    )
+    ref_ring_members = set([frozenset(ring) for ring in ref_ring_members])
+
+    assert test_ring_members == ref_ring_members
+
+
+@pytest.mark.parametrize(
+    "stacking_type, included_interactions, excluded_interactions",
+    [
+        (
+            struc.PiStacking.PARALLEL,
+            [
+                (13, 14),
+                (32, 33),
+                (109, 121),
+            ],
+            [
+                (109, 120),
+                (109, 122),
+            ],
+        ),
+        (
+            struc.PiStacking.PERPENDICULAR,
+            [
+                (99, 100),
+                (125, 126),
+            ],
+            [
+                (16, 30),
+                (97, 130),
+                (16, 29),
+            ],
+        ),
+    ],
+    ids=lambda x: x.name if isinstance(x, IntEnum) else None,
+)
+def test_find_known_stacking_interactions(
+    riboswitch_structure, stacking_type, included_interactions, excluded_interactions
+):
+    """
+    Check if :func:`find_stacking_interactions()` correctly identifies pi-stacking
+    interactions in a known complex folded nucleic acid structure.
+    Due to the high number of interactions, check this exemplarily, i.e.
+    check if interactions between certain residues are reported and others are
+    definitely absent.
+    """
+    interactions = struc.find_stacking_interactions(
+        riboswitch_structure,
+    )
+    interaction_res_ids = []
+    for ring_indices_1, ring_indices_2, s_type in interactions:
+        if s_type == stacking_type:
+            interaction_res_ids.append(
+                frozenset(
+                    (
+                        # Taking the first atom index is sufficient,
+                        # as all atoms in the same ring are part of the same residue
+                        riboswitch_structure.res_id[ring_indices_1[0]],
+                        riboswitch_structure.res_id[ring_indices_2[0]],
+                    )
+                )
+            )
+
+    included_interactions = set(
+        [frozenset(interaction) for interaction in included_interactions]
+    )
+    excluded_interactions = set(
+        [frozenset(interaction) for interaction in excluded_interactions]
+    )
+
+    assert included_interactions.issubset(interaction_res_ids)
+    assert excluded_interactions.isdisjoint(interaction_res_ids)
+
+
+def test_no_duplicate_stacking_interactions(riboswitch_structure):
+    """
+    Check if :func:`find_stacking_interactions()` does not report duplicate
+    interactions.
+    """
+    interactions = struc.find_stacking_interactions(riboswitch_structure)
+    original_length = len(interactions)
+
+    interactions = set(
+        [
+            frozenset((frozenset(ring_indices_1), frozenset(ring_indices_2)))
+            for ring_indices_1, ring_indices_2, _ in interactions
+        ]
+    )
+    deduplicated_length = len(interactions)
+
+    assert deduplicated_length == original_length
+
+
+def test_no_adjacent_stacking_interactions():
+    """
+    Ensure that :func:`find_stacking_interactions()` does not report interactions
+    between adjacent (fused) aromatic rings.
+    """
+    # Tryptophan contains two fused aromatic rings
+    molecule = info.residue("TRP")
+    interactions = struc.find_stacking_interactions(molecule)
+
+    assert len(interactions) == 0


### PR DESCRIPTION
This PR adds the `find_aromatic_rings()` and `find_stacking_interactions()` functions to `biotite.structure`, that can be used to identify atoms that are part of aromatic rings and find pi-stacking interactions between them, respectively.