### PR TITLE
Perf: align_multiple speedup from using typed memoryviews

### DIFF
--- a/src/biotite/sequence/align/multiple.pyx
+++ b/src/biotite/sequence/align/multiple.pyx
@@ -373,8 +373,8 @@ def _get_distance_matrix(CodeType[:] _T, sequences, matrix,
             for code1 in range(alphabet_size):
                 for code2 in range(alphabet_size):
                     score_rand += score_matrix[code1,code2] \
-                                  * code_count[i,code1] \
-                                  * code_count[j,code2]
+                                  * code_count_v[i,code1] \
+                                  * code_count_v[j,code2]
             score_rand /= alignments[i,j].trace.shape[0]
             gap_open_count, gap_ext_count = _count_gaps(
                 alignments[i,j].trace.astype(np.int64, copy=False),


### PR DESCRIPTION
Very small change, decent performance impact depending on problem dimensions. [Typed memoryviews](https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html) already existed for `code_count`; we just weren't using them. Switching lets the indexing run at C speed.

Let's say the length of the alphabet is `A`, and the number of sequences is `N`, and the sequence length is `L`: this indexing was running `O(N^2 * A^2)` times. So for small `L` but large `A` and `N` the speedup is quite significant. For large `L` (e.g. cas9, which is what the benchmark uses here https://github.com/biotite-dev/biotite/blob/1fa1b705b3437adba50db8e99713052d69a0b1a0/benchmarks/sequence/align/benchmark_multiple.py#L9), other steps of `align_multiple` dominate, so the wallclock improvement isn't so great.

I had claude run through a number of realistic-looking examples on a `c4-standard-8` gcloud vm, this is what it came up with, should give you a sense of how things scale:

```
┌───────────────┬─────┬──────┬──────────┬─────────┬─────────┐
│    dataset    │  n  │ Lmed │  before  │  after  │ speedup │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ kunitz (BPTI) │ 99  │ 53   │ 3087 ms  │ 195 ms  │ 15.9×   │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ ig_iset       │ 45  │ 90   │ 690 ms   │ 100 ms  │ 6.9×    │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ globin_seed   │ 73  │ 114  │ 1979 ms  │ 398 ms  │ 5.0×    │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ pkinase       │ 37  │ 263  │ 915 ms   │ 512 ms  │ 1.8×    │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ aldh          │ 84  │ 462  │ 9421 ms  │ 7301 ms │ 1.3×    │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ cas9          │ 10  │ 1227 │ 805 ms   │ 770 ms  │ 1.05×   │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ globin N=25   │ 25  │ 146  │ 246 ms   │ 69 ms   │ 3.6×    │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ globin N=50   │ 50  │ 146  │ 1002 ms  │ 271 ms  │ 3.7×    │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ globin N=100  │ 100 │ 146  │ 3999 ms  │ 1071 ms │ 3.7×    │
├───────────────┼─────┼──────┼──────────┼─────────┼─────────┤
│ globin N=200  │ 200 │ 146  │ 16092 ms │ 4209 ms │ 3.8×    │
└───────────────┴─────┴──────┴──────────┴─────────┴─────────┘
```

So as for "how much faster," the answer is "it depends," but I think in any case this is the right change to make (and if I had to guess is what was intended from the beginning).