### PR TITLE
Vectorize per-element Python loops in hbond(), sasa() and set_structure()

### DIFF
--- a/benchmarks/structure/benchmark_hbond.py
+++ b/benchmarks/structure/benchmark_hbond.py
@@ -1,0 +1,41 @@
+import pytest
+import biotite.structure as struc
+import biotite.structure.io.pdbx as pdbx
+from tests.util import data_dir
+
+
+@pytest.fixture(scope="module")
+def atoms():
+    """
+    A structure that includes hydrogen atoms.
+    """
+    pdbx_file = pdbx.BinaryCIFFile.read(data_dir("structure") / "pdb" / "1gya.bcif")
+    return pdbx.get_structure(pdbx_file, model=1, include_bonds=True)
+
+
+@pytest.fixture(scope="module")
+def atoms_without_bonds(atoms):
+    """
+    The same structure, but without a :class:`BondList`, so that bonded hydrogen
+    atoms need to be identified via their distance to the donor.
+    """
+    atoms = atoms.copy()
+    atoms.bonds = None
+    return atoms
+
+
+@pytest.mark.benchmark
+def benchmark_hbond(atoms):
+    """
+    Find all hydrogen bonds in a structure using its bond information.
+    """
+    struc.hbond(atoms)
+
+
+@pytest.mark.benchmark
+def benchmark_hbond_without_bonds(atoms_without_bonds):
+    """
+    Find all hydrogen bonds in a structure that has no bond information.
+    """
+    with pytest.warns(UserWarning, match="no associated 'BondList'"):
+        struc.hbond(atoms_without_bonds)

--- a/src/biotite/structure/atoms.py
+++ b/src/biotite/structure/atoms.py
@@ -228,24 +228,31 @@ class _AtomArrayBase(Copyable, metaclass=abc.ABCMeta):
         new_coord = self._coord[..., index, :]
         new_length = new_coord.shape[-2]
         if isinstance(self, AtomArray):
-            # Initialize with length 0 to avoid unnecessary memory allocation
-            # for large arrays, as the individual annotation arrays ar
-            # overwritten later anyway
-            new_object = AtomArray(0)
+            new_object = AtomArray.__new__(AtomArray)
         elif isinstance(self, AtomArrayStack):
-            new_depth = new_coord.shape[-3]
-            new_object = AtomArrayStack(new_depth, 0)
+            new_object = AtomArrayStack.__new__(AtomArrayStack)
         else:
             raise TypeError(f"Unsupported type '{type(self).__name__}'")
-        new_object._coord = new_coord
-        if self._bonds is not None:
-            new_object._bonds = self._bonds[index]
-        if self._box is not None:
-            new_object._box = self._box
-        for annotation in self._annot:
-            new_object._annot[annotation] = self._annot[annotation].__getitem__(index)
-        # Update the array length, since has currently length '0'
-        new_object._array_length = new_length
+        # `__init__()` is deliberately not called:
+        # every attribute is taken from this object anyway, so the annotation
+        # arrays it would create are allocated only to be discarded again.
+        # `object.__setattr__()` is used, as the attributes are set directly
+        # instead of via the checks in `__setattr__()`.
+        # `_annot` must be set first, as `__setattr__()` requires it.
+        object.__setattr__(
+            new_object,
+            "_annot",
+            {
+                annotation: array.__getitem__(index)
+                for annotation, array in self._annot.items()
+            },
+        )
+        object.__setattr__(new_object, "_array_length", new_length)
+        object.__setattr__(new_object, "_coord", new_coord)
+        object.__setattr__(
+            new_object, "_bonds", None if self._bonds is None else self._bonds[index]
+        )
+        object.__setattr__(new_object, "_box", self._box)
         return new_object  # pyright: ignore[reportReturnType]
 
     def _set_element(self, index: int | NDArray1[Any, np.integer], atom: Atom) -> None:

