### PR TITLE
Bypass DSSP in tests and documentation

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -209,10 +209,6 @@ jobs:
           miniforge-version: latest
       - name: Install distribution
         run: pip install ./dist/*.whl
-      - name: "TEMP: Skip DSSP tests"
-        # TEMP: Omit DSSP tests for now until conda-forge DSSP is functional
-        # (https://github.com/conda-forge/dssp-feedstock/pull/4)
-        run: mamba uninstall dssp
       - name: Run tests
         # Running NCBI BLAST and SRA takes too long
         # The tests on the NCBI Entrez database are not reliable enough

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -32,7 +32,7 @@ env:
   # mussllinux takes 6+ hrs to build and test so ignore it
   CIBW_TEST_SKIP: "*musllinux* *-macosx_arm64"
   # Configuration for the architecture-agnostic jobs
-  PY_VERSION: "3.11"  # Keep in sync with version in environment.yml
+  PY_VERSION: "3.12"  # Keep in sync with version in environment.yml
 
 
 jobs:

--- a/doc/examples/scripts/structure/modeling/trajectory_sse.py
+++ b/doc/examples/scripts/structure/modeling/trajectory_sse.py
@@ -18,10 +18,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colors
 from matplotlib.lines import Line2D
+import biotite
 import biotite.structure as struc
 import biotite.structure.io as strucio
 import biotite.structure.io.xtc as xtc
-from biotite.application.dssp import DsspApp
 
 # Put here the path of the downloaded files
 templ_file_path = "../../../download/lysozyme_md.pdb"
@@ -33,26 +33,15 @@ traj = xtc_file.get_structure(template=strucio.load_structure(templ_file_path))
 time = xtc_file.get_time()
 traj = traj[:, struc.filter_amino_acids(traj)]
 
-# DSSP does not assign an SSE to the last residue -> -1
-sse = np.empty((traj.shape[0], struc.get_residue_count(traj) - 1), dtype="U1")
-for idx, frame in enumerate(traj):
-    app = DsspApp(traj[idx])
-    app.start()
-    app.join()
-    sse[idx] = app.get_sse()
+sse = np.array([struc.annotate_sse(frame) for frame in traj])
 
 
 # Matplotlib needs numbers to assign colors correctly
 def sse_to_num(sse):
-    num = np.empty(sse.shape, dtype=int)
-    num[sse == "C"] = 0
-    num[sse == "E"] = 1
-    num[sse == "B"] = 2
-    num[sse == "S"] = 3
-    num[sse == "T"] = 4
-    num[sse == "H"] = 5
-    num[sse == "G"] = 6
-    num[sse == "I"] = 7
+    num = np.empty(sse.shape, dtype=float)
+    num[sse == "a"] = 0
+    num[sse == "b"] = 1
+    num[sse == "c"] = np.nan
     return num
 
 
@@ -62,14 +51,8 @@ sse = sse_to_num(sse)
 # Plotting
 # SSE colormap
 color_assign = {
-    r"coil": "white",
-    r"$\beta$-sheet": "red",
-    r"$\beta$-bridge": "black",
-    r"bend": "green",
-    r"turn": "yellow",
-    r"$\alpha$-helix": "blue",
-    r"$3_{10}$-helix": "gray",
-    r"$\pi$-helix": "purple",
+    r"$\alpha$-helix": biotite.colors["dimgreen"],
+    r"$\beta$-sheet": biotite.colors["lightorange"],
 }
 cmap = colors.ListedColormap(color_assign.values())
 
@@ -80,7 +63,7 @@ plt.ylabel("Residue")
 ticks = np.arange(0, len(traj), 10)
 plt.xticks(ticks, time[ticks].astype(int))
 
-# Custom legend below the DSSP plot
+# Custom legend below the SSE plot
 custom_lines = [Line2D([0], [0], color=cmap(i), lw=4) for i in range(len(color_assign))]
 plt.legend(
     custom_lines,

--- a/doc/examples/scripts/structure/protein/transketolase_sse.py
+++ b/doc/examples/scripts/structure/protein/transketolase_sse.py
@@ -18,7 +18,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Rectangle
 import biotite
-import biotite.application.dssp as dssp
 import biotite.database.entrez as entrez
 import biotite.database.rcsb as rcsb
 import biotite.sequence as seq
@@ -128,7 +127,7 @@ graphics.plot_feature_map(
 )
 fig.tight_layout()
 
-########################################################################
+########################################################################################
 # Now let us do some serious application.
 # We want to visualize the secondary structure of one monomer of the
 # homodimeric transketolase (PDB: 1QGD).
@@ -157,22 +156,8 @@ graphics.plot_feature_map(
 )
 fig.tight_layout()
 
-########################################################################
-# Next we calculate the secondary structure using the DSSP software
-# from structure.
-
-# Converter for the DSSP secondary structure elements
-# to the classical ones
-dssp_to_abc = {
-    "I": "c",
-    "S": "c",
-    "H": "a",
-    "E": "b",
-    "G": "c",
-    "B": "b",
-    "T": "c",
-    "C": "c",
-}
+########################################################################################
+# Next we extract the secondary structure from annotations in the structure file.
 
 
 def visualize_secondary_structure(sse, first_id):
@@ -230,21 +215,20 @@ def visualize_secondary_structure(sse, first_id):
 # Fetch and load structure
 file_name = rcsb.fetch("1QGD", "bcif", gettempdir())
 pdbx_file = pdbx.BinaryCIFFile.read(file_name)
+
+sse = pdbx.get_sse(pdbx_file)["A"]
+visualize_secondary_structure(sse, 1)
+# sphinx_gallery_thumbnail_number = 3
+
+########################################################################################
+# Last but not least we calculate the secondary structure using
+# *Biotite*'s built-in method, based on the P-SEA algorithm.
+
 array = pdbx.get_structure(pdbx_file, model=1)
 # Transketolase homodimer
 tk_dimer = array[struc.filter_amino_acids(array)]
 # Transketolase monomer
 tk_mono = tk_dimer[tk_dimer.chain_id == "A"]
-
-sse = dssp.DsspApp.annotate_sse(tk_mono)
-sse = np.array([dssp_to_abc[e] for e in sse], dtype="U1")
-visualize_secondary_structure(sse, tk_mono.res_id[0])
-# sphinx_gallery_thumbnail_number = 3
-
-########################################################################
-# Last but not least we calculate the secondary structure using
-# *Biotite*'s built-in method, based on the P-SEA algorithm.
-
 sse = struc.annotate_sse(tk_mono)
 visualize_secondary_structure(sse, tk_mono.res_id[0])
 

--- a/doc/tutorial/application/blast.rst
+++ b/doc/tutorial/application/blast.rst
@@ -10,8 +10,7 @@ the :mod:`biotite.application.blast` subpackage provides an interface to
 Let's dive directly into the code, we try to find homologous sequences to the
 miniprotein *TC5b*.
 
-..
-    Do not run the following Jupyter cells, as BLAST runs may take a long time
+.. Do not run the following Jupyter cells, as BLAST runs may take a long time
 
 .. jupyter-input::
 

--- a/doc/tutorial/application/dssp.rst
+++ b/doc/tutorial/application/dssp.rst
@@ -10,7 +10,9 @@ assign secondary structure elements based on the P-SEA algorithm, DSSP can also
 be used via the :mod:`biotite.application.dssp` subpackage.
 Let us demonstrate this on the example of the good old miniprotein *TC5b*.
 
-.. jupyter-execute::
+.. Do not run the following Jupyter cells, as DSSP is currently not in build environment
+
+.. jupyter-input::
 
     from tempfile import gettempdir
     import biotite.database.rcsb as rcsb
@@ -24,6 +26,10 @@ Let us demonstrate this on the example of the good old miniprotein *TC5b*.
     app.join()
     sse = app.get_sse()
     print("".join(sse))
+
+.. jupyter-output::
+
+    CHHHHHHHTTGGGGTCCCCC
 
 Similar to the MSA examples, :class:`DsspApp` has the convenience
 method :func:`DsspApp.annotate_sse()` as shortcut.

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ channels:
   - anaconda
   - conda-forge
   - bioconda
-  - salilab
 
 dependencies:
   - python =3.11
@@ -33,7 +32,6 @@ dependencies:
   # Interfaced software in biotite.application (can also be installed separately)
   - autodock-vina
   - clustalo
-  - dssp =3
   - mafft
   - muscle =3
   - sra-tools =3

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
   - bioconda
 
 dependencies:
-  - python =3.11
+  - python =3.12
   # Package building
   - cython >=3.0
   - pip >=10.0

--- a/src/biotite/sequence/io/genbank/file.py
+++ b/src/biotite/sequence/io/genbank/file.py
@@ -80,7 +80,7 @@ class GenBankFile(TextFile):
     >>> print(content)
     ['One line', 'A second line']
     >>> print(subfields)
-    OrderedDict([('SUBFIELD1', ['Single Line']), ('SUBFIELD2', ['Two', 'lines'])])
+    OrderedDict({'SUBFIELD1': ['Single Line'], 'SUBFIELD2': ['Two', 'lines']})
 
     Adding an additional field:
 


### PR DESCRIPTION
Due to the ongoing problems with Conda DSSP builds, this PR bypasses the usage of `DsspApp` for now:

- `dssp` is removed from Conda environment.
- DSSP tutorial is not run but displayed statically (like the *NCBI BLAST* tutorial does for the sake of run time).
- Affected examples use other means to get the secondary structure for now.