### PR TITLE
Add `pocketeer` to list of extensions

### DIFF
--- a/doc/extensions.rst
+++ b/doc/extensions.rst
@@ -61,7 +61,7 @@ Python packages that are developed independently.
         Evaluation of predicted poses against reference structures
 
     .. grid-item-card:: Pocketeer
-        :link: https://github.com/cch1999/pocketeer
+        :link: https://pocketeer.readthedocs.io/
         :img-top: https://raw.githubusercontent.com/cch1999/pocketeer/main/docs/assets/logo_nameless.png
         :class-img-top: extension-logo
 


### PR DESCRIPTION
Add `pocketeer` package to the list of extensions in the `biotite` docs:

https://www.biotite-python.org/latest/extensions.html 