### PR TITLE
Remove forward references by using PEP 649 deferred evaluation

### DIFF
--- a/src/biotite/database/entrez/query.py
+++ b/src/biotite/database/entrez/query.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.database.entrez"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Query", "SimpleQuery", "CompositeQuery", "search"]
@@ -31,17 +33,17 @@ class Query(metaclass=abc.ABCMeta):
     def __str__(self) -> str:
         pass
 
-    def __or__(self, operand: "Query | str") -> "CompositeQuery":
+    def __or__(self, operand: Query | str) -> CompositeQuery:
         if not isinstance(operand, Query):
             operand = SimpleQuery(operand)
         return CompositeQuery("OR", self, operand)
 
-    def __and__(self, operand: "Query | str") -> "CompositeQuery":
+    def __and__(self, operand: Query | str) -> CompositeQuery:
         if not isinstance(operand, Query):
             operand = SimpleQuery(operand)
         return CompositeQuery("AND", self, operand)
 
-    def __xor__(self, operand: "Query | str") -> "CompositeQuery":
+    def __xor__(self, operand: Query | str) -> CompositeQuery:
         if not isinstance(operand, Query):
             operand = SimpleQuery(operand)
         return CompositeQuery("NOT", self, operand)

--- a/src/biotite/database/pubchem/query.py
+++ b/src/biotite/database/pubchem/query.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.database.pubchem"
 __author__ = "Patrick Kunzmann"
 __all__ = [
@@ -236,7 +238,7 @@ class FormulaQuery(Query):
         atoms: AtomArray[N],
         allow_other_elements: bool = False,
         number: int | None = None,
-    ) -> "FormulaQuery":
+    ) -> FormulaQuery:
         """
         Create the query from an the given structure by using its
         molecular formula.
@@ -385,7 +387,7 @@ class StructureQuery(Query, metaclass=abc.ABCMeta):
         atoms: AtomArray[N],
         *args: Any,
         **kwargs: Any,
-    ) -> "StructureQuery":
+    ) -> StructureQuery:
         """
         Create a query using the given query structure.
 

--- a/src/biotite/database/pubchem/throttle.py
+++ b/src/biotite/database/pubchem/throttle.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.database.pubchem"
 __author__ = "Patrick Kunzmann"
 __all__ = ["ThrottleStatus"]
@@ -52,7 +54,7 @@ class ThrottleStatus:
     service: float
 
     @staticmethod
-    def from_response(response: requests.Response) -> "ThrottleStatus":
+    def from_response(response: requests.Response) -> ThrottleStatus:
         """
         Extract the throttle status from a *Pubchem* server response.
 

--- a/src/biotite/database/rcsb/query.py
+++ b/src/biotite/database/rcsb/query.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.database.rcsb"
 __author__ = "Patrick Kunzmann, Maximilian Dombrowsky"
 __all__ = [
@@ -71,10 +73,10 @@ class Query(metaclass=abc.ABCMeta):
         """
         pass
 
-    def __and__(self, query: "Query") -> "CompositeQuery":
+    def __and__(self, query: Query) -> CompositeQuery:
         return CompositeQuery([self, query], "and")
 
-    def __or__(self, query: "Query") -> "CompositeQuery":
+    def __or__(self, query: Query) -> CompositeQuery:
         return CompositeQuery([self, query], "or")
 
 
@@ -433,7 +435,7 @@ class FieldQuery(SingleQuery):
             content["parameters"]["value"] = self._value
         return content
 
-    def __invert__(self) -> "FieldQuery":
+    def __invert__(self) -> FieldQuery:
         clone = copy.deepcopy(self)
         clone._negation = not clone._negation
         return clone
