### PR TITLE
Perf: 30% to 70% speedup for `superimpose`

### DIFF
--- a/benchmarks/structure/benchmark_superimpose.py
+++ b/benchmarks/structure/benchmark_superimpose.py
@@ -25,3 +25,22 @@ def benchmark_superimpose(method, atoms):
     Compute superimposition of two structures with the same number of atoms.
     """
     method(atoms[0], atoms[1])
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(
+    "method",
+    [
+        struc.superimpose,
+        struc.superimpose_without_outliers,
+        struc.superimpose_homologs,
+    ],
+)
+def benchmark_superimpose_multi_model(method, atoms):
+    """
+    Superimpose every model of an ensemble onto a single reference model.
+
+    ``superimpose_structural_homologs`` is omitted, as it does not accept an
+    :class:`AtomArrayStack`.
+    """
+    method(atoms[0], atoms)

--- a/src/biotite/structure/superimpose.py
+++ b/src/biotite/structure/superimpose.py
@@ -489,7 +489,7 @@ def _get_rotation_matrices(
     Both sets of coordinates must already be centered at origin.
     """
     # Calculate cross-covariance matrices
-    cov = np.sum(fixed[:, :, :, np.newaxis] * mobile[:, :, np.newaxis, :], axis=1)
+    cov = np.matmul(np.swapaxes(fixed, -1, -2), mobile)  # (M, XYZ, XYZ)
     v, s, w = np.linalg.svd(cov)
     # Remove possibility of reflected atom coordinates
     reflected_mask = np.linalg.det(v) * np.linalg.det(w) < 0


### PR DESCRIPTION
`_get_rotation_matrices` was doing `np.sum(fixed[:, :, :, np.newaxis] * mobile[:, :, np.newaxis, :], axis=1)` which materializes the full `m*n*3*3` intermediate (so if m = 100 and n = 10000 you get 9,000,000 floats). This is expensive! `_get_rotation_matrices` can be made up to 20x faster if you just do this as a single matmul, since the original implementation was just expressing the same contraction as `fixed.T @ mobile` (ignoring the batch dimension). BLAS runs the computation directly without materializing the intermediate.

This shows up as a 1.3 to 1.7x end to end improvement on `superimpose` runtime at various dimensions (thanks Amdahl's law).

Tests pass locally. Expect this to not be byte-identical since float reduction order is changing, but the differences are at the level of floating point roundoff.

Claude did some benchmarking on `superimpose` for me:

x86 — GCP c3-standard-8 (Sapphire Rapids), OpenBLAS 8-thread, best-of-7:

| (M, N) | Before (ms) | After (ms) | Speedup |
|--------|------------:|-----------:|:-------:|
| (1, 200) | 0.08 | 0.06 | 1.29x |
| (1, 1000) | 0.16 | 0.11 | 1.49x |
| (1, 5000) | 0.54 | 0.32 | 1.69x |
| (1, 25000) | 3.18 | 2.13 | 1.49x |
| (5, 200) | 0.17 | 0.12 | 1.42x |
| (5, 1000) | 0.55 | 0.33 | 1.67x |
| (5, 5000) | 3.17 | 2.16 | 1.47x |
| (5, 25000) | 15.33 | 11.71 | 1.31x |
| (25, 200) | 0.62 | 0.40 | 1.58x |
| (25, 1000) | 2.64 | 1.52 | 1.73x |
| (25, 5000) | 16.11 | 11.33 | 1.42x |
| (25, 25000) | 75.97 | 52.06 | 1.46x |
| (100, 200) | 2.39 | 1.48 | 1.62x |
| (100, 1000) | 10.70 | 6.10 | 1.75x |
| (100, 5000) | 63.26 | 41.58 | 1.52x |
| (100, 25000) | 327.55 | 206.73 | 1.58x |
| (500, 200) | 11.87 | 7.25 | 1.64x |
| (500, 1000) | 58.11 | 34.42 | 1.69x |
| (500, 5000) | 332.39 | 208.28 | 1.60x |
| (500, 25000) | 1645.84 | 1025.11 | 1.61x |
