### PR TITLE
Make order of `BondType` enum member deterministic

### DIFF
--- a/src/biotite/structure/bonds.py
+++ b/src/biotite/structure/bonds.py
@@ -47,7 +47,7 @@ def _without_aromaticity(self):
 # Create BondType IntEnum dynamically from Rust enum members
 BondType = IntEnum(
     "BondType",
-    {name: value for name, value in bond_type_members().items()},
+    bond_type_members(),
     module=__name__,
 )
 BondType.__doc__ = """

--- a/src/rust/structure/bonds.rs
+++ b/src/rust/structure/bonds.rs
@@ -4,7 +4,7 @@ use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::{PyModule, PySet, PyTuple};
 use smallvec::SmallVec;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::convert::TryFrom;
 
 const TYPICAL_MAX_BONDS_PER_ATOM: usize = 4;
@@ -37,29 +37,29 @@ impl BondType {
     }
 }
 
+/// Return the members of the :class:`BondType` enum as key-value pairs.
+///
+/// Returns
+/// -------
+/// members : list of tuples
+///     The members of the :class:`BondType` enum as key-value pairs.
 #[pyfunction]
-pub fn bond_type_members() -> HashMap<String, u8> {
-    let mut map = HashMap::new();
-    map.insert("ANY".to_string(), BondType::Any as u8);
-    map.insert("SINGLE".to_string(), BondType::Single as u8);
-    map.insert("DOUBLE".to_string(), BondType::Double as u8);
-    map.insert("TRIPLE".to_string(), BondType::Triple as u8);
-    map.insert("QUADRUPLE".to_string(), BondType::Quadruple as u8);
-    map.insert(
-        "AROMATIC_SINGLE".to_string(),
-        BondType::AromaticSingle as u8,
-    );
-    map.insert(
-        "AROMATIC_DOUBLE".to_string(),
-        BondType::AromaticDouble as u8,
-    );
-    map.insert(
-        "AROMATIC_TRIPLE".to_string(),
-        BondType::AromaticTriple as u8,
-    );
-    map.insert("COORDINATION".to_string(), BondType::Coordination as u8);
-    map.insert("AROMATIC".to_string(), BondType::Aromatic as u8);
-    map
+pub fn bond_type_members() -> Vec<(String, u8)> {
+    [
+        ("ANY", BondType::Any),
+        ("SINGLE", BondType::Single),
+        ("DOUBLE", BondType::Double),
+        ("TRIPLE", BondType::Triple),
+        ("QUADRUPLE", BondType::Quadruple),
+        ("AROMATIC_SINGLE", BondType::AromaticSingle),
+        ("AROMATIC_DOUBLE", BondType::AromaticDouble),
+        ("AROMATIC_TRIPLE", BondType::AromaticTriple),
+        ("COORDINATION", BondType::Coordination),
+        ("AROMATIC", BondType::Aromatic),
+    ]
+    .iter()
+    .map(|(name, member)| (name.to_string(), *member as u8))
+    .collect()
 }
 
 impl TryFrom<u8> for BondType {

--- a/tests/interface/test_rdkit.py
+++ b/tests/interface/test_rdkit.py
@@ -164,7 +164,7 @@ def test_kekulization():
         or [
             struc.BondType.AROMATIC_SINGLE
             if btype == struc.BondType.AROMATIC_DOUBLE
-            else struc.BondType.AROMATIC_SINGLE
+            else struc.BondType.AROMATIC_DOUBLE
             for btype in test_bond_types
         ]
         == ref_bond_types.tolist()

--- a/tests/structure/test_bonds.py
+++ b/tests/structure/test_bonds.py
@@ -512,3 +512,11 @@ def test_pickle(bond_list):
     """
     restored = pickle.loads(pickle.dumps(bond_list))
     assert restored == bond_list
+
+
+def test_bond_type_order():
+    """
+    Check that :class:`BondType` members are ordered by their values.
+    """
+    values = [member.value for member in struc.BondType]
+    assert values == sorted(values)


### PR DESCRIPTION
Previously a `HashMap` was used to map the Rust `BondType` enum into a Python `IntEnum`. However the iteration order in a `HashMap` is not deterministic, and thus the member order in the Python `BondType` is neither. This PR fixes the issue.