### PR TITLE
Use persistent HTTP connection

### DIFF
--- a/src/biotite/database/entrez/download.py
+++ b/src/biotite/database/entrez/download.py
@@ -106,6 +106,7 @@ def fetch(
     if target_path is not None and not isdir(target_path):
         os.makedirs(target_path)
     files = []
+    session = requests.Session()
     for i, id in enumerate(uids):
         # Verbose output
         if verbose:
@@ -127,7 +128,7 @@ def fetch(
             api_key = get_api_key()
             if api_key is not None:
                 param_dict["api_key"] = api_key
-            r = requests.get(_fetch_url, params=param_dict)
+            r = session.get(_fetch_url, params=param_dict)
             check_for_errors(r)
             content = r.text
             if file is None:

--- a/src/biotite/database/pubchem/download.py
+++ b/src/biotite/database/pubchem/download.py
@@ -107,6 +107,7 @@ def fetch(
         os.makedirs(target_path)
 
     files = []
+    session = requests.Session()
     for i, cid in enumerate(cids):
         # Prevent IDs as strings, this could be a common error, as other
         # database interfaces of Biotite use string IDs
@@ -125,7 +126,7 @@ def fetch(
 
         if file is None or not isfile(file) or getsize(file) == 0 or overwrite:
             record_type = "2d" if as_structural_formula else "3d"
-            r = requests.get(
+            r = session.get(
                 _base_url + f"compound/cid/{cid}/{format.upper()}",
                 params={"record_type": record_type},
             )

--- a/src/biotite/database/rcsb/download.py
+++ b/src/biotite/database/rcsb/download.py
@@ -102,6 +102,7 @@ def fetch(
         gz_suffix = ""
 
     files = []
+    session = requests.Session()
     for i, id in enumerate(pdb_ids):
         # Verbose output
         if verbose:
@@ -116,25 +117,25 @@ def fetch(
 
         if file is None or not isfile(file) or getsize(file) == 0 or overwrite:
             if format == "pdb":
-                r = requests.get(_standard_url + id + ".pdb" + gz_suffix)
+                r = session.get(_standard_url + id + ".pdb" + gz_suffix)
                 _assert_valid_file(r, id)
                 if gzip:
                     content = r.content
                 else:
                     content = r.text
             elif format in ["cif", "mmcif", "pdbx"]:
-                r = requests.get(_standard_url + id + ".cif" + gz_suffix)
+                r = session.get(_standard_url + id + ".cif" + gz_suffix)
                 _assert_valid_file(r, id)
                 if gzip:
                     content = r.content
                 else:
                     content = r.text
             elif format in ["bcif"]:
-                r = requests.get(_bcif_url + id + ".bcif" + gz_suffix)
+                r = session.get(_bcif_url + id + ".bcif" + gz_suffix)
                 _assert_valid_file(r, id)
                 content = r.content
             elif format == "fasta":
-                r = requests.get(_fasta_url + id)
+                r = session.get(_fasta_url + id)
                 _assert_valid_file(r, id)
                 content = r.text
             else:

--- a/src/biotite/database/uniprot/download.py
+++ b/src/biotite/database/uniprot/download.py
@@ -93,6 +93,7 @@ def fetch(ids, format, target_path=None, overwrite=False, verbose=False):
     if target_path is not None and not isdir(target_path):
         os.makedirs(target_path)
     files = []
+    session = requests.Session()
     for i, id in enumerate(ids):
         db_name = _get_database_name(id)
         # Verbose output
@@ -106,7 +107,7 @@ def fetch(ids, format, target_path=None, overwrite=False, verbose=False):
             file = None
         if file is None or not isfile(file) or getsize(file) == 0 or overwrite:
             if format in ["fasta", "gff", "txt", "xml", "rdf", "tab"]:
-                r = requests.get(_fetch_url + db_name + "/" + id + "." + format)
+                r = session.get(_fetch_url + db_name + "/" + id + "." + format)
                 content = r.text
                 assert_valid_response(r)
             else:

--- a/tests/database/test_afdb.py
+++ b/tests/database/test_afdb.py
@@ -98,7 +98,7 @@ def test_fetch_invalid(monkeypatch, format, invalid_id, bypass_metadata):
         monkeypatch.setattr(
             module,
             "_get_file_url",
-            lambda id, f: f"https://alphafold.ebi.ac.uk/files/AF-{id}-F1-model_v4.{f}",
+            lambda session, id, format: f"{AFDB_URL}files/AF-{id}-F1-model_v4.{format}",
         )
     with pytest.raises((RequestError, ValueError)):
         afdb.fetch(invalid_id, format)


### PR DESCRIPTION
This PR introduces a persistent HTTP connection to speed up download of multiple files in all `biotite.database` subpackages.