### PR TITLE
Add more benchmarks for modules to be replaced by Rust code

### DIFF
--- a/benchmarks/structure/benchmark_alphabet.py
+++ b/benchmarks/structure/benchmark_alphabet.py
@@ -7,7 +7,7 @@ from tests.util import data_dir
 PDB_ID = "1aki"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def atoms():
     pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / f"{PDB_ID}.bcif")
     return pdbx.get_structure(pdbx_file, model=1, include_bonds=True)

--- a/benchmarks/structure/benchmark_bonds.py
+++ b/benchmarks/structure/benchmark_bonds.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+import pytest
+import biotite.structure as struc
+import biotite.structure.info as info
+import biotite.structure.io.pdbx as pdbx
+from tests.util import data_dir
+
+PDB_ID = "1aki"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def load_ccd():
+    """
+    Ensure that the CCD is already loaded to avoid biasing tests with its loading time.
+    """
+    info.get_ccd()
+
+
+@pytest.fixture(scope="module")
+def atoms():
+    pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / f"{PDB_ID}.bcif")
+    return pdbx.get_structure(pdbx_file, model=1, include_bonds=True)
+
+
+@pytest.fixture(scope="module")
+def bond_array(atoms):
+    return atoms.bonds.as_array()
+
+
+@pytest.mark.benchmark
+def benchmark_bond_list_creation(atoms, bond_array):
+    """
+    Create a `BondList` from an array of bonds, which involves sorting and deduplication.
+    """
+    struc.BondList(atoms.array_length(), bond_array)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(
+    "method",
+    [
+        struc.BondList.as_set,
+        struc.BondList.as_graph,
+        struc.BondList.as_array,
+        struc.BondList.get_all_bonds,
+        struc.BondList.adjacency_matrix,
+        struc.BondList.bond_type_matrix,
+    ],
+    ids=lambda x: x.__name__,
+)
+def benchmark_conversion(atoms, method):
+    """
+    Convert the `BondList` to a different representation.
+    """
+    method(atoms.bonds)
+
+
+@pytest.mark.benchmark
+def benchmark_get_bonds(atoms):
+    """
+    Get the bonds for each atom index.
+    """
+    for i in range(atoms.array_length()):
+        atoms.bonds.get_bonds(i)
+
+
+@pytest.mark.benchmark
+def benchmark_get_all_bonds(atoms):
+    """
+    Get the bonds for all atom indices.
+    """
+    atoms.bonds.get_all_bonds()
+
+
+@pytest.mark.benchmark
+def benchmark_concatenate(atoms):
+    """
+    Concatenate two `BondList` objects.
+    """
+    atoms.bonds.concatenate([atoms.bonds, atoms.bonds])
+
+
+@pytest.mark.parametrize(
+    "connect_fn", [struc.connect_via_distances, struc.connect_via_residue_names]
+)
+@pytest.mark.benchmark
+def benchmark_connect(atoms, connect_fn):
+    """
+    Find bonds between atoms using the specified method.
+    """
+    connect_fn(atoms)
+
+
+@pytest.mark.benchmark
+def benchmark_find_connected(atoms):
+    """
+    Find all connected atoms for a given atom index.
+    """
+    struc.find_connected(atoms.bonds, 0)
+
+
+@pytest.mark.benchmark
+def benchmark_find_rotatable_bonds(atoms):
+    """
+    Find all rotatable bonds in a `BondList`.
+    """
+    struc.find_rotatable_bonds(atoms.bonds)

--- a/benchmarks/structure/benchmark_celllist.py
+++ b/benchmarks/structure/benchmark_celllist.py
@@ -5,15 +5,28 @@ import biotite.structure.io.pdbx as pdbx
 from tests.util import data_dir
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def atoms():
     pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / "1gya.bcif")
     return pdbx.get_structure(pdbx_file, model=1)
 
 
-def benchmark_cell_list(atoms):
+@pytest.fixture(scope="module")
+def cell_list(atoms):
+    return struc.CellList(atoms, 5.0)
+
+
+@pytest.mark.benchmark
+def benchmark_cell_list_creation(atoms):
     """
-    Find all contacts in a structure using a cell list.
+    Create a cell list for a structure.
     """
