### PR TITLE
Fix homepage button sizes

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -75,7 +75,7 @@ Biotite documentation
 
 
 
-        .. grid:: 3
+        .. grid:: 2 3 2 3
 
             .. grid-item::
 


### PR DESCRIPTION
Currently the buttons on the homepage have weird line breaks on smaller display sizes. This PR fixes it by making them taking a greater part of the grid