### PR TITLE
Fix missing stop entry for empty atom arrays

### DIFF
--- a/src/biotite/structure/segments.py
+++ b/src/biotite/structure/segments.py
@@ -50,7 +50,10 @@ def get_segment_starts(
         The start indices of segments in `array`.
     """
     if array.array_length() == 0:
-        return np.array([], dtype=int)
+        if add_exclusive_stop:
+            return np.array([0], dtype=int)
+        else:
+            return np.array([], dtype=int)
 
     segment_start_mask = np.zeros(array.array_length() - 1, dtype=bool)
     for annot_name in continuous_categories:


### PR DESCRIPTION
If `get_residue_start(add_exclusive_stop=True)`/`get_chain_starts(add_exclusive_stop=True)` is called on an empty structure, the exclusive stop at `[0]` is missing. This PR fixes this