@@ -831,7 +833,7 @@ class UniprotGrouping(Grouping):
 def count(
     query: Query,
     return_type: _ReturnType = "entry",
-    group_by: "Grouping | None" = None,
+    group_by: Grouping | None = None,
     content_types: Iterable[_ContentType] = ("experimental",),
 ) -> int:
     """

--- a/src/biotite/database/uniprot/query.py
+++ b/src/biotite/database/uniprot/query.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.database.uniprot"
 __author__ = "Maximilian Greil"
 __all__ = ["Query", "SimpleQuery", "CompositeQuery", "search"]
@@ -27,13 +29,13 @@ class Query(metaclass=abc.ABCMeta):
     def __str__(self) -> str:
         pass
 
-    def __or__(self, operand: "Query") -> "CompositeQuery":
+    def __or__(self, operand: Query) -> CompositeQuery:
         return CompositeQuery("OR", self, operand)
 
-    def __and__(self, operand: "Query") -> "CompositeQuery":
+    def __and__(self, operand: Query) -> CompositeQuery:
         return CompositeQuery("AND", self, operand)
 
-    def __xor__(self, operand: "Query") -> "CompositeQuery":
+    def __xor__(self, operand: Query) -> CompositeQuery:
         return CompositeQuery("NOT", self, operand)
 
 

--- a/src/biotite/sequence/graphics/plasmid.py
+++ b/src/biotite/sequence/graphics/plasmid.py
@@ -412,7 +412,7 @@ try:
             else:
                 self._arrow_head = None
 
-            self._label: "CurvedText | None"
+            self._label: CurvedText | None
             if label is not None:
                 label_properties["color"] = label_color
                 self._label = CurvedText(

--- a/src/biotite/setup_ccd.py
+++ b/src/biotite/setup_ccd.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __author__ = "Patrick Kunzmann"
 __all__ = []
 
@@ -18,7 +20,7 @@ CCD_URL = "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
 
 def concatenate_ccd(
     categories: Iterable[str] | None = None,
-) -> "BinaryCIFFile":  # noqa: F405
+) -> BinaryCIFFile:  # noqa: F405
     """
     Create the CCD in BinaryCIF format with each category contains the
     data of all blocks.
@@ -55,9 +57,9 @@ def concatenate_ccd(
 
 
 def _concatenate_blocks_into_category(
-    pdbx_file: "CIFFile",  # noqa: F405
+    pdbx_file: CIFFile,  # noqa: F405
     category_name: str,
-) -> "BinaryCIFCategory":  # noqa: F405
+) -> BinaryCIFCategory:  # noqa: F405
     """
     Concatenate the given category from all blocks into a single
     category.
@@ -115,7 +117,7 @@ def _concatenate_blocks_into_category(
 
 
 def _list_all_column_names(
-    pdbx_file: "CIFFile",  # noqa: F405
+    pdbx_file: CIFFile,  # noqa: F405
     category_name: str,
 ) -> list[str]:
     """