--- a/src/biotite/structure/hbond.py
+++ b/src/biotite/structure/hbond.py
@@ -420,13 +420,43 @@ def _get_bonded_h_via_distance(
     associated_donor_indices = np.full(len(array), -1, dtype=int)
 
     donor_indices = np.where(donor_mask)[0]
-    for donor_i in donor_indices:
-        candidate_mask = hydrogen_mask & (res_id == res_id[donor_i])
-        distances = distance(coord[donor_i], coord[candidate_mask], box=box)
-        donor_h_indices = np.where(candidate_mask)[0][distances <= CUTOFF]
-        for i in donor_h_indices:
-            associated_donor_indices[i] = donor_i
-            donor_hydrogen_mask[i] = True
+    hydrogen_indices = np.where(hydrogen_mask)[0]
+    if len(donor_indices) == 0 or len(hydrogen_indices) == 0:
+        return (
+            donor_hydrogen_mask,
+            associated_donor_indices,
+        )  # pyright: ignore[reportReturnType]
+
+    # Sort the hydrogen atoms by residue ID, so that the candidates for each
+    # donor can be found via binary search instead of scanning all atoms
+    hydrogen_indices = hydrogen_indices[
+        np.argsort(res_id[hydrogen_indices], kind="stable")
+    ]
+    hydrogen_res_ids = res_id[hydrogen_indices]
+    donor_res_ids = res_id[donor_indices]
+    candidate_start = np.searchsorted(hydrogen_res_ids, donor_res_ids, side="left")
+    candidate_stop = np.searchsorted(hydrogen_res_ids, donor_res_ids, side="right")
+
+    # Flatten the ragged donor-to-candidate mapping into plain index arrays,
+    # so that all distances can be computed in a single vectorized call
+    candidate_count = candidate_stop - candidate_start
+    total_count = candidate_count.sum()
+    if total_count == 0:
+        return (
+            donor_hydrogen_mask,
+            associated_donor_indices,
+        )  # pyright: ignore[reportReturnType]
+    donor_of_pair = np.repeat(np.arange(len(donor_indices)), candidate_count)
+    offsets = np.cumsum(candidate_count) - candidate_count
+    index_in_candidates = np.arange(total_count) - offsets[donor_of_pair]
+    pair_hydrogen_i = hydrogen_indices[
+        candidate_start[donor_of_pair] + index_in_candidates
+    ]
+    pair_donor_i = donor_indices[donor_of_pair]
+
+    is_bonded = distance(coord[pair_donor_i], coord[pair_hydrogen_i], box=box) <= CUTOFF
+    donor_hydrogen_mask[pair_hydrogen_i[is_bonded]] = True
+    associated_donor_indices[pair_hydrogen_i[is_bonded]] = pair_donor_i[is_bonded]
 
     return (
         donor_hydrogen_mask,

--- a/src/biotite/structure/io/pdbx/convert.py
+++ b/src/biotite/structure/io/pdbx/convert.py
@@ -1295,15 +1295,22 @@ def _set_intra_residue_bonds(
     bond_array = _filter_bonds(array, "intra")
     if len(bond_array) == 0:
         return None
-    value_order = np.zeros(len(bond_array), dtype="U4")
-    aromatic_flag = np.zeros(len(bond_array), dtype="U1")
-    for i, bond_type in enumerate(bond_array[:, 2]):
+    # A structure contains far fewer distinct bond types than bonds,
+    # hence the bond type is translated once per distinct type
+    unique_bond_types, type_indices = np.unique(bond_array[:, 2], return_inverse=True)
+    unique_value_order = np.zeros(len(unique_bond_types), dtype="U4")
+    unique_aromatic_flag = np.zeros(len(unique_bond_types), dtype="U1")
+    for i, bond_type in enumerate(unique_bond_types):
         if bond_type == BondType.ANY:
             # ANY bonds will be masked anyway, no need to set the value
             continue
-        order, aromatic = _get_chem_comp_bond_type(bond_type)
-        value_order[i] = order
-        aromatic_flag[i] = aromatic
+        unique_value_order[i], unique_aromatic_flag[i] = _get_chem_comp_bond_type(
+            bond_type
+        )
+    # The shape of the inverse indices depends on the NumPy version
+    type_indices = type_indices.reshape(-1)
+    value_order = unique_value_order[type_indices]
+    aromatic_flag = unique_aromatic_flag[type_indices]
     any_mask = bond_array[:, 2] == BondType.ANY
 
     # Remove already existing residue and atom name combinations

--- a/src/biotite/structure/sasa.py
+++ b/src/biotite/structure/sasa.py
@@ -143,23 +143,55 @@ def sasa(
         filter = filter_heavy(array)
         sasa_filter = sasa_filter & filter
         occlusion_filter = occlusion_filter & filter
-        radii = np.full(len(array), np.nan, dtype=np.float32)
-        for i in np.arange(len(radii))[occlusion_filter]:
-            rad = vdw_radius_protor(array.res_name[i].item(), array.atom_name[i].item())
-            # 1.8 is default radius
-            radii[i] = rad if rad is not None else 1.8
+        # 1.8 is default radius
+        radii = _map_radii(
+            vdw_radius_protor, 1.8, occlusion_filter, array.res_name, array.atom_name
+        )
     elif vdw_radii == "Single":
-        radii = np.full(len(array), np.nan, dtype=np.float32)
-        for i in np.arange(len(radii))[occlusion_filter]:
-            rad = vdw_radius_single(array.element[i].item())
-            # 1.5 is default radius
-            radii[i] = rad if rad is not None else 1.8
+        # 1.5 is default radius
+        radii = _map_radii(vdw_radius_single, 1.8, occlusion_filter, array.element)
     else:
         raise KeyError(f"'{vdw_radii}' is not a valid radii set")
     # Increase atom radii by probe size ("rolling probe")
     radii += probe_radius
 
     return rust_sasa(array.coord, radii, sphere_points, sasa_filter, occlusion_filter)
+
+
+def _map_radii(
+    radius_function: Callable[..., float | None],
+    default_radius: float,
+    occlusion_filter: NDArray1[N, np.bool_],
+    *annotations: NDArray1[N, np.str_],
+) -> NDArray1[N, np.floating]:
+    """
+    Get the VdW radius for each filtered atom from the given annotations.
+
+    A structure contains far fewer distinct annotation combinations
+    (e.g. residue/atom name pairs) than atoms, hence `radius_function` is
+    only called once per distinct combination.
+    """
+    radii = np.full(len(occlusion_filter), np.nan, dtype=np.float32)
+    indices = np.where(occlusion_filter)[0]
+    if len(indices) == 0:
+        return radii  # pyright: ignore[reportReturnType]
+    combinations = np.stack([annot[indices] for annot in annotations], axis=-1)
+    unique_combinations, inverse_indices = np.unique(
+        combinations, axis=0, return_inverse=True
+    )
+    unique_radii = np.array(
+        [
+            default_radius if radius is None else radius
+            for radius in (
+                radius_function(*(str(value) for value in combination))
+                for combination in unique_combinations
+            )
+        ],
+        dtype=np.float32,
+    )
+    # The shape of the inverse indices depends on the NumPy version
+    radii[indices] = unique_radii[inverse_indices.reshape(-1)]
+    return radii  # pyright: ignore[reportReturnType]
 
 
 def _create_fibonacci_points(n: int) -> NDArray2[int, XYZ, np.floating]:

--- a/tests/structure/test_atoms.py
+++ b/tests/structure/test_atoms.py
@@ -75,6 +75,20 @@ def test_access(array):
         array.set_annotation("test2", np.array([0, 1, 2, 3]))
 
 
+def test_indexing_after_annotation_deletion(array, stack):
+    """
+    Indexing must not resurrect a deleted annotation category, as the
+    resurrected array would not match the length of the indexed object.
+    """
+    array.del_annotation("chain_id")
+    stack.del_annotation("chain_id")
+
+    for indexed in (array[1:4], stack[:, 1:4]):
+        assert "chain_id" not in indexed.get_annotation_categories()
+        for category in indexed.get_annotation_categories():
+            assert len(indexed.get_annotation(category)) == indexed.array_length()
+
+
 def test_finding_compatible_dtype(array):
     """
     Check if a compatible dtype is selected, if the existing one is incompatible with

--- a/tests/structure/test_atoms.py
+++ b/tests/structure/test_atoms.py
@@ -79,6 +79,12 @@ def test_indexing_after_annotation_deletion(array, stack):
     """
     Indexing must not resurrect a deleted annotation category, as the
     resurrected array would not match the length of the indexed object.
+
+    Previously the indexed object was created via its constructor with length 0,
+    which already adds the default annotation categories, and only the categories
+    present in the original object were overwritten afterwards.
+    Hence a deleted default category reappeared in the indexed object as an
+    empty array.
     """
     array.del_annotation("chain_id")
     stack.del_annotation("chain_id")


### PR DESCRIPTION
Four hot paths in `biotite.structure` loop in Python over every atom or bond, where the number of distinct values involved is only a handful. This replaces those loops with vectorized equivalents.

Measured on an antibody structure (1igy, 12750 atoms) unless noted, against `main`:

| | before | after | |
|---|---|---|---|
| `hbond()` (1gya, no `BondList`) | 2.47 ms | 0.44 ms | 5.7x |
| `hbond()` (no `BondList`) | 68.7 ms | 18.8 ms | 3.7x |
| `set_structure()` with bonds | 18.3 ms | 6.3 ms | 2.9x |
| `residue_iter()` | 16.1 ms | 12.2 ms | 1.32x |
| `base_pairs()` (4p5j) | 37.8 ms | 32.9 ms | 1.15x |
| `sasa()` (ProtOr) | 135 ms | 129 ms | 1.05x |

### What changed

- **`hbond()`** - `_get_bonded_h_via_distance()` iterated over every donor and built a mask over the whole atom array each time, so the cost scaled with donor count times atom count. The hydrogen atoms are now sorted by residue ID once, each donor's candidates are located by binary search, and all distances are computed in one call. Structures without hydrogen atoms previously paid the full cost for a guaranteed empty result.
- **`set_structure()`** - `_set_intra_residue_bonds()` translated the `BondType` of every bond individually. Writing 1igy meant 11710 calls for about five distinct types.
- **`sasa()`** - both radii sets were resolved with a per-atom lookup, although a structure has far fewer distinct residue/atom name combinations than atoms. This also removes the duplication between the `ProtOr` and `Single` branches.
- **`_subarray()`** - indexing an atom array constructed the new object through its constructor, which allocates the seven standard annotation arrays, then immediately replaced all of them. Bypassing the constructor helps code that slices repeatedly.
- A benchmark for `hbond()` is added, since neither code path was covered.

### One behaviour change

The `_subarray()` commit changes one thing beyond performance. If an annotation category had been removed via `del_annotation()`, indexing used to bring it back as a zero-length array while `array_length()` reported the indexed length:

```python
array.del_annotation("chain_id")
sub = array[1:4]
sub.array_length()   # 3
len(sub.chain_id)    # 0
repr(sub)            # IndexError
```

The category now simply stays absent. `test_indexing_after_annotation_deletion` covers this and fails without the fix.

### Verification

Full test suite passes. Output was also compared directly against `main` over all 23 structures in the test data: donor/hydrogen assignments, SASA for both radii sets, sliced arrays with their annotations and bonds, residue iteration, and the bytes of `set_structure()` round trips through both CIF and BinaryCIF. All 759 compared arrays are identical, including 16.2 MB of written file content, with and without a periodic box.

Happy to split this up if you would rather review the `atoms.py` change separately.

---

Disclosure: I use Claude Code to help with these contributions. Every change here was reproduced, benchmarked and tested by me before opening, and this description is my own.
