### PR TITLE
Add optional `entity_id` annotation

### DIFF
--- a/src/biotite/structure/__init__.py
+++ b/src/biotite/structure/__init__.py
@@ -65,6 +65,7 @@ b_factor   float        0.9, 12.3, ...      Temperature factor
 occupancy  float        .1, .3, .9, ...     Occupancy
 charge     int          -2,-1,0,1,2, ...    Electric charge of the atom
 sym_id     string       1,2,3, ...          Symmetry ID for assemblies/symmetry mates
+entity_id  string       '1','2', ...        Entity ID grouping equivalent chains
 =========  ===========  =================   =========================================
 
 For each type, the attributes can be accessed directly.

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -293,7 +293,8 @@ def get_structure(
         subcategory name.
         The array type is always `str`.
         An exception are the special field identifiers:
-        ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and ``'charge'``.
+        ``'atom_id'``, ``'b_factor'``, ``'occupancy'``, ``'charge'`` and
+        ``'entity_id'``.
         These will convert the fitting subcategory into an
         annotation array with reasonable type.
     use_author_fields : bool, optional
@@ -593,6 +594,21 @@ def _fill_annotations(array, atom_site, extra_fields, use_author_fields):
             )
             array.set_annotation("charge", np.zeros(array.array_length(), dtype=int))
         extra_fields.remove("charge")
+    if "entity_id" in extra_fields:
+        if "label_entity_id" in atom_site:
+            array.set_annotation(
+                "entity_id", atom_site["label_entity_id"].as_array(str)
+            )
+        else:
+            warnings.warn(
+                "Missing 'label_entity_id' in 'atom_site' category. "
+                "'entity_id' will be set to empty strings.",
+                UserWarning,
+            )
+            array.set_annotation(
+                "entity_id", np.full(array.array_length(), "", dtype="U1")
+            )
+        extra_fields.remove("entity_id")
 
     # Handle all remaining custom fields
     for field in extra_fields:
