### PR TITLE
Update license metadata

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
         # MAKE SURE THIS STAYS IN SYNC WITH THE LOWER GHA cibuildwheel
-        run: pipx install cibuildwheel==2.20.0
+        run: pipx install cibuildwheel==2.23.3
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -157,7 +157,7 @@ jobs:
 
       - name: Build & (optionally) test wheels
         # MAKE SURE THIS STAYS IN SYNC WITH THE UPPER pipx call to cibuildwheel
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.23.3
         with:
           only: ${{ matrix.dist }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ requires-python = ">=3.11"
 description = "A comprehensive library for computational molecular biology"
 readme = "README.rst"
 authors = [{name = "The Biotite contributors"}]
-license = {"file" = "LICENSE.rst"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.rst"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",


### PR DESCRIPTION
The `pyproject.toml` uses a new format for specifying the license as described [here](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license).