### PR TITLE
Hotfix: failing gallery examples

### DIFF
--- a/doc/examples/scripts/sequence/annotation/plasmid_map.py
+++ b/doc/examples/scripts/sequence/annotation/plasmid_map.py
@@ -25,7 +25,7 @@ import biotite.sequence.graphics as graphics
 import biotite.sequence.io.genbank as gb
 
 PLASMID_URL = (
-    "https://media.addgene.org/snapgene-media/v3.0.0/sequences/466943/"
+    "https://www.addgene.org/browse/sequences/466943/"
     "17c6ce2c-cf6d-46e8-a4c9-58cd4a4760b6/addgene-plasmid-26092-sequence-466943.gbk"
 )
 

--- a/doc/examples/scripts/structure/alphabet/structure_search.py
+++ b/doc/examples/scripts/structure/alphabet/structure_search.py
@@ -198,8 +198,8 @@ for pdb_id in database_pdb_ids:
             continue
         # Since we input a single chain, we know only one sequence is created
         structural_sequence = strucalph.to_3di(chain)[0][0]
-        if len(structural_sequence) < K:
-            # Cannot index a sequence later, if it is shorter than the k-mer length
+        if len(structural_sequence) < len(SPACED_SEED):
+            # Cannot index a sequence later, if it is shorter than the k-mer span
             continue
         db_ids.append((pdb_id, representative_chain_id))
         db_sequences.append(structural_sequence)


### PR DESCRIPTION
The Biotite `1.6.0` release [currently fails](https://github.com/biotite-dev/biotite/actions/runs/21115212262/job/60791634510) due to two examples. This PR fixes these two examples.