### PR TITLE
Fix slice indices for PyMOL object selection

### DIFF
--- a/src/biotite/interface/pymol/object.py
+++ b/src/biotite/interface/pymol/object.py
@@ -388,7 +388,9 @@ class PyMOLObject:
         elif isinstance(selection, str):
             return f"%{self._name} and ({selection})"
         else:
-            sel = self.where(np.asarray(selection))
+            if not isinstance(selection, slice):
+                selection = np.asarray(selection)
+            sel = self.where(selection)
             if sel == "none" and not_none:
                 raise ValueError("Selection contains no atoms")
             return sel


### PR DESCRIPTION
Currently an exception is raised when the `selection` parameter of `PyMOLObject` method is supplied with a slice. This PR fixes this.