### PR TITLE
Optimize memory utilization of `get_structure()`.

### DIFF
--- a/src/biotite/interface/rdkit/mol.py
+++ b/src/biotite/interface/rdkit/mol.py
@@ -304,20 +304,22 @@ def from_mol(mol, conformer_id=None, add_hydrogen=None):
     >>> UFFOptimizeMolecule(mol)
     0
     >>> alanine_atom_array = from_mol(mol, conformer_id)
+    >>> # RDKit does not assign atom names -> for convenience, do this in Biotite
+    >>> alanine_atom_array.atom_name = create_atom_names(alanine_atom_array)
     >>> print(alanine_atom_array)
-                0             C        -1.067    1.111   -0.079
-                0             C        -0.366   -0.241   -0.217
-                0             C         1.128   -0.082   -0.117
-                0             O         1.654    0.353    0.943
-                0             O         1.932   -0.413   -1.203
-                0             N        -0.865   -1.173    0.796
-                0             H        -0.715    1.807   -0.871
-                0             H        -2.165    0.980   -0.191
-                0             H        -0.862    1.562    0.916
-                0             H        -0.613   -0.650   -1.221
-                0             H         2.938   -0.311   -1.154
-                0             H        -0.590   -0.837    1.749
-                0             H        -0.408   -2.103    0.649
+                0      C1     C        -1.076    1.102   -0.094
+                0      C2     C        -0.363   -0.246   -0.218
+                0      C3     C         1.129   -0.073   -0.109
+                0      O1     O         1.644    0.373    0.952
+                0      O2     O         1.943   -0.405   -1.187
+                0      N1     N        -0.861   -1.175    0.798
+                0      H1     H        -0.724    1.795   -0.888
+                0      H2     H        -2.171    0.960   -0.212
+                0      H3     H        -0.881    1.561    0.899
+                0      H4     H        -0.600   -0.664   -1.221
+                0      H5     H         2.949   -0.295   -1.132
+                0      H6     H        -0.595   -0.830    1.750
+                0      H7     H        -0.395   -2.102    0.660
     """
     if add_hydrogen is None:
         add_hydrogen = not _has_explicit_hydrogen(mol)

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -104,8 +104,8 @@ CANONICAL_RESIDUE_LIST = canonical_aa_list + canonical_nucleotide_list
 # exceed a certain threshold,
 # a dictionary approach is less computation and memory intensive than the dense
 # vectorized approach.
-# https://github.com/biotite-dev/biotite/pull/765#issuecomment-2696591338
-FIND_MATCHES_SWITCH_THRESHOLD = 10000
+# https://github.com/biotite-dev/biotite/pull/765#issuecomment-2708867357
+FIND_MATCHES_SWITCH_THRESHOLD = 4000000
 
 _proteinseq_type_list = ["polypeptide(D)", "polypeptide(L)"]
 _nucleotideseq_type_list = [

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -115,6 +115,8 @@ _other_type_list = [
     "polysaccharide(L)",
 ]
 
+FIND_MATCHES_SWITCH_THRES = 10000
+
 
 def _filter(category, index):
     """
@@ -644,7 +646,7 @@ def _parse_inter_residue_bonds(atom_site, struct_conn):
     )
 
 
