### PR TITLE
bug fix: string truncation in AtomArray annotations

### DIFF
--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -1195,9 +1195,18 @@ def array(atoms):
                 f"annotation categories as the atom at index 0"
             )
     array = AtomArray(len(atoms))
+
     # Add all (also optional) annotation categories
     for name in names:
-        array.add_annotation(name, dtype=type(atoms[0]._annot[name]))
+        value = atoms[0]._annot[name]
+        if isinstance(value, str):
+            # Find maximum string length across all atoms for this annotation
+            max_len = max(len(str(atom._annot[name])) for atom in atoms)
+            dtype = f"<U{max_len}"
+        else:
+            dtype = type(value)
+        array.add_annotation(name, dtype=dtype)
+
     # Add all atoms to AtomArray
     for i in range(len(atoms)):
         for name in names:


### PR DESCRIPTION
The `structure.array()` method truncates any string-based annotations to an arbitrary length of string. i.e. you can end up with
```
atoms[1000] --> Atom(..., str_annot="111", ...)
atoms[1000].str_annot.dtype --> dtype('<U3')

array = structure.array(atoms)
array[1000] --> Atom(..., str_annot="1", ...)
array[1000].str_annot.dtype --> dtype('<U1')
```
The culprit is this
```array.add_annotation(name, dtype=type(atoms[0]._annot[name]))```
is using the first atom in the array, which is often the shortest, to determine the dtype of the whole array. This is particularly problematic when processing cif columns that contains string representations of ids. Instead, we need to find the maximum length across the atom list to ensure no truncations occur.