### PR TITLE
Avoid warning in case of no contact in structure

### DIFF
--- a/src/biotite/structure/compare.py
+++ b/src/biotite/structure/compare.py
@@ -449,6 +449,8 @@ def lddt(
     # Aggregate the fractions over the desired level
     if isinstance(aggregation, str) and aggregation == "all":
         # Average over all contacts
+        if len(fraction_preserved_bins) == 0:
+            return np.float32(np.nan)
         return np.mean(fraction_preserved_bins, axis=-1)
     else:
         # A string is also a 'Sequence'

--- a/tests/interface/test_openmm.py
+++ b/tests/interface/test_openmm.py
@@ -128,8 +128,9 @@ def test_topology_consistency(test_path):
     topology = app.PDBxFile(test_path).topology
     test_atoms = openmm_interface.from_topology(topology)
 
-    # OpenMM does not parse the bond type from CIF files
+    # OpenMM does not parse bond types for all bonds when parsing CIF files
     ref_atoms.bonds.remove_bond_order()
+    test_atoms.bonds.remove_bond_order()
     # Biotite does not parse disulfide bridges
     # -> Remove them from the bonds parsed by OpenMM
     for i, j, _ in test_atoms.bonds.as_array():


### PR DESCRIPTION
Currently `lddt()` raises a warning if the atoms are within the threshold distance of each other in the reference structure. This PR fixes this.