### PR TITLE
Stricter dtype checks during BinaryCIF encoding

### DIFF
--- a/src/biotite/structure/io/pdbx/encoding.pyx
+++ b/src/biotite/structure/io/pdbx/encoding.pyx
@@ -230,6 +230,12 @@ class Encoding(_Component, metaclass=ABCMeta):
         # since the file content may be invalid/malicious.
         raise NotImplementedError()
 
+    def __str__(self):
+        # Restore original behavior, as `__str__()` implementation of `_Component`
+        # may require serialization, which is not possible for some encodings prior
+        # to the first encoding pass
+        return object.__str__(self)
+
 
 @dataclass
 class ByteArrayEncoding(Encoding):

--- a/src/biotite/structure/io/pdbx/encoding.pyx
+++ b/src/biotite/structure/io/pdbx/encoding.pyx
@@ -326,15 +326,7 @@ class FixedPointEncoding(Encoding):
 
         # Round to avoid wrong values due to floating point inaccuracies
         scaled_data = np.round(data * self.factor)
-        # Check if an integer underflow/overflow would occur during conversion
-        if (
-            np.max(scaled_data) > np.iinfo(np.int32).max or
-            np.min(scaled_data) < np.iinfo(np.int32).min
-        ):  # fmt: skip
-            raise ValueError(
-                "With the given factor some values get too large for integer encoding"
-            )
-        return scaled_data.astype(np.int32)
+        return _safe_cast(scaled_data, np.int32, allow_decimal_loss=True)
 
     def decode(self, data):
         return (data / self.factor).astype(
@@ -401,7 +393,7 @@ class IntervalQuantizationEncoding(Encoding):
             self.min, self.max, self.num_steps, dtype=data.dtype
         )
         indices = np.searchsorted(steps, data, side="left")
-        return indices.astype(np.int32, copy=False)
+        return _safe_cast(indices, np.int32)
 
     def decode(self, data):
         output = data * (self.max - self.min) / (self.num_steps - 1)
@@ -579,8 +571,14 @@ class DeltaEncoding(Encoding):
         if self.origin is None:
             self.origin = data[0]
 
+        # Differences (including `np.diff`) return an array with the same dtype as the
+        # input array
+        # As the input dtype may be unsigned, the output dtype could underflow,
+        # if the difference is negative
+        # -> cast to int64 to avoid this
+        data = data.astype(np.int64, copy=False)
         data = data - self.origin
-        return np.diff(data, prepend=0).astype(np.int32, copy=False)
+        return _safe_cast(np.diff(data, prepend=0), np.int32)
 
     def decode(self, data):
         output = np.cumsum(data, dtype=self.src_type.to_dtype())
@@ -644,7 +642,7 @@ class IntegerPackingEncoding(Encoding):
             # Only positive values -> use unsigned integers
             self.is_unsigned = data.min().item() >= 0
 
-        data = data.astype(np.int32, copy=False)
+        data = _safe_cast(data, np.int32)
         return self._encode(
             data, np.empty(0, dtype=self._determine_packed_dtype())
         )
@@ -879,7 +877,7 @@ class StringArrayEncoding(Encoding):
         else:
             check_present = True
 
-        string_order = np.argsort(self.strings).astype(np.int32)
+        string_order = _safe_cast(np.argsort(self.strings), np.int32)
         sorted_strings = self.strings[string_order]
         sorted_indices = np.searchsorted(sorted_strings, data)
         indices = string_order[sorted_indices]
@@ -1019,22 +1017,25 @@ def _snake_to_camel_case(attribute_name):
     return attribute_name[0].lower() + attribute_name[1:]
 
 
-def _safe_cast(array, dtype):
-    dtype = np.dtype(dtype)
-    if dtype == array.dtype:
+def _safe_cast(array, dtype, allow_decimal_loss=False):
+    source_dtype = array.dtype
+    target_dtype = np.dtype(dtype)
+
+    if target_dtype == source_dtype:
         return array
-    if np.issubdtype(dtype, np.integer):
-        if not np.issubdtype(array.dtype, np.integer):
-            raise ValueError("Cannot cast floating point to integer")
-        dtype_info = np.iinfo(dtype)
-        if np.any(array < dtype_info.min) or np.any(array > dtype_info.max):
-            raise ValueError("Integer values do not fit into the given dtype")
-    return array.astype(dtype)
 
+    if np.issubdtype(target_dtype, np.integer):
+        if np.issubdtype(source_dtype, np.floating):
+            if not allow_decimal_loss:
+                raise ValueError("Cannot cast floating point to integer")
+            if not np.isfinite(array).all():
+                raise ValueError("Data contains non-finite values")
+        elif not np.issubdtype(source_dtype, np.integer):
+            # Neither float, nor integer -> cannot cast
+            raise ValueError(f"Cannot cast '{source_dtype}' to integer")
+        dtype_info = np.iinfo(target_dtype)
+        # Check if an integer underflow/overflow would occur during conversion
+        if np.max(array) > dtype_info.max or np.min(array) < dtype_info.min:
+            raise ValueError("Values do not fit into the given dtype")
 
-def _get_n_decimals(value, tolerance):
-    MAX_DECIMALS = 10
-    for n in range(MAX_DECIMALS):
-        if abs(value - round(value, n)) < tolerance:
-            return n
-    return MAX_DECIMALS
+    return array.astype(target_dtype)

--- a/tests/structure/io/test_pdbx.py
+++ b/tests/structure/io/test_pdbx.py
@@ -1025,12 +1025,12 @@ def test_compress_file(path):
     assert _file_size(compressed_file) <= _file_size(orig_file)
 
 
-@pytest.mark.parametrize("value", [1e10, 1e-10])
+@pytest.mark.parametrize("value", [1e10, 1e-10, np.nan, np.inf, -np.inf])
 def test_extreme_float_compression(value):
     """
     Check if :func:`compress()` correctly falls back to direct byte encoding of floats
     in extreme cases where fixed point encoding would lead to integer
-    underflow/overflow.
+    underflow/overflow or the value could not be represented by an integer.
     """
     # Not only very small/large values, but a large difference between the values are
     # required, to make fixed point encoding fail
@@ -1043,7 +1043,7 @@ def test_extreme_float_compression(value):
     # Check that no fixed point encoding was used
     assert len(data.encoding) == 1
     assert type(data.encoding[0]) is pdbx.ByteArrayEncoding
-    assert np.all(data.array == ref_array)
+    assert data.array.tolist() == pytest.approx(ref_array.tolist(), nan_ok=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR ensures more strictly for each `pdbx.Encoding` that only compatible values can be cast into the target dtype. These checks revealed two additional issues:
- Currently non-finite values (Infinity, NaN) are not properly handled by `compress()` and thus `compress()` still converts them into integers (`0`). In this PR `compress()` does not try `FixedPointEncoding` if any value in the input array is non-finite.
- `DeltaEncoding.encode()` may encounter Integer underflows, if the input dtype is unsigned, as `np.diff()` does not return a signed dtype but keeps the input dtype instead. As `DeltaEncoding.decode()` performs the reverse operation (encountering an integer overflow) the value becomes correct again, which was confirmed by the tests. So in summary a BinaryCIF file created by `compress()`, may be corrupted (if it uses `DeltaEncoding`), if read by another software. This PR also fixes this problem.