### PR TITLE
Use LRU cache for `structure.info.residue()`

### DIFF
--- a/src/biotite/structure/info/atoms.py
+++ b/src/biotite/structure/info/atoms.py
@@ -6,6 +6,7 @@ __name__ = "biotite.structure.info"
 __author__ = "Patrick Kunzmann"
 __all__ = ["residue"]
 
+import functools
 from biotite.structure.info.ccd import get_ccd
 
 # fmt: off
@@ -75,6 +76,13 @@ def residue(res_name, allow_missing_coord=False):
      ['CB' 'HB3']
      ['OXT' 'HXT']]
     """
+    # Use a cache internally, but always return a copy,
+    # as the returned AtomArray is mutable
+    return _residue(res_name, allow_missing_coord).copy()
+
+
+@functools.lru_cache(maxsize=100)
+def _residue(res_name, allow_missing_coord=False):
     # Avoid circular import
     from biotite.structure.io.pdbx import get_component
 


### PR DESCRIPTION
This PR caches subsequent calls of `structure.info.residue()` to make a common application like [creating a chain from scratch](https://www.biotite-python.org/latest/examples/gallery/structure/protein/peptide_assembly.html) more efficient, as many calls to `pdbx.get_component()` accumulate quite some run time.

To keep the memory footprint still very low an LRU cache with maximum size 100 is used. This is enough to cache the number of different residues to build polymer chains (peptides, nucleic acids, saccharides), but will not blow up the memory requirements for use cases where large parts of the CCD are parsed.