@@ -140,7 +142,7 @@ def _list_all_column_names(
     return sorted(columns_names)
 
 
-def _list_all_category_names(pdbx_file: "CIFFile") -> list[str]:  # noqa: F405
+def _list_all_category_names(pdbx_file: CIFFile) -> list[str]:  # noqa: F405
     """
     Get all categories that exist in any block.
 

--- a/src/biotite/structure/alphabet/pb.py
+++ b/src/biotite/structure/alphabet/pb.py
@@ -6,6 +6,8 @@
 Conversion of structures into the *Protein Blocks* structural alphabet.
 """
 
+from __future__ import annotations
+
 __name__ = "biotite.structure.alphabet"
 __author__ = "Patrick Kunzmann"
 __all__ = ["ProteinBlocksSequence", "to_protein_blocks"]
@@ -79,7 +81,7 @@ class ProteinBlocksSequence(Sequence):
     def get_alphabet(self) -> LetterAlphabet:
         return ProteinBlocksSequence.alphabet
 
-    def remove_undefined(self) -> "ProteinBlocksSequence":
+    def remove_undefined(self) -> ProteinBlocksSequence:
         """
         Remove undefined symbols from the sequence.
 

--- a/src/biotite/structure/alphabet/unkerasify.py
+++ b/src/biotite/structure/alphabet/unkerasify.py
@@ -8,6 +8,8 @@ Parser for extracting weights from Keras files.
 Adapted from `moof2k/kerasify <https://github.com/moof2k/kerasify>`_.
 """
 
+from __future__ import annotations
+
 __name__ = "biotite.structure.alphabet"
 __author__ = "Martin Larralde"
 __all__ = ["load_kerasify"]
@@ -88,7 +90,7 @@ class KerasifyParser:
         else:
             raise NotImplementedError(f"Unsupported layer type: {layer_type!r}")
 
-    def __iter__(self) -> "KerasifyParser":
+    def __iter__(self) -> KerasifyParser:
         return self
 
     def __next__(self) -> Layer:

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -17,6 +17,8 @@ This module contains the main types of the ``structure`` subpackage:
 :class:`Atom`, :class:`AtomArray` and :class:`AtomArrayStack`.
 """
 
+from __future__ import annotations
+
 __name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = [
@@ -108,7 +110,7 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def add_annotation(self, category: str, dtype: "np.dtype | type | str") -> None:
+    def add_annotation(self, category: str, dtype: np.dtype | type | str) -> None:
         """
         Add an annotation category, if not already existing.
 
@@ -246,9 +248,7 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         new_object._array_length = new_length
         return new_object  # pyright: ignore[reportReturnType]
 
-    def _set_element(
-        self, index: int | NDArray1[Any, np.integer], atom: "Atom"
-    ) -> None:
+    def _set_element(self, index: int | NDArray1[Any, np.integer], atom: Atom) -> None:
         try:
             if isinstance(index, (numbers.Integral, np.ndarray)):
                 for name in self._annot:
@@ -309,7 +309,7 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
                 return False
         return True
 
-    def equal_annotation_categories(self, item: "_AtomArrayBase") -> bool:
+    def equal_annotation_categories(self, item: _AtomArrayBase) -> bool:
         """
         Check, if this object shares equal annotation array categories
         with the given :class:`AtomArray` or :class:`AtomArrayStack`.
@@ -594,11 +594,11 @@ class Atom(Copyable):
     def __ne__(self, item: object) -> bool:
         return not self == item
 
-    def __copy_create__(self) -> "Atom":
+    def __copy_create__(self) -> Atom:
         return Atom(self.coord, **self._annot)
 
 
-class AtomArray(_AtomArrayBase, Sequence["Atom"], Generic[N]):
+class AtomArray(_AtomArrayBase, Sequence[Atom], Generic[N]):
     """
     An array representation of a model consisting of multiple atoms.
 
@@ -777,7 +777,7 @@ class AtomArray(_AtomArrayBase, Sequence["Atom"], Generic[N]):
             kwargs[name] = annotation[index]
         return Atom(coord=self._coord[index], kwargs=kwargs)
 
-    def __iter__(self) -> "Iterator[Atom]":
+    def __iter__(self) -> Iterator[Atom]:
         """
         Iterate through the array.
 
@@ -790,7 +790,7 @@ class AtomArray(_AtomArrayBase, Sequence["Atom"], Generic[N]):
             yield self.get_atom(i)
             i += 1
 
-    def __getitem__(self, index: Any) -> "Atom | AtomArray[Any]":
+    def __getitem__(self, index: Any) -> Atom | AtomArray[Any]:
         """
         Obtain a subarray or the atom instance at the specified index.
 
@@ -887,11 +887,11 @@ class AtomArray(_AtomArrayBase, Sequence["Atom"], Generic[N]):
             string += "\n\t..."
         return string
 
-    def __copy_create__(self) -> "AtomArray[Any]":
+    def __copy_create__(self) -> AtomArray[Any]:
         return AtomArray(self.array_length())
 
 
-class AtomArrayStack(_AtomArrayBase, Sequence["AtomArray"], Generic[M, N]):
+class AtomArrayStack(_AtomArrayBase, Sequence[AtomArray], Generic[M, N]):
     """
     A collection of multiple :class:`AtomArray` instances, where each
     atom array has equal annotation arrays.
@@ -1003,7 +1003,7 @@ class AtomArrayStack(_AtomArrayBase, Sequence["AtomArray"], Generic[M, N]):
             arrays = arrays + "\t...,\n"
         return f"stack([\n{arrays}])"
 
-    def get_array(self, index: int) -> "AtomArray[Any]":
+    def get_array(self, index: int) -> AtomArray[Any]:
         """
         Obtain the atom array instance of the stack at the specified
         index.
@@ -1065,7 +1065,7 @@ class AtomArrayStack(_AtomArrayBase, Sequence["AtomArray"], Generic[M, N]):
         """
         return self.stack_depth(), self.array_length()
 
-    def __iter__(self) -> "Iterator[AtomArray[Any]]":
+    def __iter__(self) -> Iterator[AtomArray[Any]]:
         """
         Iterate through the array.
 
@@ -1080,7 +1080,7 @@ class AtomArrayStack(_AtomArrayBase, Sequence["AtomArray"], Generic[M, N]):
 
     def __getitem__(
         self, index: Any
-    ) -> "Atom | AtomArray[Any] | AtomArrayStack[Any, Any]":
+    ) -> Atom | AtomArray[Any] | AtomArrayStack[Any, Any]:
         """
         Obtain the atom array instance or an substack at the specified
         index.
@@ -1131,7 +1131,7 @@ class AtomArrayStack(_AtomArrayBase, Sequence["AtomArray"], Generic[M, N]):
                 new_stack._box = self._box[index]
             return new_stack
 
-    def __setitem__(self, index: int, array: "AtomArray[N]") -> None:
+    def __setitem__(self, index: int, array: AtomArray[N]) -> None:
         """
         Set the atom array at the specified stack position.
 
