### PR TITLE
Set nonzero vina seed for determinism

### DIFF
--- a/doc/examples/scripts/structure/modeling/docking.py
+++ b/doc/examples/scripts/structure/modeling/docking.py
@@ -65,7 +65,8 @@ ligand = info.residue("BTN")
 # of the original ligand position
 app = autodock.VinaApp(ligand, receptor, ref_ligand_center, [20, 20, 20])
 # For reproducibility
-app.set_seed(0)
+# (Vina interprets seed 0 as a request for a random seed, so use a non-zero one)
+app.set_seed(42)
 app.set_cpu(1)
 # This is the maximum number:
 # Vina may find less interesting binding modes

--- a/tests/application/test_autodock.py
+++ b/tests/application/test_autodock.py
@@ -49,7 +49,9 @@ def test_docking(flexible):
         [20, 20, 20],
         flexible=flexible_mask,
     )
-    app.set_seed(0)
+    # A non-zero seed is required: Vina interprets seed 0 as a request for
+    # a random seed, which would make this test non-deterministic
+    app.set_seed(42)
     # Single-threaded execution is required for fully reproducible
     # results — even with a fixed seed, parallel Vina is not deterministic
     app.set_cpu(1)


### PR DESCRIPTION
Should fix this failing test:

```
=========================== short test summary info ============================
FAILED tests/application/test_autodock.py::test_docking[True] - assert np.float32(2.6669219) < 2.0
 +  where np.float32(2.6669219) = <function max at 0x7feb411b0f70>(array([0., 0., 0., ..., 0., 0., 0.], shape=(1776,), dtype=float32))
 +    where <function max at 0x7feb411b0f70> = np.max
 +    and   array([0., 0., 0., ..., 0., 0., 0.], shape=(1776,), dtype=float32) = <function distance at 0x7feb189d28e0>(array([[38.607, 14.202, 18.949],\n       [39.073, 14.187, 17.510],\n       [38.898, 15.623, 16.986],\n       ...,\n       ...49, 23.656,  8.504],\n       [49.002, 21.454,  6.825],\n       [50.497, 22.367,  7.110]], shape=(1776, 3), dtype=float32), array([\n	Atom(np.array([ 31.137,  21.711, -13.344], dtype=float32), chain_id="B", res_id=84, ins_code="", res_name="ARG", hetero=False, atom_name="CD", element="C", charge=0),\n	...,\n]))
 +      where <function distance at 0x7feb189d28e0> = struc.distance
= 1 failed, 943 passed, 7 skipped, 4 xpassed, 14 warnings in 157.23s (0:02:37) =
```

Reason for this is pretty wild, apparently Vina interprets `0` as "please give me a random seed"

https://github.com/ccsb-scripps/AutoDock-Vina/blob/3c65c0b3e6c2c1d183f6a175ecb65e3c5ba91645/src/lib/vina.cpp#L56