### PR TITLE
Check `sym_id` for determining residue and chain starts

### DIFF
--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -33,7 +33,7 @@ from biotite.structure.segments import (
 )
 
 
-def get_chain_starts(array, add_exclusive_stop=False):
+def get_chain_starts(array, add_exclusive_stop=False, extra_categories=()):
     """
     Get the indices in an atom array, which indicates the beginning of
     a new chain.
@@ -49,6 +49,9 @@ def get_chain_starts(array, add_exclusive_stop=False):
         If true, the exclusive stop of the input atom array, i.e.
         ``array.array_length()``, is added to the returned array of
         start indices as last element.
+    extra_categories : tuple of str, optional
+        Additional annotation categories that induce the start of a new chain,
+        when their value change from one atom to the next.
 
     Returns
     -------
@@ -60,7 +63,7 @@ def get_chain_starts(array, add_exclusive_stop=False):
     This method is internally used by all other chain-related
     functions.
     """
-    categories = ["chain_id"]
+    categories = ["chain_id"] + list(extra_categories)
     if "sym_id" in array.get_annotation_categories():
         categories.append("sym_id")
     return get_segment_starts(

--- a/src/biotite/structure/chains.py
+++ b/src/biotite/structure/chains.py
@@ -67,11 +67,15 @@ def get_chain_starts(array, add_exclusive_stop=False):
     res_id_decrement = diff < 0
     # This mask is 'true' at indices where the value changes
     chain_id_changes = array.chain_id[1:] != array.chain_id[:-1]
+    if "sym_id" in array.get_annotation_categories():
+        sym_id_changes = array.sym_id[1:] != array.sym_id[:-1]
+    else:
+        sym_id_changes = np.full(array.array_length() - 1, False, dtype=bool)
 
     # Convert mask to indices
     # Add 1, to shift the indices from the end of a chain
     # to the start of a new chain
-    chain_starts = np.where(res_id_decrement | chain_id_changes)[0] + 1
+    chain_starts = np.where(res_id_decrement | chain_id_changes | sym_id_changes)[0] + 1
 
     # The first chain is not included yet -> Insert '[0]'
     if add_exclusive_stop:

--- a/src/biotite/structure/residues.py
+++ b/src/biotite/structure/residues.py
@@ -77,10 +77,18 @@ def get_residue_starts(array, add_exclusive_stop=False):
     res_id_changes = array.res_id[1:] != array.res_id[:-1]
     ins_code_changes = array.ins_code[1:] != array.ins_code[:-1]
     res_name_changes = array.res_name[1:] != array.res_name[:-1]
+    if "sym_id" in array.get_annotation_categories():
+        sym_id_changes = array.sym_id[1:] != array.sym_id[:-1]
+    else:
+        sym_id_changes = np.full(array.array_length() - 1, False, dtype=bool)
 
     # If any of these annotation arrays change, a new residue starts
     residue_change_mask = (
-        chain_id_changes | res_id_changes | ins_code_changes | res_name_changes
+        chain_id_changes
+        | res_id_changes
+        | ins_code_changes
+        | res_name_changes
+        | sym_id_changes
     )
 
     # Convert mask to indices

--- a/src/biotite/structure/residues.py
+++ b/src/biotite/structure/residues.py
@@ -32,7 +32,7 @@ from biotite.structure.segments import (
 )
 
 
-def get_residue_starts(array, add_exclusive_stop=False):
+def get_residue_starts(array, add_exclusive_stop=False, extra_categories=()):
     """
     Get indices for an atom array, each indicating the beginning of
     a residue.
@@ -48,6 +48,9 @@ def get_residue_starts(array, add_exclusive_stop=False):
         If true, the exclusive stop of the input atom array, i.e.
         ``array.array_length()``, is added to the returned array of
         start indices as last element.
+    extra_categories : tuple of str, optional
+        Additional annotation categories that induce the start of a new residue,
+        when their value change from one atom to the next.
 
     Returns
     -------
@@ -69,7 +72,7 @@ def get_residue_starts(array, add_exclusive_stop=False):
     [  0  16  35  56  75  92 116 135 157 169 176 183 197 208 219 226 250 264
      278 292 304]
     """
-    categories = ["chain_id", "res_id", "ins_code", "res_name"]
+    categories = ["chain_id", "res_id", "ins_code", "res_name"] + list(extra_categories)
     if "sym_id" in array.get_annotation_categories():
         categories.append("sym_id")
     return get_segment_starts(array, add_exclusive_stop, equal_categories=categories)

--- a/src/biotite/structure/residues.py
+++ b/src/biotite/structure/residues.py
@@ -21,11 +21,11 @@ __all__ = [
     "residue_iter",
 ]
 
-import numpy as np
 from biotite.structure.segments import (
     apply_segment_wise,
     get_segment_masks,
     get_segment_positions,
+    get_segment_starts,
     get_segment_starts_for,
     segment_iter,
     spread_segment_wise,
@@ -37,7 +37,7 @@ def get_residue_starts(array, add_exclusive_stop=False):
     Get indices for an atom array, each indicating the beginning of
     a residue.
 
-    A new residue starts, either when the chain ID, residue ID,
+    A new residue starts, either when the chain ID, sym ID, residue ID,
     insertion code or residue name changes from one to the next atom.
 
     Parameters
@@ -69,38 +69,10 @@ def get_residue_starts(array, add_exclusive_stop=False):
     [  0  16  35  56  75  92 116 135 157 169 176 183 197 208 219 226 250 264
      278 292 304]
     """
-    if array.array_length() == 0:
-        return np.array([], dtype=int)
-
-    # These mask are 'true' at indices where the value changes
-    chain_id_changes = array.chain_id[1:] != array.chain_id[:-1]
-    res_id_changes = array.res_id[1:] != array.res_id[:-1]
-    ins_code_changes = array.ins_code[1:] != array.ins_code[:-1]
-    res_name_changes = array.res_name[1:] != array.res_name[:-1]
+    categories = ["chain_id", "res_id", "ins_code", "res_name"]
     if "sym_id" in array.get_annotation_categories():
-        sym_id_changes = array.sym_id[1:] != array.sym_id[:-1]
-    else:
-        sym_id_changes = np.full(array.array_length() - 1, False, dtype=bool)
-
-    # If any of these annotation arrays change, a new residue starts
-    residue_change_mask = (
-        chain_id_changes
-        | res_id_changes
-        | ins_code_changes
-        | res_name_changes
-        | sym_id_changes
-    )
-
-    # Convert mask to indices
-    # Add 1, to shift the indices from the end of a residue
-    # to the start of a new residue
-    residue_starts = np.where(residue_change_mask)[0] + 1
-
-    # The first residue is not included yet -> Insert '[0]'
-    if add_exclusive_stop:
-        return np.concatenate(([0], residue_starts, [array.array_length()]))
-    else:
-        return np.concatenate(([0], residue_starts))
+        categories.append("sym_id")
+    return get_segment_starts(array, add_exclusive_stop, equal_categories=categories)
 
 
 def apply_residue_wise(array, data, function, axis=None):


### PR DESCRIPTION
`AtomArray` object from biological assemblies and unit cells set the `sym_id` annotation. This PR takes `sym_id` also into consideration when determining chain and residue starts. This is especially useful in the edge case, where a unit cell/assembly chain contains only a single residue/chain, as this still allows for distinguishing different molecules.