@@ -891,7 +907,7 @@ def set_structure(
 
     This will save the coordinates, the mandatory annotation categories
     and the optional annotation categories
-    ``b_factor``, ``occupancy`` and ``charge``.
+    ``b_factor``, ``occupancy``, ``charge`` and ``entity_id``.
     If the atom array (stack) contains the annotation ``'atom_id'``,
     these values will be used for atom numbering instead of continuous
     numbering.
@@ -960,11 +976,6 @@ def set_structure(
     )
     atom_site["label_comp_id"] = np.copy(array.res_name)
     atom_site["label_asym_id"] = np.copy(array.chain_id)
-    atom_site["label_entity_id"] = (
-        np.copy(array.label_entity_id)
-        if "label_entity_id" in array.get_annotation_categories()
-        else _determine_entity_id(array.chain_id)
-    )
     atom_site["label_seq_id"] = np.copy(array.res_id)
     atom_site["pdbx_PDB_ins_code"] = Column(
         np.copy(array.ins_code),
@@ -985,6 +996,16 @@ def set_structure(
             np.array([f"{c:+d}" if c != 0 else "?" for c in array.charge]),
             np.where(array.charge == 0, MaskValue.MISSING, MaskValue.PRESENT),
         )
+    if "entity_id" in annot_categories:
+        atom_site["label_entity_id"] = np.copy(array.entity_id)
+    elif "label_entity_id" in annot_categories:
+        warnings.warn(
+            "The 'label_entity_id' annotation is deprecated, use 'entity_id' instead",
+            DeprecationWarning,
+        )
+        atom_site["label_entity_id"] = np.copy(array.label_entity_id)
+    else:
+        atom_site["label_entity_id"] = _determine_entity_id(array.chain_id)
 
     # Handle all remaining custom fields
     if len(extra_fields) > 0:
@@ -1001,6 +1022,7 @@ def set_structure(
             "b_factor",
             "occupancy",
             "charge",
+            "entity_id",
         ]
         _reserved_annotation_names = list(atom_site.keys()) + _standard_annotations
 
@@ -1674,7 +1696,8 @@ def get_assembly(
         subcategory name.
         The array type is always `str`.
         An exception are the special field identifiers:
-        ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and ``'charge'``.
+        ``'atom_id'``, ``'b_factor'``, ``'occupancy'``, ``'charge'`` and
+        ``'entity_id'``.
         These will convert the fitting subcategory into an
         annotation array with reasonable type.
     use_author_fields : bool, optional
@@ -1957,7 +1980,8 @@ def get_unit_cell(
         subcategory name.
         The array type is always `str`.
         An exception are the special field identifiers:
-        ``'atom_id'``, ``'b_factor'``, ``'occupancy'`` and ``'charge'``.
+        ``'atom_id'``, ``'b_factor'``, ``'occupancy'``, ``'charge'`` and
+        ``'entity_id'``.
         These will convert the fitting subcategory into an
         annotation array with reasonable type.
     use_author_fields : bool, optional

--- a/tests/structure/io/test_pdbx.py
+++ b/tests/structure/io/test_pdbx.py
@@ -286,6 +286,8 @@ def test_bond_sparsity():
 
 @pytest.mark.parametrize("format", ["cif", "bcif"])
 def test_extra_fields(tmpdir, format):
+    EXTRA_FIELDS = ["atom_id", "b_factor", "occupancy", "charge", "entity_id"]
+
     path = join(data_dir("structure"), f"1l2y.{format}")
     if format == "cif":
         File = pdbx.CIFFile
@@ -293,9 +295,7 @@ def test_extra_fields(tmpdir, format):
         File = pdbx.BinaryCIFFile
 
     pdbx_file = File.read(path)
-    ref_atoms = pdbx.get_structure(
-        pdbx_file, extra_fields=["atom_id", "b_factor", "occupancy", "charge"]
-    )
+    ref_atoms = pdbx.get_structure(pdbx_file, extra_fields=EXTRA_FIELDS)
 
     pdbx_file = File()
     pdbx.set_structure(pdbx_file, ref_atoms, data_block="test")
@@ -303,15 +303,14 @@ def test_extra_fields(tmpdir, format):
     pdbx_file.write(file_path)
 
     pdbx_file = File.read(path)
-    test_atoms = pdbx.get_structure(
-        pdbx_file, extra_fields=["atom_id", "b_factor", "occupancy", "charge"]
-    )
+    test_atoms = pdbx.get_structure(pdbx_file, extra_fields=EXTRA_FIELDS)
 
     assert test_atoms.ins_code.tolist() == ref_atoms.ins_code.tolist()
     assert test_atoms.atom_id.tolist() == ref_atoms.atom_id.tolist()
     assert test_atoms.b_factor.tolist() == approx(ref_atoms.b_factor.tolist())
     assert test_atoms.occupancy.tolist() == approx(ref_atoms.occupancy.tolist())
     assert test_atoms.charge.tolist() == ref_atoms.charge.tolist()
+    assert test_atoms.entity_id.tolist() == ref_atoms.entity_id.tolist()
     assert test_atoms == ref_atoms
 
 

--- a/tests/structure/test_sequence.py
+++ b/tests/structure/test_sequence.py
@@ -28,11 +28,11 @@ def test_pdbx_sequence_consistency(path):
     ref_sequences = pdbx.get_sequence(pdbx_file)
 
     atoms = pdbx.get_structure(
-        pdbx_file, use_author_fields=False, model=1, extra_fields=["label_entity_id"]
+        pdbx_file, use_author_fields=False, model=1, extra_fields=["entity_id"]
     )
     # Remove non-polymer chains
     polymer_entity_ids = pdbx_file.block["entity_poly"]["entity_id"].as_array(str)
-    atoms = atoms[np.isin(atoms.label_entity_id, polymer_entity_ids)]
+    atoms = atoms[np.isin(atoms.entity_id, polymer_entity_ids)]
     test_sequences, _ = struc.to_sequence(atoms, allow_hetero=True)
 
     # Matching against the PDBx file is not trivial


### PR DESCRIPTION
As discussed in https://github.com/biotite-dev/biotite/pull/732#issuecomment-2573051148, this PR adds `entity_id` as optional `AtomArray` annotation that mirrors the `atom_site.label_entity_id`.