### PR TITLE
Remove `anaconda` channel from development environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@
 name: biotite-dev
 
 channels:
-  - anaconda
   - conda-forge
   - bioconda
 


### PR DESCRIPTION
Due to [Anaconda licensing changes](https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research) packages from Anaconda are only available without license for organizations with less than 200 members.

To avoid accidental license violations by users using the Biotite development environment (i.e. the `environment.yml`), the anaconda channel is removed from this environment. This should not be a problem, as all dependencies are also available in `conda-forge` or `bioconda`.