### PR TITLE
Test fetching PDB entries with extended IDs

### DIFF
--- a/src/biotite/database/rcsb/download.py
+++ b/src/biotite/database/rcsb/download.py
@@ -155,6 +155,7 @@ def _assert_valid_file(response_text, pdb_id):
             "<title>PDB Archive over AWS</title>",
             "No fasta files were found.",
             "No valid PDB IDs were submitted.",
+            "The requested URL was incorrect, too long or otherwise malformed.",
         ]
     ):
         raise RequestError("PDB ID {:} is invalid".format(pdb_id))


### PR DESCRIPTION
This PR adds a test that checks if [extended PDB IDs](https://www.wwpdb.org/documentation/new-format-for-pdb-ids) are supported by `fetch()`.