@@ -1218,7 +1218,7 @@ class AtomArrayStack(_AtomArrayBase, Sequence["AtomArray"], Generic[M, N]):
             string += str(array) + "\n" + "\n"
         return string
 
-    def __copy_create__(self) -> "AtomArrayStack[Any, Any]":
+    def __copy_create__(self) -> AtomArrayStack[Any, Any]:
         return AtomArrayStack(self.stack_depth(), self.array_length())
 
 
@@ -1592,10 +1592,10 @@ def repeat(
 
 
 def from_template(
-    template: "AtomArray[N] | AtomArrayStack[Any, N]",
+    template: AtomArray[N] | AtomArrayStack[Any, N],
     coord: NDArray3[M, N, XYZ, np.floating],
     box: NDArray3[M, XYZ, XYZ, np.floating] | None = None,
-) -> "AtomArrayStack[M, N]":
+) -> AtomArrayStack[M, N]:
     """
     Create an :class:`AtomArrayStack` using template atoms and given
     coordinates.

--- a/src/biotite/structure/atoms.pyi
+++ b/src/biotite/structure/atoms.pyi
@@ -17,7 +17,7 @@ analysis, so every public name listed in ``atoms.py.__all__`` must
 also be declared here.
 """
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from types import EllipsisType
 from typing import Any, Generic, TypeAliasType, overload
 import numpy as np
@@ -50,7 +50,7 @@ class _AtomArrayBase(Copyable):
     def set_annotation(self, category: str, array: np.ndarray) -> None: ...
     def get_annotation_categories(self) -> list[str]: ...
 
-class AtomArrayStack(_AtomArrayBase, Generic[M, N]):
+class AtomArrayStack(_AtomArrayBase, Sequence[AtomArray[N]], Generic[M, N]):
     # --- Mandatory annotation categories ---
     chain_id: NDArray1[N, np.str_]
     res_id: NDArray1[N, np.integer]
@@ -104,7 +104,7 @@ class AtomArrayStack(_AtomArrayBase, Generic[M, N]):
     def __add__(self, other: AtomArrayStack[M, int]) -> AtomArrayStack[M, int]: ...
     def __copy_create__(self) -> AtomArrayStack[M, N]: ...
 
-class AtomArray(_AtomArrayBase, Generic[N]):
+class AtomArray(_AtomArrayBase, Sequence[Atom], Generic[N]):
     # --- Mandatory annotation categories ---
     chain_id: NDArray1[N, np.str_]
     res_id: NDArray1[N, np.integer]

