### PR TITLE
use isinstance() to support subclassing

### DIFF
--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -1554,7 +1554,7 @@ def coord(item):
         Atom coordinates.
     """
 
-    if type(item) in (Atom, AtomArray, AtomArrayStack):
+    if isinstance(item, (Atom, _AtomArrayBase)):
         return item.coord
     elif isinstance(item, np.ndarray):
         return item.astype(np.float32, copy=False)


### PR DESCRIPTION
Hi biotite team,

Thanks for this great tool! I implemented a wrapper upon AtomArray to support some custom functions, but the current type() function doesn't support subclassing, which will cause an error. I changed it to isinstance() to handle this.

This is a minor change that improves the flexibility of the API. Let me know if you have any questions.

Best,
