### PR TITLE
Fix failing `test_kekulization` test after RDKit update

### DIFF
--- a/tests/interface/test_rdkit.py
+++ b/tests/interface/test_rdkit.py
@@ -164,7 +164,7 @@ def test_kekulization():
         or [
             struc.BondType.AROMATIC_SINGLE
             if btype == struc.BondType.AROMATIC_DOUBLE
-            else struc.BondType.AROMATIC_SINGLE
+            else struc.BondType.AROMATIC_DOUBLE
             for btype in test_bond_types
         ]
         == ref_bond_types.tolist()


### PR DESCRIPTION
The problem as a typo in the test itself.