--- a/src/biotite/structure/bonds.py
+++ b/src/biotite/structure/bonds.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = [
@@ -13,7 +15,7 @@ from enum import IntEnum
 from biotite.rust.structure import BondList, bond_type_members
 
 
-def _without_aromaticity(self: "BondType") -> "BondType":
+def _without_aromaticity(self: BondType) -> BondType:
     """
     Get the non-aromatic counterpart of this bond type.
 

--- a/src/biotite/structure/info/ccd.py
+++ b/src/biotite/structure/info/ccd.py
@@ -32,7 +32,7 @@ _DEFAULT_ID_COLUMN_NAME = "comp_id"
 
 
 @functools.cache
-def get_ccd() -> "BinaryCIFBlock":
+def get_ccd() -> BinaryCIFBlock:
     """
     Get the internal subset of the PDB
     *Chemical Component Dictionary* (CCD).
@@ -104,17 +104,17 @@ def set_ccd_path(ccd_path: str | PathLike[str]) -> None:
 @overload
 def get_from_ccd(
     category_name: str, comp_id: str, column_name: None = None
-) -> "BinaryCIFCategory | None": ...
+) -> BinaryCIFCategory | None: ...
 @overload
 def get_from_ccd(
     category_name: str, comp_id: str, column_name: str
-) -> "BinaryCIFColumn | None": ...
+) -> BinaryCIFColumn | None: ...
 @functools.cache
 def get_from_ccd(
     category_name: str,
     comp_id: str,
     column_name: str | None = None,
-) -> "BinaryCIFCategory | BinaryCIFColumn | None":
+) -> BinaryCIFCategory | BinaryCIFColumn | None:
     """
     Get the rows for the given residue in the given category from the
     internal subset of the PDB *Chemical Component Dictionary* (CCD).
@@ -191,9 +191,7 @@ def _residue_index(category_name: str) -> dict[str, tuple[int, int]]:
     return index
 
 
-def _filter_category(
-    category: "BinaryCIFCategory", index: slice
-) -> "BinaryCIFCategory":
+def _filter_category(category: BinaryCIFCategory, index: slice) -> BinaryCIFCategory:
     """
     Reduce the category to the values for the given index.∂
     """
@@ -205,7 +203,7 @@ def _filter_category(
     )
 
 
-def _filter_column(column: "BinaryCIFColumn", index: slice) -> "BinaryCIFColumn":
+def _filter_column(column: BinaryCIFColumn, index: slice) -> BinaryCIFColumn:
     """
     Reduce the column to the values for the given index.
     """

--- a/src/biotite/structure/io/general.py
+++ b/src/biotite/structure/io/general.py
@@ -7,6 +7,8 @@ This module contains a convenience function for loading structures from
 general structure files.
 """
 
+from __future__ import annotations
+
 __name__ = "biotite.structure.io"
 __author__ = "Patrick Kunzmann"
 __all__ = ["load_structure", "save_structure"]