-    cell_list = struc.CellList(atoms, 5.0)
+    struc.CellList(atoms, 5.0)
+
+
+@pytest.mark.benchmark
+def benchmark_cell_list_compute_contacts(cell_list, atoms):
+    """
+    Find all contacts in a structure using an existing cell list.
+    """
     cell_list.get_atoms(atoms.coord, 5.0)

--- a/benchmarks/structure/benchmark_charges.py
+++ b/benchmarks/structure/benchmark_charges.py
@@ -1,0 +1,16 @@
+import pytest
+import biotite.structure as struc
+import biotite.structure.info as info
+
+
+@pytest.fixture(scope="module")
+def atoms():
+    return info.residue("PNN")
+
+
+@pytest.mark.benchmark
+def benchmark_partial_charges(atoms):
+    """
+    Compute the partial charges of each atom in a structure.
+    """
+    struc.partial_charges(atoms)

--- a/benchmarks/structure/benchmark_compare.py
+++ b/benchmarks/structure/benchmark_compare.py
@@ -7,7 +7,7 @@ from biotite.structure.filter import filter_heavy
 from tests.util import data_dir
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def atoms():
     pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / "1gya.bcif")
     atoms = pdbx.get_structure(pdbx_file)

--- a/benchmarks/structure/benchmark_pdb.py
+++ b/benchmarks/structure/benchmark_pdb.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pytest
+import biotite.structure.info as info
 import biotite.structure.io.pdb as pdb
-from biotite.structure.info.ccd import get_ccd
 from tests.util import data_dir
 
 
@@ -10,22 +10,27 @@ def load_ccd():
     """
     Ensure that the CCD is already loaded to avoid biasing tests with its loading time.
     """
-    get_ccd()
+    info.get_ccd()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def pdb_file_path():
     return Path(data_dir("structure")) / "1aki.pdb"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def empty_pdb_file():
     return pdb.PDBFile()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def pdb_file(pdb_file_path):
     return pdb.PDBFile.read(pdb_file_path)
+
+
+@pytest.fixture(scope="module")
+def atoms(pdb_file):
+    return pdb_file.get_structure(model=1, include_bonds=True)
 
 
 @pytest.mark.benchmark
@@ -51,11 +56,6 @@ def benchmark_get_structure_with_bonds(pdb_file):
 @pytest.mark.benchmark
 def benchmark_get_remark(pdb_file):
     pdb_file.get_remark(350)
-
-
-@pytest.fixture
-def atoms(pdb_file):
-    return pdb_file.get_structure(model=1, include_bonds=True)
 
 
 @pytest.mark.benchmark

--- a/benchmarks/structure/benchmark_sasa.py
+++ b/benchmarks/structure/benchmark_sasa.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import pytest
+import biotite.structure as struc
+import biotite.structure.io.pdbx as pdbx
+from tests.util import data_dir
+
+
+@pytest.fixture(scope="module")
+def atoms():
+    """
+    A structure that includes hydrogen atoms.
+    """
+    pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / "1gya.bcif")
+    return pdbx.get_structure(pdbx_file, model=1, include_bonds=True)
+
+
+@pytest.mark.benchmark
+def benchmark_sasa(atoms):
+    """
+    Compute the SASA of each atom in a structure.
+    """
+    struc.sasa(atoms, vdw_radii="Single")

--- a/benchmarks/structure/benchmark_superimpose.py
+++ b/benchmarks/structure/benchmark_superimpose.py
@@ -5,7 +5,7 @@ import biotite.structure.io.pdbx as pdbx
 from tests.util import data_dir
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def atoms():
     pdbx_file = pdbx.BinaryCIFFile.read(Path(data_dir("structure")) / "1gya.bcif")
     return pdbx.get_structure(pdbx_file)

--- a/src/biotite/structure/bonds.pyx
+++ b/src/biotite/structure/bonds.pyx
@@ -1875,7 +1875,7 @@ def find_connected(bond_list, uint32 root, bint as_mask=False):
     """
     find_connected(bond_list, root, as_mask=False)
 
-    Get indices to all atoms that are directly or inderectly connected
+    Get indices to all atoms that are directly or indirectly connected
     to the root atom indicated by the given index.
 
     An atom is *connected* to the `root` atom, if that atom is reachable


### PR DESCRIPTION
In order to see if performance improves or degrades during the migration to Rust (#688), this PR adds benchmarks for modules that are migrated soon.