### PR TITLE
Remove support for Python 3.10

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
+  CIBW_BUILD: cp311-* cp312-* cp313-*
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: >
     pytest {project}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "biotite"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 description = "A comprehensive library for computational molecular biology"
 readme = "README.rst"
 authors = [{name = "The Biotite contributors"}]


### PR DESCRIPTION
Compliant with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table), this PR sunsets support for Python 3.10.