@@ -254,7 +256,7 @@ def _as_single_model_if_possible(
         return atoms
 
 
-def _mol_header() -> "Header":
+def _mol_header() -> Header:
     from biotite.structure.io.mol import Header
 
     return Header(

--- a/src/biotite/structure/io/mol/header.py
+++ b/src/biotite/structure/io/mol/header.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.structure.io.mol"
 __author__ = "Patrick Kunzmann"
 __all__ = ["Header"]
@@ -56,7 +58,7 @@ class Header:
     comments: str = ""
 
     @staticmethod
-    def deserialize(text: str) -> "Header":
+    def deserialize(text: str) -> Header:
         lines = text.splitlines()
 
         mol_name = lines[0].strip()

--- a/src/biotite/structure/io/mol/mol.py
+++ b/src/biotite/structure/io/mol/mol.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.structure.io.mol"
 __author__ = "Patrick Kunzmann"
 __all__ = ["MOLFile"]
@@ -87,7 +89,7 @@ class MOLFile(TextFile):
         self._header: Header | None = None
 
     @classmethod
-    def read(cls, file: str | PathLike[str] | IO[str]) -> "MOLFile":
+    def read(cls, file: str | PathLike[str] | IO[str]) -> MOLFile:
         mol_file = super().read(file)
         mol_file._header = None
         return mol_file

--- a/src/biotite/structure/io/mol/sdf.py
+++ b/src/biotite/structure/io/mol/sdf.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite.structure.io.mol"
 __author__ = "Patrick Kunzmann, Benjamin Mayer"
 __all__ = ["SDFile", "SDRecord", "Metadata"]
@@ -207,11 +209,11 @@ class Metadata(MutableMapping):
 
     def __init__(
         self,
-        metadata: "Mapping[Metadata.Key | str, str] | None" = None,
+        metadata: Mapping[Metadata.Key | str, str] | None = None,
     ) -> None:
         if metadata is None:
             metadata = {}
-        self._metadata: dict["Metadata.Key", str] = {}
+        self._metadata: dict[Metadata.Key, str] = {}
         for key, value in metadata.items():
             self._metadata[_to_metadata_key(key)] = value
 
@@ -269,18 +271,18 @@ class Metadata(MutableMapping):
             text_blocks.append(value + "\n")
         return _join_with_terminal_newline(text_blocks)
 
-    def __getitem__(self, key: "Metadata.Key | str") -> str:
+    def __getitem__(self, key: Metadata.Key | str) -> str:
         return self._metadata[_to_metadata_key(key)]
 
-    def __setitem__(self, key: "Metadata.Key | str", value: str) -> None:
+    def __setitem__(self, key: Metadata.Key | str, value: str) -> None:
         if len(value) == 0:
             raise ValueError("Metadata value must not be empty")
         self._metadata[_to_metadata_key(key)] = value
 
-    def __delitem__(self, key: "Metadata.Key | str") -> None:
+    def __delitem__(self, key: Metadata.Key | str) -> None:
         del self._metadata[_to_metadata_key(key)]
 
-    def __iter__(self) -> "Iterator[Metadata.Key]":
+    def __iter__(self) -> Iterator[Metadata.Key]:
         return iter(self._metadata)
 
     def __len__(self) -> int:
@@ -388,14 +390,14 @@ class SDRecord:
         metadata: Metadata | Mapping[Metadata.Key | str, str] | str | None = None,
     ) -> None:
         if header is None:
-            self._header: "Header | str" = Header()
+            self._header: Header | str = Header()
         else:
             self._header = header
 
         self._ctab = ctab
 
         if metadata is None:
-            self._metadata: "Metadata | str" = Metadata()
+            self._metadata: Metadata | str = Metadata()
         elif isinstance(metadata, Metadata):
             self._metadata = metadata
         elif isinstance(metadata, Mapping):
@@ -439,7 +441,7 @@ class SDRecord:
         return self._metadata
 
     @metadata.setter
-    def metadata(self, metadata: "Metadata | Mapping[Metadata.Key | str, str]") -> None:
+    def metadata(self, metadata: Metadata | Mapping[Metadata.Key | str, str]) -> None:
         if isinstance(metadata, Metadata):
             self._metadata = metadata
         elif isinstance(metadata, Mapping):

--- a/src/biotite/structure/io/pdbx/bcif.py
+++ b/src/biotite/structure/io/pdbx/bcif.py
@@ -354,7 +354,7 @@ class BinaryCIFColumn(_Component):
         return True
 
 
-class BinaryCIFCategory(_HierarchicalContainer["BinaryCIFColumn"]):
+class BinaryCIFCategory(_HierarchicalContainer[BinaryCIFColumn]):
     """
     This class represents a category in a :class:`BinaryCIFBlock`.
 
@@ -468,7 +468,7 @@ class BinaryCIFCategory(_HierarchicalContainer["BinaryCIFColumn"]):
         super().__setitem__(key, element)
 
 
-class BinaryCIFBlock(_HierarchicalContainer["BinaryCIFCategory"]):
+class BinaryCIFBlock(_HierarchicalContainer[BinaryCIFCategory]):
     """
     This class represents a block in a :class:`BinaryCIFFile`.
 
@@ -563,7 +563,7 @@ class BinaryCIFBlock(_HierarchicalContainer["BinaryCIFCategory"]):
         return super().__contains__("_" + key)
 
 
-class BinaryCIFFile(File, _HierarchicalContainer["BinaryCIFBlock"]):
+class BinaryCIFFile(File, _HierarchicalContainer[BinaryCIFBlock]):
     """
     This class represents a *BinaryCIF* file.
 

--- a/src/biotite/structure/io/pdbx/encoding.py
+++ b/src/biotite/structure/io/pdbx/encoding.py
@@ -6,6 +6,8 @@
 This module contains data encodings for BinaryCIF files.
 """
 
+from __future__ import annotations
+
 __name__ = "biotite.structure.io.pdbx"
 __author__ = "Patrick Kunzmann"
 __all__ = [
@@ -57,7 +59,7 @@ class TypeCode(IntEnum):
     FLOAT64 = 33
 
     @staticmethod
-    def from_dtype(dtype: "np.dtype | int | TypeCode") -> "TypeCode":
+    def from_dtype(dtype: np.dtype | int | TypeCode) -> TypeCode:
         """
         Convert a *NumPy* dtype to a *BinaryCIF* type code.
 
@@ -927,7 +929,7 @@ def _safe_cast(
         elif not np.issubdtype(source_dtype, np.integer):
             # Neither float, nor integer -> cannot cast
             raise ValueError(f"Cannot cast '{source_dtype}' to integer")
-        dtype_info = np.iinfo(cast("np.dtype[np.integer]", target_dtype))
+        dtype_info = np.iinfo(cast(np.dtype[np.integer], target_dtype))
         # Check if an integer underflow/overflow would occur during conversion
         max_val = np.max(array).item()
         min_val = np.min(array).item()

--- a/src/biotite/structure/pseudoknots.py
+++ b/src/biotite/structure/pseudoknots.py
@@ -6,6 +6,8 @@
 This module provides functionality for pseudoknot detection.
 """
 
+from __future__ import annotations
+
 __name__ = "biotite.structure"
 __author__ = "Tom David Müller"
 __all__ = ["pseudoknots"]
@@ -186,7 +188,7 @@ class _Region:
         """
         return self.region_pairs
 
-    def __lt__(self, other: "_Region") -> bool:
+    def __lt__(self, other: _Region) -> bool:
         """
         This comparison operator is required for :func:`np.unique()`. As
         only the difference between the regions is relevant and not any

--- a/src/biotite/structure/rings.py
+++ b/src/biotite/structure/rings.py
@@ -6,6 +6,8 @@
 This module provides functions related to aromatic rings.
 """
 
+from __future__ import annotations
+
 __name__ = "biotite.structure"
 __author__ = "Patrick Kunzmann"
 __all__ = [
@@ -112,7 +114,7 @@ def find_stacking_interactions(
     centroid_cutoff: float = 6.5,
     plane_angle_tol: float = np.deg2rad(30.0),
     shift_angle_tol: float = np.deg2rad(30.0),
-) -> list[tuple[NDArray1[Any, np.integer], NDArray1[Any, np.integer], "PiStacking"]]:
+) -> list[tuple[NDArray1[Any, np.integer], NDArray1[Any, np.integer], PiStacking]]:
     """
     Find pi-stacking interactions between aromatic rings.
 

--- a/src/biotite/structure/superimpose.py
+++ b/src/biotite/structure/superimpose.py
@@ -322,7 +322,7 @@ def superimpose_without_outliers(
             break
 
     anchor_indices = np.where(inlier_mask)[0]
-    transform = cast("AffineTransformation[M]", transform)
+    transform = cast(AffineTransformation[M], transform)
     return transform.apply(mobile), transform, anchor_indices
 
 

--- a/src/biotite/visualize.py
+++ b/src/biotite/visualize.py
@@ -2,6 +2,8 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
+from __future__ import annotations
+
 __name__ = "biotite"
 __author__ = "Patrick Kunzmann"
 __all__ = ["colors", "plot_scaled_text", "set_font_size_in_coord", "AdaptiveFancyArrow"]
@@ -148,7 +150,7 @@ def plot_scaled_text(
 
 
 def set_font_size_in_coord(
-    text: "Text",
+    text: Text,
     width: float | None = None,
     height: float | None = None,
     mode: Literal["proportional", "unlocked", "maximum", "minimum"] = "unlocked",
@@ -205,7 +207,6 @@ def set_font_size_in_coord(
     from matplotlib.backend_bases import GraphicsContextBase, RendererBase
     from matplotlib.path import Path
     from matplotlib.patheffects import AbstractPathEffect
-    from matplotlib.text import Text
     from matplotlib.transforms import Affine2D, Bbox, Transform
 
     class TextScaler(AbstractPathEffect):


### PR DESCRIPTION
This PR replaces forward references by standard type annotations by using the deferred evaluation of type annotations ([PEP 649](https://peps.python.org/pep-0649/)).