### PR TITLE
Add pepp'r to extension packages

### DIFF
--- a/doc/extensions.rst
+++ b/doc/extensions.rst
@@ -49,3 +49,10 @@ Python packages that are developed independently.
         :class-img-top: extension-logo
 
         Investigation of molecular dynamics using elastic network models
+
+    .. grid-item-card:: pepp'r
+        :link: https://peppr.vant.ai/
+        :img-top: https://raw.githubusercontent.com/aivant/peppr/refs/heads/main/docs/static/assets/general/icon.svg
+        :class-img-top: extension-logo
+
+        Evaluation of predicted poses against reference structures


### PR DESCRIPTION
This PR adds [pepp'r](https://peppr.vant.ai/) to the list of extension packages in the docs.