### PR TITLE
Reflect new representative selection behavior

### DIFF
--- a/tests/database/test_rcsb.py
+++ b/tests/database/test_rcsb.py
@@ -376,7 +376,9 @@ def test_search_grouping(grouping, resolution_threshold, return_type, ref_groups
 
     # List is not hashable
     assert set([tuple(group) for group in test_groups]) == ref_groups
-    assert set(test_representatives) == set([group[0] for group in ref_groups])
+    # The representative must appear in any of the groups
+    for representative in test_representatives:
+        assert any([representative in group for group in ref_groups])
     assert test_count == len(ref_groups)
 
 


### PR DESCRIPTION
The representative of a group result in `rcsb.search()` is not necessarily the first group member anymore as of a [recent change](https://search.rcsb.org/#changelog) in the RCSB search API. This PR reflects the new behavior in the tests.