### PR TITLE
Add proper error message when interface dependency is missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ ignore = [
 "doc/conf.py" = ["E402"]
 # Due to `from .module import *` imports in `__init__.py` modules
 "__init__.py" = ["F403", "TID252"]
+# Due to package existence check before other modules are imported
+"src/biotite/interface/**/__init__.py" = ["E402"]
 # Due to pymol scripts that are evaluated in other example scripts
 "doc/examples/**/*_pymol.py" = ["F821"]
 # Due to 'Table' class used as parametrized argument in test functions

--- a/src/biotite/interface/openmm/__init__.py
+++ b/src/biotite/interface/openmm/__init__.py
@@ -12,5 +12,9 @@ structure-related objects from *OpenMM*.
 __name__ = "biotite.interface.openmm"
 __author__ = "Patrick Kunzmann"
 
+from biotite.interface.version import require_package
+
+require_package("openmm")
+
 from .state import *
 from .system import *

--- a/src/biotite/interface/pymol/__init__.py
+++ b/src/biotite/interface/pymol/__init__.py
@@ -162,6 +162,9 @@ or ``pymol_interface.cmd`` at the required places in your code.
 __name__ = "biotite.interface.pymol"
 __author__ = "Patrick Kunzmann"
 
+from biotite.interface.version import require_package
+
+require_package("pymol")
 
 from .cgo import *
 from .convert import *

--- a/src/biotite/interface/rdkit/__init__.py
+++ b/src/biotite/interface/rdkit/__init__.py
@@ -12,4 +12,8 @@ objects.
 __name__ = "biotite.interface.rdkit"
 __author__ = "Patrick Kunzmann"
 
+from biotite.interface.version import require_package
+
+require_package("rdkit")
+
 from .mol import *

--- a/src/biotite/interface/version.py
+++ b/src/biotite/interface/version.py
@@ -26,6 +26,29 @@ class VersionError(Exception):
     pass
 
 
+def require_package(package):
+    """
+    Check if the given package is installed and raise an exception if not.
+
+    Parameters
+    ----------
+    package : str
+        The name of the package to be checked.
+
+    Raises
+    ------
+    ImportError
+        If the package is not installed.
+
+    Notes
+    -----
+    It is useful to call this function in the ``__init__.py`` of each ``interface``
+    subpackage, to obtain clear error messages about missing dependencies.
+    """
+    if importlib.util.find_spec(package) is None:
+        raise ImportError(f"'{package}' is not installed")
+
+
 def requires_version(package, version_specifier):
     """
     Declare a function variant that is compatible with a specific version range of the


### PR DESCRIPTION
If *PyMOL* is not installed, the error message `cannot import name 'Atom' from 'chempy'` (#787) is shown. This can be quite confusing, as it does not directly point to the missing *PyMOL* installation.

This PR adds the `require_package()` function that outputs clear error messages for missing dependencies and uses it across all `biotite.interface` subpackages.