-def _find_matches(query_arrays, reference_arrays):
+def _find_matches_by_dense_array(query_arrays, reference_arrays):
     """
     For each index in the `query_arrays` find the indices in the
     `reference_arrays` where all query values match the reference counterpart.
@@ -674,6 +676,63 @@ def _find_matches(query_arrays, reference_arrays):
     # -1 indicates that no match was found in the reference
     match_indices = np.full(len(query_arrays[0]), -1, dtype=int)
     match_indices[query_matches] = reference_matches
+    return match_indices
+
+
+def _find_matches_by_dict(query_arrays, reference_arrays):
+    """
+    For each index in the `query_arrays` find the indices in the
+    `reference_arrays` where all query values match the reference counterpart.
+    If no match is found for a query, the corresponding index is -1.
+    """
+    # Convert reference arrays to a dictionary for O(1) lookups
+    reference_dict = {}
+    ambiguous_keys = set()
+    for ref_idx, ref_row in enumerate(zip(*reference_arrays)):
+        ref_key = tuple(ref_row)
+        if ref_key in reference_dict:
+            ambiguous_keys.add(ref_key)
+            continue
+        reference_dict[ref_key] = ref_idx
+
+    match_indices = []
+    for query_idx, query_row in enumerate(zip(*query_arrays)):
+        query_key = tuple(query_row)
+        occurrence = reference_dict.get(query_key)
+
+        if occurrence is None:
+            # -1 indicates that no match was found in the reference
+            match_indices.append(-1)
+        elif query_key in ambiguous_keys:
+            # The query cannot be uniquely matched to an atom in the reference
+            raise InvalidFileError(
+                f"The covalent bond in the 'struct_conn' category at index "
+                f"{query_idx} cannot be unambiguously assigned to atoms in "
+                f"the 'atom_site' category"
+            )
+        else:
+            match_indices.append(occurrence)
+
+    return np.array(match_indices)
+
+
+def _find_matches(query_arrays, reference_arrays):
+    """
+    For each index in the `query_arrays` find the indices in the
+    `reference_arrays` where all query values match the reference counterpart.
+    If no match is found for a query, the corresponding index is -1.
+    """
+    # it was observed that when the size exceeds 2^13 (8192)
+    # the dict strategy becomes significantly faster than the dense array
+    # and does not cause excessive memory usage.
+    # https://github.com/biotite-dev/biotite/pull/765#issuecomment-2696591338
+    if (
+        query_arrays[0].shape[0] * reference_arrays[0].shape[0]
+        <= FIND_MATCHES_SWITCH_THRES
+    ):
+        match_indices = _find_matches_by_dense_array(query_arrays, reference_arrays)
+    else:
+        match_indices = _find_matches_by_dict(query_arrays, reference_arrays)
     return match_indices
 
 

--- a/tests/structure/io/test_pdbx.py
+++ b/tests/structure/io/test_pdbx.py
@@ -88,18 +88,20 @@ def test_split_one_line(cif_line, expected_fields):
     assert list(pdbx.cif._split_one_line(cif_line)) == expected_fields
 
 
-@pytest.mark.parametrize(
-    "format, path, model",
-    itertools.product(
-        ["cif", "bcif"], glob.glob(join(data_dir("structure"), "*.cif")), [None, 1, -1]
-    ),
-)
-def test_conversion(tmpdir, format, path, model):
+@pytest.mark.parametrize("find_matches_by_dict", [False, True])
+@pytest.mark.parametrize("model", [None, 1, -1])
+@pytest.mark.parametrize("path", glob.glob(join(data_dir("structure"), "*.cif")))
+@pytest.mark.parametrize("format", ["cif", "bcif"])
+def test_conversion(monkeypatch, tmpdir, format, path, model, find_matches_by_dict):
     """
     Test serializing and deserializing a structure from a file
     restores the same structure.
     """
     DELETED_ANNOTATION = "auth_comp_id"
+
+    if find_matches_by_dict:
+        # Lower the threshold to 0 to force usage of `_find_matches_by_dict()`
+        monkeypatch.setattr(pdbx.convert, "FIND_MATCHES_SWITCH_THRESHOLD", 0)
 
     base_path = splitext(path)[0]
     if format == "cif":


### PR DESCRIPTION
When obtaining an AtomArray using `pdbx.get_structure()`, the invoked `_find_matches()` function generates a `[N_struct_conn_col, N_struct_conn_row, N_atom]` matrix. In cases where a CIF file contains numerous atoms and numerous inter-residue bonds, this can lead to a significant increase in memory usage. For example, for PDB ID 7Y4L, memory consumption can reach up to 100GB, and it takes approximately 450 seconds to run `pdbx.get_structure()`.
This PR modifies the implementation of `_find_matches()` to address and prevent this issue. With the updated code, processing 7Y4L requires less than 1.5GB of memory, and the runtime is reduced to approximately 45 seconds.