### PR TITLE
Note limited meaning of box in assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ biotite.egg-info
 *.code-workspace
 .vscode/*
 
+# Ignore Zed project files
+.zed/*
+
 # Ignore hidden OS related files
 *.fuse_hidden*
 .DS_Store

--- a/src/biotite/structure/io/pdb/convert.py
+++ b/src/biotite/structure/io/pdb/convert.py
@@ -223,6 +223,11 @@ def get_assembly(
         Contains the `sym_id` annotation, which enumerates the copies of the asymmetric
         unit in the assembly.
 
+    Notes
+    -----
+    The ``box`` attribute of the :class:`AtomArray`/:class:`AtomArrayStack` returned by
+    this function has limited meaning, as the assembly is not tied to the unit cell.
+
     Examples
     --------
 

--- a/src/biotite/structure/io/pdb/file.py
+++ b/src/biotite/structure/io/pdb/file.py
@@ -869,6 +869,11 @@ class PDBFile(TextFile):
             Contains the `sym_id` annotation, which enumerates the copies of the
             asymmetric unit in the assembly.
 
+        Notes
+        -----
+        The ``box`` attribute of the :class:`AtomArray`/:class:`AtomArrayStack` returned by
+        this function has limited meaning, as the assembly is not tied to the unit cell.
+
         Examples
         --------
 

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -1706,6 +1706,11 @@ def get_assembly(
         Contains the `sym_id` annotation, which enumerates the copies of the asymmetric
         unit in the assembly.
 
+    Notes
+    -----
+    The ``box`` attribute of the :class:`AtomArray`/:class:`AtomArrayStack` returned by
+    this function has limited meaning, as the assembly is not tied to the unit cell.
+
     Examples
     --------
 


### PR DESCRIPTION
Notes that the `Box` attribute of an `AtomArray` has limited meaning in `get_assembly()` as discussed in https://github.com/biotite-dev/biotite/issues/888.