### PR TITLE
Add block name to deserialized blocks

### DIFF
--- a/src/biotite/structure/io/pdbx/cif.py
+++ b/src/biotite/structure/io/pdbx/cif.py
@@ -896,6 +896,7 @@ class CIFFile(_Component, File, MutableMapping):
                 block = CIFBlock.deserialize(block)
             except Exception:
                 raise DeserializationError(f"Failed to deserialize block '{key}'")
+            block.name = key
             # Update with deserialized object
             self._blocks[key] = block
         return block


### PR DESCRIPTION
Fixes e.g. the following snippet:

```python
import biotite.structure.io.pdbx as pdbx
import biotite.structure as struc
import biotite.database.rcsb as rcsb

pdbx_file = pdbx.CIFFile.read(rcsb.fetch("1aki", "cif", "."))
for block in pdbx_file.values():
    print(block)
```